### PR TITLE
Add support for system alerts

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,5 +5,8 @@
       "root": ["."],
       "alias": {"hyperview": "./"}
     }]
-  ]
+  ],
+  "ignore": [
+    "demo"
+  ],
 }

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ website/build/
 website/yarn.lock
 website/node_modules
 website/i18n/*
+
+.yalc
+.yalcignore
+demo/yalc.lock

--- a/examples/advanced_behaviors/alert.xml
+++ b/examples/advanced_behaviors/alert.xml
@@ -1,0 +1,130 @@
+<doc xmlns="https://hyperview.org/hyperview"
+     xmlns:ns1="https://instawork.com/hyperview-redux"
+     xmlns:alert="https://hyperview.org/hyperview-alert"
+>
+  <screen>
+    <styles>
+      <style alignItems="center"
+             backgroundColor="white"
+             borderBottomColor="#eee"
+             borderBottomWidth="1"
+             flexDirection="row"
+             height="72"
+             id="Header"
+             paddingLeft="24"
+             paddingRight="24"
+             paddingTop="24" />
+      <style color="blue"
+             fontWeight="600"
+             fontSize="16"
+             id="Header__Back"
+             paddingRight="16" />
+      <style color="black"
+             fontWeight="600"
+             fontSize="24"
+             id="Header__Title" />
+      <style backgroundColor="white"
+             flex="1"
+             id="Body" />
+      <style fontWeight="600"
+             fontSize="16"
+             id="Description"
+             margin="24" />
+      <style backgroundColor="#63CB76"
+             borderRadius="16"
+             flex="1"
+             flexDirection="row"
+             id="Button"
+             justifyContent="center"
+             margin="24"
+             padding="24" />
+      <style color="white"
+             fontWeight="bold"
+             fontSize="24"
+             id="Button__Label" />
+      <style flex="1"
+             id="Main" />
+      <style borderColor="#e1e1e1"
+             borderRadius="16"
+             borderWidth="2"
+             id="Container"
+             margin="24"
+             padding="24" />
+      <style color="black"
+             fontWeight="normal"
+             fontSize="16"
+             id="Container__Label" />
+    </styles>
+    <body style="Body">
+      <header style="Header">
+        <text action="back"
+              href="#"
+              style="Header__Back">Back</text>
+        <text style="Header__Title">Alert</text>
+      </header>
+
+      <view scroll="true"
+            style="Main">
+
+        <text style="Description">Alert options can trigger navigation behaviors.</text>
+        <view style="Button">
+          <behavior
+            trigger="press"
+            action="alert"
+            alert:title="Alert title"
+            alert:message="Alert message"
+          >
+            <alert:option alert:label="Push" trigger="press" href="/index.xml" action="push" />
+            <alert:option alert:label="Back" trigger="press" href="#" action="back" />
+            <alert:option alert:label="Cancel" />
+          </behavior>
+          <text style="Button__Label">Navigation options</text>
+        </view>
+
+        <text style="Description">Alert options can trigger update behaviors.</text>
+        <view style="Button">
+          <behavior
+            trigger="press"
+            action="alert"
+            alert:title="Alert title"
+            alert:message="Alert message"
+          >
+            <alert:option alert:label="Append" trigger="press" href="#option1" action="append" target="alert1Container" />
+            <alert:option alert:label="Prepend" trigger="press" href="#option2" action="prepend" target="alert1Container" />
+            <alert:option alert:label="Replace" trigger="press" href="#option3" action="replace-inner" target="alert1Container" />
+          </behavior>
+          <text style="Button__Label">Update options</text>
+        </view>
+        <view id="alert1Container" style="Container">
+        </view>
+        <view hide="true">
+          <text id="option1" style="Container__Label">Appended</text>
+          <text id="option2" style="Container__Label">Prepended</text>
+          <text id="option3" style="Container__Label">Replace</text>
+        </view>
+
+        <text style="Description">Alert options can trigger other action types, including alerts</text>
+        <view style="Button">
+          <behavior
+            trigger="press"
+            action="alert"
+            alert:title="Alert title"
+            alert:message="Alert message"
+          >
+            <alert:option alert:label="Another Alert">
+              <behavior
+                trigger="press"
+                action="alert"
+                alert:title="Second Alert"
+                alert:message="Press for another alert"
+              >
+                <alert:option alert:label="Close" />
+              </behavior>
+            </alert:option>
+          </behavior>
+          <text style="Button__Label">Nested</text>
+        </view>
+      </view>
+    </body>
+  </screen>
+</doc>

--- a/examples/advanced_behaviors/alert/behavior.xml
+++ b/examples/advanced_behaviors/alert/behavior.xml
@@ -1,0 +1,132 @@
+<doc xmlns="https://hyperview.org/hyperview"
+     xmlns:ns1="https://instawork.com/hyperview-redux"
+>
+  <screen>
+    <styles>
+      <style alignItems="center"
+             backgroundColor="white"
+             borderBottomColor="#eee"
+             borderBottomWidth="1"
+             flexDirection="row"
+             height="72"
+             id="Header"
+             paddingLeft="24"
+             paddingRight="24"
+             paddingTop="24" />
+      <style color="blue"
+             fontWeight="600"
+             fontSize="16"
+             id="Header__Back"
+             paddingRight="16" />
+      <style color="black"
+             fontWeight="600"
+             fontSize="24"
+             id="Header__Title" />
+      <style backgroundColor="white"
+             flex="1"
+             id="Body" />
+      <style fontWeight="600"
+             fontSize="16"
+             id="Description"
+             margin="24" />
+      <style backgroundColor="#63CB76"
+             borderRadius="16"
+             flex="1"
+             flexDirection="row"
+             id="Button"
+             justifyContent="center"
+             margin="24"
+             padding="24" />
+      <style color="white"
+             fontWeight="bold"
+             fontSize="24"
+             id="Button__Label" />
+      <style flex="1"
+             id="Main" />
+      <style borderColor="#e1e1e1"
+             borderRadius="16"
+             borderWidth="2"
+             id="Container"
+             margin="24"
+             padding="24" />
+      <style color="black"
+             fontWeight="normal"
+             fontSize="16"
+             id="Container__Label" />
+    </styles>
+    <body style="Body">
+      <header style="Header">
+        <text action="back"
+              href="#"
+              style="Header__Back">Back</text>
+        <text style="Header__Title">Behavior</text>
+      </header>
+
+      <view scroll="true"
+            style="Main">
+
+        <text style="Description">Alert options can trigger navigation behaviors.</text>
+        <view style="Button">
+          <behavior
+            xmlns:alert="https://hyperview.org/hyperview-alert"
+            trigger="press"
+            action="alert"
+            alert:title="Navigation"
+            alert:message="Pressing the options below will navigate screens."
+          >
+            <alert:option alert:label="Push" trigger="press" href="/advanced_behaviors/alert/index.xml" action="push" />
+            <alert:option alert:label="Back" trigger="press" href="#" action="back" />
+            <alert:option alert:label="Cancel" />
+          </behavior>
+          <text style="Button__Label">Navigation options</text>
+        </view>
+
+        <text style="Description">Alert options can trigger update behaviors.</text>
+        <view style="Button">
+          <behavior
+            xmlns:alert="https://hyperview.org/hyperview-alert"
+            trigger="press"
+            action="alert"
+            alert:title="Updates"
+            alert:message="Pressing the options below will change the content in the screen container."
+          >
+            <alert:option alert:label="Append" trigger="press" href="#option1" action="append" target="alert1Container" />
+            <alert:option alert:label="Prepend" trigger="press" href="#option2" action="prepend" target="alert1Container" />
+            <alert:option alert:label="Replace" trigger="press" href="#option3" action="replace-inner" target="alert1Container" />
+          </behavior>
+          <text style="Button__Label">Update options</text>
+        </view>
+        <view id="alert1Container" style="Container">
+        </view>
+        <view hide="true">
+          <text id="option1" style="Container__Label">Appended</text>
+          <text id="option2" style="Container__Label">Prepended</text>
+          <text id="option3" style="Container__Label">Replace</text>
+        </view>
+
+        <text style="Description">Alert options can trigger other action types, including alerts</text>
+        <view style="Button">
+          <behavior
+            xmlns:alert="https://hyperview.org/hyperview-alert"
+            trigger="press"
+            action="alert"
+            alert:title="First alert"
+            alert:message="Press to open a second alert."
+          >
+            <alert:option alert:label="Open Second Alert">
+              <behavior
+                trigger="press"
+                action="alert"
+                alert:title="Second Alert"
+                alert:message="Press to close the second alert."
+              >
+                <alert:option alert:label="Close" />
+              </behavior>
+            </alert:option>
+          </behavior>
+          <text style="Button__Label">Nested</text>
+        </view>
+      </view>
+    </body>
+  </screen>
+</doc>

--- a/examples/advanced_behaviors/alert/index.xml
+++ b/examples/advanced_behaviors/alert/index.xml
@@ -53,72 +53,28 @@
         <text action="back"
               href="#"
               style="Header__Back">Back</text>
-        <text style="Header__Title">Advanced Behaviors</text>
+        <text style="Header__Title">Alert</text>
       </header>
       <list>
-        <item href="/advanced_behaviors/multiple.xml"
-              key="multiple"
+        <item href="/advanced_behaviors/alert/options.xml"
+              key="options"
               show-during-load="loadingScreen"
               style="Item">
-          <text style="Item__Label">Multiple Different Behaviors</text>
+          <text style="Item__Label">Options</text>
           <text style="Item__Chevron">&gt;</text>
         </item>
-        <item href="/advanced_behaviors/multiple_same.xml"
-              key="multiple_same"
+        <item href="/advanced_behaviors/alert/behavior.xml"
+              key="behavior"
               show-during-load="loadingScreen"
               style="Item">
-          <text style="Item__Label">Multiple Same Behaviors</text>
+          <text style="Item__Label">Single Behavior</text>
           <text style="Item__Chevron">&gt;</text>
         </item>
-        <item href="/advanced_behaviors/alert/index.xml"
-              key="alert"
+        <item href="/advanced_behaviors/alert/multiple_behaviors.xml"
+              key="multiple_behaviors"
               show-during-load="loadingScreen"
               style="Item">
-          <view style="Item__Left">
-            <text style="Item__Label">Alert</text>
-          </view>
-          <text style="Item__Chevron">&gt;</text>
-        </item>
-        <item href="/advanced_behaviors/custom_toast.xml"
-              key="custom_toast"
-              show-during-load="loadingScreen"
-              style="Item">
-          <text style="Item__Label">Custom: Toast</text>
-          <text style="Item__Chevron">&gt;</text>
-        </item>
-        <item href="/advanced_behaviors/custom_web.xml"
-              key="custom_web"
-              show-during-load="loadingScreen"
-              style="Item">
-          <text style="Item__Label">Custom: Web</text>
-          <text style="Item__Chevron">&gt;</text>
-        </item>
-        <item href="/advanced_behaviors/custom_intercom.xml"
-              key="custom_intercom"
-              show-during-load="loadingScreen"
-              style="Item">
-          <text style="Item__Label">Custom: Intercom</text>
-          <text style="Item__Chevron">&gt;</text>
-        </item>
-        <item href="/advanced_behaviors/custom_amplitude.xml"
-              key="custom_amplitude"
-              show-during-load="loadingScreen"
-              style="Item">
-          <text style="Item__Label">Custom: Amplitude</text>
-          <text style="Item__Chevron">&gt;</text>
-        </item>
-        <item href="/advanced_behaviors/custom_phone.xml"
-              key="custom_phone"
-              show-during-load="loadingScreen"
-              style="Item">
-          <text style="Item__Label">Custom: Phone</text>
-          <text style="Item__Chevron">&gt;</text>
-        </item>
-        <item href="/advanced_behaviors/custom_share.xml"
-              key="custom_share"
-              show-during-load="loadingScreen"
-              style="Item">
-          <text style="Item__Label">Custom: Share</text>
+          <text style="Item__Label">Multiple Behaviors</text>
           <text style="Item__Chevron">&gt;</text>
         </item>
       </list>

--- a/examples/advanced_behaviors/alert/multiple_behaviors.xml
+++ b/examples/advanced_behaviors/alert/multiple_behaviors.xml
@@ -1,0 +1,97 @@
+<doc xmlns="https://hyperview.org/hyperview"
+     xmlns:ns1="https://instawork.com/hyperview-redux"
+>
+  <screen>
+    <styles>
+      <style alignItems="center"
+             backgroundColor="white"
+             borderBottomColor="#eee"
+             borderBottomWidth="1"
+             flexDirection="row"
+             height="72"
+             id="Header"
+             paddingLeft="24"
+             paddingRight="24"
+             paddingTop="24" />
+      <style color="blue"
+             fontWeight="600"
+             fontSize="16"
+             id="Header__Back"
+             paddingRight="16" />
+      <style color="black"
+             fontWeight="600"
+             fontSize="24"
+             id="Header__Title" />
+      <style backgroundColor="white"
+             flex="1"
+             id="Body" />
+      <style fontWeight="600"
+             fontSize="16"
+             id="Description"
+             margin="24" />
+      <style backgroundColor="#63CB76"
+             borderRadius="16"
+             flex="1"
+             flexDirection="row"
+             id="Button"
+             justifyContent="center"
+             margin="24"
+             padding="24" />
+      <style color="white"
+             fontWeight="bold"
+             fontSize="24"
+             id="Button__Label" />
+      <style flex="1"
+             id="Main" />
+      <style borderColor="#e1e1e1"
+             borderRadius="16"
+             borderWidth="2"
+             id="Container"
+             margin="24"
+             padding="24" />
+      <style color="black"
+             fontWeight="normal"
+             fontSize="16"
+             id="Container__Label" />
+    </styles>
+    <body style="Body">
+      <header style="Header">
+        <text action="back"
+              href="#"
+              style="Header__Back">Back</text>
+        <text style="Header__Title">Multiple Behaviors</text>
+      </header>
+
+      <view scroll="true" style="Main">
+
+        <text style="Description">Alert options can trigger multiple behaviors. The alert below will append fragments to two containers. One of the containers uses a delay and a loading indicator.</text>
+
+        <spinner id="spinner1" hide="true" />
+        <view id="alert1Container" style="Container" />
+
+        <view style="Button">
+          <behavior
+            xmlns:alert="https://hyperview.org/hyperview-alert"
+            trigger="press"
+            action="alert"
+            alert:title="Navigation"
+            alert:message="Pressing the option below will trigger multiple behaviors with loading indicators"
+          >
+            <alert:option alert:label="Press">
+              <behavior href="#option1" action="append" target="alert2Container" />
+              <behavior href="#option1" action="append" target="alert1Container" delay="300" show-during-load="spinner1" />
+            </alert:option>
+          </behavior>
+          <text style="Button__Label">Open alert</text>
+        </view>
+
+        <view id="alert2Container" style="Container" />
+
+        <view hide="true">
+          <text id="option1" style="Container__Label">Added</text>
+        </view>
+
+      </view>
+    </body>
+  </screen>
+</doc>

--- a/examples/advanced_behaviors/alert/options.xml
+++ b/examples/advanced_behaviors/alert/options.xml
@@ -1,6 +1,5 @@
 <doc xmlns="https://hyperview.org/hyperview"
      xmlns:ns1="https://instawork.com/hyperview-redux"
-     xmlns:alert="https://hyperview.org/hyperview-alert"
 >
   <screen>
     <styles>
@@ -60,70 +59,69 @@
         <text action="back"
               href="#"
               style="Header__Back">Back</text>
-        <text style="Header__Title">Alert</text>
+        <text style="Header__Title">Options</text>
       </header>
 
       <view scroll="true"
             style="Main">
 
-        <text style="Description">Alert options can trigger navigation behaviors.</text>
+        <text style="Description">If no options are provided, the default system dismiss button will appear.</text>
         <view style="Button">
           <behavior
+            xmlns:alert="https://hyperview.org/hyperview-alert"
             trigger="press"
             action="alert"
-            alert:title="Alert title"
-            alert:message="Alert message"
-          >
-            <alert:option alert:label="Push" trigger="press" href="/index.xml" action="push" />
-            <alert:option alert:label="Back" trigger="press" href="#" action="back" />
-            <alert:option alert:label="Cancel" />
-          </behavior>
-          <text style="Button__Label">Navigation options</text>
+            alert:title="No options"
+            alert:message="With no alert options, a single dismiss button appears."
+          />
+          <text style="Button__Label">No options</text>
         </view>
 
-        <text style="Description">Alert options can trigger update behaviors.</text>
+        <text style="Description">If one option is provided, on iOS the option will appear as a long horizontal button.</text>
         <view style="Button">
           <behavior
+            xmlns:alert="https://hyperview.org/hyperview-alert"
             trigger="press"
             action="alert"
-            alert:title="Alert title"
-            alert:message="Alert message"
+            alert:title="One option"
+            alert:message="One option on iOS appears as one long horizontal button."
           >
-            <alert:option alert:label="Append" trigger="press" href="#option1" action="append" target="alert1Container" />
-            <alert:option alert:label="Prepend" trigger="press" href="#option2" action="prepend" target="alert1Container" />
-            <alert:option alert:label="Replace" trigger="press" href="#option3" action="replace-inner" target="alert1Container" />
+            <alert:option alert:label="Custom option" />
           </behavior>
-          <text style="Button__Label">Update options</text>
-        </view>
-        <view id="alert1Container" style="Container">
-        </view>
-        <view hide="true">
-          <text id="option1" style="Container__Label">Appended</text>
-          <text id="option2" style="Container__Label">Prepended</text>
-          <text id="option3" style="Container__Label">Replace</text>
+          <text style="Button__Label">One option</text>
         </view>
 
-        <text style="Description">Alert options can trigger other action types, including alerts</text>
+        <text style="Description">If two options are provided, on iOS the buttons will appear side-by-side.</text>
         <view style="Button">
           <behavior
+            xmlns:alert="https://hyperview.org/hyperview-alert"
             trigger="press"
             action="alert"
-            alert:title="Alert title"
-            alert:message="Alert message"
+            alert:title="One option"
+            alert:message="One option on iOS appears as one long horizontal button."
           >
-            <alert:option alert:label="Another Alert">
-              <behavior
-                trigger="press"
-                action="alert"
-                alert:title="Second Alert"
-                alert:message="Press for another alert"
-              >
-                <alert:option alert:label="Close" />
-              </behavior>
-            </alert:option>
+            <alert:option alert:label="Custom option 1" />
+            <alert:option alert:label="Custom option 2" />
           </behavior>
-          <text style="Button__Label">Nested</text>
+          <text style="Button__Label">Two options</text>
         </view>
+
+        <text style="Description">On iOS, three options appear in a vertical list.</text>
+        <view style="Button">
+          <behavior
+            xmlns:alert="https://hyperview.org/hyperview-alert"
+            trigger="press"
+            action="alert"
+            alert:title="One option"
+            alert:message="One option on iOS appears as one long horizontal button."
+          >
+            <alert:option alert:label="Custom option 1" />
+            <alert:option alert:label="Custom option 2" />
+            <alert:option alert:label="Custom option 3" />
+          </behavior>
+          <text style="Button__Label">Three options</text>
+        </view>
+
       </view>
     </body>
   </screen>

--- a/examples/advanced_behaviors/index.xml
+++ b/examples/advanced_behaviors/index.xml
@@ -70,6 +70,15 @@
           <text style="Item__Label">Multiple Same Behaviors</text>
           <text style="Item__Chevron">&gt;</text>
         </item>
+        <item href="/advanced_behaviors/alert.xml"
+              key="alert"
+              show-during-load="loadingScreen"
+              style="Item">
+          <view style="Item__Left">
+            <text style="Item__Label">Alert</text>
+          </view>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
         <item href="/advanced_behaviors/custom_toast.xml"
               key="custom_toast"
               show-during-load="loadingScreen"

--- a/src/index.js
+++ b/src/index.js
@@ -1079,7 +1079,7 @@ export default class HyperScreen extends React.Component {
             // "press" is also the default trigger, so if no trigger is specified,
             // the behavior will also execute.
             e => !e.getAttribute('trigger') || e.getAttribute('trigger') === 'press'
-          ).forEach(behaviorElement => {
+          ).forEach((behaviorElement, i) => {
             const href = behaviorElement.getAttribute('href');
             const action = behaviorElement.getAttribute('action');
             const verb = behaviorElement.getAttribute('verb');
@@ -1088,15 +1088,20 @@ export default class HyperScreen extends React.Component {
             const hideIndicatorIds = behaviorElement.getAttribute('hide-during-load');
             const delay = behaviorElement.getAttribute('delay');
             const once = behaviorElement.getAttribute('once');
-            this.onUpdate(href, action, optionElement, {
-              verb,
-              targetId,
-              showIndicatorIds,
-              hideIndicatorIds,
-              delay,
-              once,
-              behaviorElement,
-            });
+
+            // With multiple behaviors for the same trigger, we need to stagger
+            // the updates a bit so that each update operates on the latest DOM.
+            // Ideally, we could apply multiple DOM updates at a time.
+            later(i).then(() => this.onUpdate(href, action, optionElement, {
+                verb,
+                targetId,
+                showIndicatorIds,
+                hideIndicatorIds,
+                delay,
+                once,
+                behaviorElement,
+              })
+            )
           });
         }
       }));

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import * as Render from 'hyperview/src/services/render';
 import * as Stylesheets from 'hyperview/src/services/stylesheets';
 import {
   ActivityIndicator,
+  Alert,
   Animated,
   Dimensions,
   Easing,
@@ -31,6 +32,7 @@ import { version } from '../package.json';
 import urlParse from 'url-parse';
 
 const HYPERVIEW_NS = Namespaces.HYPERVIEW;
+const HYPERVIEW_ALERT_NS = Namespaces.HYPERVIEW_ALERT;
 const AMPLITUDE_NS = Namespaces.AMPLITUDE;
 const PHONE_NS = Namespaces.PHONE;
 const INTERCOM_NS = Namespaces.INTERCOM;
@@ -1055,6 +1057,40 @@ export default class HyperScreen extends React.Component {
       if ((message || url) && this.props.onShare) {
         this.props.onShare({ dialogTitle, message, subject, title, url });
       }
+    } else if (action === 'alert') {
+      const title = behaviorElement.getAttributeNS(HYPERVIEW_ALERT_NS, 'title');
+      const message = behaviorElement.getAttributeNS(HYPERVIEW_ALERT_NS, 'message');
+
+      const options = Array.from(behaviorElement.childNodes).filter(
+        n => n.namespaceURI === HYPERVIEW_ALERT_NS && n.localName === 'option'
+      ).map(option => ({
+        text: option.getAttributeNS(HYPERVIEW_ALERT_NS, 'label'),
+        onPress: () => {
+          getBehaviorElements(option).filter(
+            e => e.getAttribute('trigger') === null || e.getAttribute('trigger') === 'press'
+          ).forEach(behaviorElement => {
+            const href = behaviorElement.getAttribute('href');
+            const action = behaviorElement.getAttribute('action');
+            const verb = behaviorElement.getAttribute('verb');
+            const targetId = behaviorElement.getAttribute('target');
+            const showIndicatorIds = behaviorElement.getAttribute('show-during-load');
+            const hideIndicatorIds = behaviorElement.getAttribute('hide-during-load');
+            const delay = behaviorElement.getAttribute('delay');
+            const once = behaviorElement.getAttribute('once');
+            this.onUpdate(href, action, option, {
+              verb,
+              targetId,
+              showIndicatorIds,
+              hideIndicatorIds,
+              delay,
+              once,
+              behaviorElement,
+            });
+          });
+        }
+      }));
+
+      Alert.alert(title, message, options);
     }
   }
 

--- a/src/services/namespaces/index.js
+++ b/src/services/namespaces/index.js
@@ -8,7 +8,11 @@
  *
  */
 
+// Core Namespaces
 export const HYPERVIEW = 'https://hyperview.org/hyperview';
+export const HYPERVIEW_ALERT = 'https://hyperview.org/hyperview-alert';
+
+// Custom namespaces
 export const AMPLITUDE = 'https://instawork.com/hyperview-amplitude';
 export const PHONE = 'https://instawork.com/hyperview-phone';
 export const INTERCOM = 'https://instawork.com/hyperview-intercom';


### PR DESCRIPTION
[TAD](https://instawork.atlassian.net/wiki/spaces/EN/pages/794001412/Proposal+Alert+element)

Added support for "alert" behaviors. These behaviors describe the alert options as `<alert:option>` elements, that can then contain behaviors that trigger when the user presses the option:

```xml
<view style="Button">
  <behavior
    trigger="press"
    action="alert"
    alert:title="Alert title"
    alert:message="Alert message"
  >
    <alert:option alert:label="Push" trigger="press" href="/index.xml" action="push" />
    <alert:option alert:label="Back" trigger="press" href="#" action="back" />
    <alert:option alert:label="Cancel" />
  </behavior>
  <text style="Button__Label">Navigation options</text>
</view>
```

### Video
![2019-01-11 21 33 13](https://user-images.githubusercontent.com/1034502/51069672-96510980-15e8-11e9-9ce9-c8eba873e7df.gif)

