### PR TITLE
Warn when encountering unsupported tags or behaviors in XML

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1116,6 +1116,9 @@ export default class HyperScreen extends React.Component {
 
       // Show alert
       Alert.alert(title, message, options);
+    } else {
+      // No behavior detected.
+      console.warn(`No behavior registered for action "${action}"`);
     }
   }
 

--- a/src/services/render/index.js
+++ b/src/services/render/index.js
@@ -88,15 +88,15 @@ export const renderElement = (
           options={options}
         />
       );
-    } else {
-      // No component registered for the namespace/local name.
-      // Warn in case this was an unintended mistake.
-      console.warn(
-        `No component registered for tag <${element.localName}> (namespace: ${
-          element.namespaceURI
-        })`,
-      );
     }
+
+    // No component registered for the namespace/local name.
+    // Warn in case this was an unintended mistake.
+    console.warn(
+      `No component registered for tag <${element.localName}> (namespace: ${
+        element.namespaceURI
+      })`,
+    );
   }
 
   if (element.nodeType === NODE_TYPE.TEXT_NODE) {

--- a/src/types.js
+++ b/src/types.js
@@ -15,21 +15,25 @@ export type DOMString = string;
 export type NamespaceURI = string;
 
 export const LOCAL_NAME = {
-  IMAGE: 'image',
-  LIST: 'list',
-  OPTION: 'option',
-  SECTION_LIST: 'section-list',
-  SELECT_MULTIPLE: 'select-multiple',
-  SELECT_SINGLE: 'select-single',
-  TEXT_FIELD: 'text-field',
+  BEHAVIOR: 'behavior',
   BODY: 'body',
   FORM: 'form',
   HEADER: 'header',
+  IMAGE: 'image',
   ITEM: 'item',
+  LIST: 'list',
+  MODIFIER: 'modifier',
+  OPTION: 'option',
+  SECTION_LIST: 'section-list',
   SECTION_TITLE: 'section-title',
+  SELECT_MULTIPLE: 'select-multiple',
+  SELECT_SINGLE: 'select-single',
   SPINNER: 'spinner',
-  TEXT_AREA: 'text-area',
+  STYLE: 'style',
+  STYLES: 'styles',
   TEXT: 'text',
+  TEXT_AREA: 'text-area',
+  TEXT_FIELD: 'text-field',
   VIEW: 'view',
 };
 


### PR DESCRIPTION
Asana: https://app.asana.com/0/518926233438259/1106456911336594/f

To help with debugging, we show a console warning if Hyperview encounters an unsupported tag or action. Rendering and triggers will skip the unsupported tags and actions as before.

As part of the change, I also added more explicit guards in the render code to check for comment nodes, text nodes, and element nodes.

<img width="374" alt="screen shot 2019-02-04 at 1 39 03 pm" src="https://user-images.githubusercontent.com/1034502/52239523-85ac5000-2883-11e9-94d6-1b1e8227653c.png">
