### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,21 @@
 # React Native Hyperview Client
 
-This is a RN-based implementation of a Hyperview Client, meant to be integrated into an existing React Native app. The only requirements:
-- RN 0.55+
+[![CircleCI](https://circleci.com/gh/Instawork/hyperview.svg?style=svg)](https://circleci.com/gh/Instawork/hyperview)
+
+This is a React Native-based implementation of a Hyperview Client, meant to be integrated into an existing React Native app. 
+
+See the [Hyperview website](https://hyperview.org) for more information about Hyperview and Hyperview XML.
+
+## Requirements
+- React Native 0.55+
 - React Native Navigation 2.X+
 
-See the [Design Doc](https://instawork.atlassian.net/wiki/spaces/~adam/pages/610074909/Hyperview) for more information about Hyperview XML and Hyperview.
+## Getting Started
+> TODO
 
-
-## Installing
-Clone the repo, go into the directory, and run
+## Running the example server
+The [examples](/examples) directory contains examples of Hyperview screens and interactions. To access the examples, run
 ```
-yarn
+yarn test:xmlserver
 ```
-
-## Running the Demo
-To load the demo backend, run the demo server from a shell:
-```
-yarn demo
-```
-This will start a server on port 8080. It simply serves the files from the `./examples` directory.
-
-To access the demo Hyperview XML resources, run the client either on a device or in the iOS simulator:
-```
-yarn start
-```
-To run on an iOS device, download the Expo app, then scan the QR code in the terminal with the Camera app. This should deep link into the Expo app, configured to load the code from your machine.
-
-To run the app in the iOS simulator, press 'i' in the terminal once the server is started.
+This will start an HTTP server listening on port 8085. It simply serves files from the `./examples` directory.

--- a/examples/index.xml
+++ b/examples/index.xml
@@ -115,24 +115,6 @@
           </view>
           <text style="Item__Chevron">&gt;</text>
         </item>
-        <item href="http://localhost:8080/biz_app/gigs/groups/"
-              key="biz_app"
-              show-during-load="loadingScreen"
-              style="Item">
-          <view style="Item__Left">
-            <text style="Item__Label">Biz App</text>
-          </view>
-          <text style="Item__Chevron">&gt;</text>
-        </item>
-        <item href="http://localhost:8080/worker_app/gigs/shifts/mqMzLo8/feedback"
-              key="worker_app"
-              show-during-load="loadingScreen"
-              style="Item">
-          <view style="Item__Left">
-            <text style="Item__Label">Worker App</text>
-          </view>
-          <text style="Item__Chevron">&gt;</text>
-        </item>
       </list>
     </body>
   </screen>


### PR DESCRIPTION
- Remove old instructions
- add CircleCI badge
- update links to point to hyperview.org
- removed IW-specific example links

TODO: Create installation instructions for running a simple Expo app that loads the examples. Simple starting point for people to play around.
