### PR TITLE
Use npm package version as hyperview client version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperview",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "lib/index.js",
   "description": "React Native client for Hyperview XML",
   "homepage": "https://hyperview.org",

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scrollview'
 import React from 'react';
 import VisibilityDetectingView from './VisibilityDetectingView.js';
 import { createProps, getFirstTag } from 'hyperview/src/services';
+import { version } from '../package.json';
 import urlParse from 'url-parse';
 
 const HYPERVIEW_NS = Namespaces.HYPERVIEW;
@@ -31,7 +32,7 @@ const SHARE_NS = Namespaces.SHARE;
 const ROUTE_KEYS = {};
 const PRELOAD_SCREEN = {};
 
-const HYPERVIEW_VERSION = '0.6';
+const HYPERVIEW_VERSION = version;
 
 function uid() {
   return Date.now(); // Not trully unique but sufficient for our use-case


### PR DESCRIPTION
Depends on backend support (https://github.com/Instawork/instawork/pull/4296). This will make sure the Hyperview client version (reported to the backend in an HTTP header) gets updated any time we rev the package version.