### PR TITLE
Show helpful XML parse errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -490,15 +490,21 @@ export default class HyperScreen extends React.Component {
   constructor(props) {
     super(props);
 
+    this.onUpdate = this.onUpdate.bind(this);
+    this.shallowClone = this.shallowClone.bind(this);
+    this.shallowCloneToRoot = this.shallowCloneToRoot.bind(this);
+    this.reload = this.reload.bind(this);
+    this.parseError = this.parseError.bind(this);
+
     this.navActions = ['push', 'new', 'back', 'close', 'navigate'];
     this.updateActions = ['replace', 'replace-inner', 'append', 'prepend'];
 
     this.parser = new DOMParser({
       locator: {},
       errorHandler: {
-        warning: (w) => console.error(w),
-        error: (e) => console.error(e),
-        fatalError: (e) => console.error(e),
+        warning: this.parseError,
+        error: this.parseError,
+        fatalError: this.parseError,
       },
     });
     this.needsLoad = false;
@@ -508,12 +514,19 @@ export default class HyperScreen extends React.Component {
       url: null,
       error: false,
     };
-    this.onUpdate = this.onUpdate.bind(this);
-    this.shallowClone = this.shallowClone.bind(this);
-    this.shallowCloneToRoot = this.shallowCloneToRoot.bind(this);
-    this.reload = this.reload.bind(this);
 
     this.componentRegistry = Components.getRegistry(this.props.components);
+  }
+
+  /**
+   * Callback for parser errors. Logs error to console and shows error screen.
+   */
+  parseError(e) {
+    console.error(e);
+    this.setState({
+      doc: null,
+      error: true,
+    });
   }
 
   componentDidMount() {
@@ -627,19 +640,19 @@ export default class HyperScreen extends React.Component {
         const docElement = getFirstTag(doc, 'doc');
         if (!docElement) {
           console.error(`No <doc> tag found in the response from ${url}.`);
-          doc = false;
+          doc = null;
           error = true;
         } else {
           const screenElement = getFirstTag(docElement, 'screen');
           if (!screenElement) {
             console.error(`No <screen> tag found in the <doc> tag from ${url}.`);
-            doc = false;
+            doc = null;
             error = true;
           } else {
             const bodyElement = getFirstTag(screenElement, 'body');
             if (!bodyElement) {
               console.error(`No <body> tag found in the <screen> tag from ${url}.`);
-              doc = false;
+              doc = null;
               error = true;
             }
           }

--- a/src/index.js
+++ b/src/index.js
@@ -496,7 +496,7 @@ export default class HyperScreen extends React.Component {
     this.parser = new DOMParser({
       locator: {},
       errorHandler: {
-        warning: (w) => console.warn(w),
+        warning: (w) => console.error(w),
         error: (e) => console.error(e),
         fatalError: (e) => console.error(e),
       },
@@ -623,12 +623,26 @@ export default class HyperScreen extends React.Component {
         const stylesheets = Stylesheets.createStylesheets(doc);
         ROUTE_KEYS[getHrefKey(url)] = this.props.navigation.state.key;
 
-        // Make sure the full screen has a body tag. Otherwise, the response is malformed.
-        const bodyElements = doc.getElementsByTagNameNS(HYPERVIEW_NS, 'body');
-        if (bodyElements.length == 0) {
-          console.error(`No <body> tag found in ${url}.`);
+        // Make sure the XML has the required elements: <doc>, <screen>, <body>.
+        const docElement = getFirstTag(doc, 'doc');
+        if (!docElement) {
+          console.error(`No <doc> tag found in the response from ${url}.`);
           doc = false;
           error = true;
+        } else {
+          const screenElement = getFirstTag(docElement, 'screen');
+          if (!screenElement) {
+            console.error(`No <screen> tag found in the <doc> tag from ${url}.`);
+            doc = false;
+            error = true;
+          } else {
+            const bodyElement = getFirstTag(screenElement, 'body');
+            if (!bodyElement) {
+              console.error(`No <body> tag found in the <screen> tag from ${url}.`);
+              doc = false;
+              error = true;
+            }
+          }
         }
 
         Object.entries(animations.timings).forEach(([key, timing]) => {


### PR DESCRIPTION
https://app.asana.com/0/518926233438259/1106456911336593/f

When parsing a screen, show errors if the XML does not parse correctly. In addition, show errors if the XML is missing `<doc>`, `<screen>`, or `<body>` tags. These errors show the default error screen that allows the screen to be reloaded, allowing faster iteration.

<img width="375" alt="screen shot 2019-02-05 at 11 16 28 am" src="https://user-images.githubusercontent.com/1034502/52299935-8c969980-293b-11e9-890d-6f0b7d4b5563.png">
<img width="375" alt="screen shot 2019-02-05 at 11 16 46 am" src="https://user-images.githubusercontent.com/1034502/52299942-90c2b700-293b-11e9-9487-71b44ed9aae8.png">
<img width="376" alt="screen shot 2019-02-05 at 11 16 58 am" src="https://user-images.githubusercontent.com/1034502/52299952-93bda780-293b-11e9-94f0-55bf4bf987c7.png">
<img width="377" alt="screen shot 2019-02-05 at 11 24 13 am" src="https://user-images.githubusercontent.com/1034502/52299977-a2a45a00-293b-11e9-8040-e23868bb2f75.png">
