### PR TITLE
Fix syntax formatting in Markdown files

### DIFF
--- a/docs/example_index.md
+++ b/docs/example_index.md
@@ -1,10 +1,11 @@
 ---
 id: example_index
-title: "Examples"
-sidebar_label: "Index"
+title: Examples
+sidebar_label: Index
 ---
 
 ### Interactions
+
 The following examples demonstrate how to use Hyperview behaviors to perform common mobile interactions.
 
 <div style="display:flex;justify-content:space-around">
@@ -26,7 +27,6 @@ The following examples demonstrate how to use Hyperview behaviors to perform com
     <img src="/img/examples_index/tags.png" />
   </p>
 </div>
-
 
 - [Navigation](/docs/example_navigation): Moving between screens, with custom screen loading states
 - [Delayed navigation](/docs/example_delayed_navigation): Moving to a screen after a server response

--- a/docs/guide_html.md
+++ b/docs/guide_html.md
@@ -1,7 +1,7 @@
 ---
 id: guide_html
-title: "HXML vs HTML"
-sidebar_label: "HXML vs HTML"
+title: HXML vs HTML
+sidebar_label: HXML vs HTML
 ---
 
 Hyperview XML (HXML) is an XML-based format used to describe the layout of mobile apps. It draws inspiration from HTML, but differs in a few key ways. This guide describes some of the important differences to help the transition from writing HTML to writing HXML.
@@ -9,11 +9,14 @@ Hyperview XML (HXML) is an XML-based format used to describe the layout of mobil
 ## Structure
 
 ### XML
+
 HTML does not need to be well-formed according to the XML standard.
 HXML follows strict XML formatting rules. All core HXML elements belong to the namespace `https://hyperview.org/hyperview`.
 
 ### Top-level docs
+
 In HTML, the `<html>` element defines one web page.
+
 ```html
 <html>
   <body>
@@ -21,7 +24,9 @@ In HTML, the `<html>` element defines one web page.
   </body>
 </html>
 ```
+
 In HXML, the [`<doc>`](/docs/reference_doc) element can define multiple app screens.
+
 ```xml
 <doc xmlns="https://hyperview.org/hyperview">
   <screen id="main">
@@ -39,16 +44,21 @@ In HXML, the [`<doc>`](/docs/reference_doc) element can define multiple app scre
 ```
 
 ### Basic elements
+
 In HTML, `<div>` is the basic container element.
 
 In HXML, [`<view>`](/docs/reference_view) is the basic container element.
 
 ### Text content
+
 In HTML, text content can appear in any element:
+
 ```html
 <div>Hello!</div>
 ```
+
 In HXML, text content can only appear in `<text>` elements:
+
 ```xml
 <view>
   <text>Hello!</text>
@@ -56,6 +66,7 @@ In HXML, text content can only appear in `<text>` elements:
 ```
 
 ### Form inputs
+
 In HTML, the `<input>` element has a `type` attribute that's used to render the element as a checbox or radio input. The use of a shared `name` attribute determines the behavior of a group of inputs (whether one or multiple can be selected).
 
 In HXML, two parent elements called [`<select-single>`](/docs/reference_selectsingle) and [`<select-multiple>`](/docs/reference_selectmultiple) take several [`<option>`](/docs/reference_option) elements. The outer element determines whether one or many options can be selected. The [`<option>`](/docs/reference_option) element has no default styling, and can be customized to look like a checkbox, button, or anything else.
@@ -63,11 +74,15 @@ In HXML, two parent elements called [`<select-single>`](/docs/reference_selectsi
 ## References & behaviors
 
 ### href
+
 In HTML, the `href` can only appear on `<a>` elements.
+
 ```html
 <a href="/page2">Hello</a>
 ```
+
 In HXML, the [`href`](/docs/reference_behavior_attributes#href) attribute can appear on most UI elements, including [`<view>`](/docs/reference_view), [`<image>`](/docs/reference_image), [`<text>`](/docs/reference_text), [`<item>`](/docs/reference_image), etc.
+
 ```xml
 <view href="/page2">
   <text>Hello</text>
@@ -76,6 +91,7 @@ In HXML, the [`href`](/docs/reference_behavior_attributes#href) attribute can ap
 
 In HTML, the [`href`](/docs/reference_behavior_attributes#href) can be a relative URI or absolute URL.
 In HXML, the [`href`](/docs/reference_behavior_attributes#href) attribute can additionally refer to any element id in the current [`<doc>`](/docs/reference_doc).
+
 ```xml
 <doc xmlns="https://hyperview.org/hyperview">
   <screen id="main">
@@ -93,8 +109,10 @@ In HXML, the [`href`](/docs/reference_behavior_attributes#href) attribute can ad
 ```
 
 ### action
+
 In HTML, clicking on an anchor element will always open the href in a new page.
 In HXML, elements with an [`href`](/docs/reference_behavior_attributes#href) can also specify an [`action`](/docs/reference_behavior_attributes#action) attribute. Some actions will open new screens, but other actions will modify the current screen by replacing/injecting the response content into the screen's XML.
+
 ```xml
 <doc xmlns="https://hyperview.org/hyperview">
   <screen id="main">
@@ -109,9 +127,11 @@ In HXML, elements with an [`href`](/docs/reference_behavior_attributes#href) can
 ```
 
 ### target
+
 In HTML, the `target` attribute on an `<a>` element can be used to determine if the href opens in a new window or the same window.
 
 In HXML, the [`target`](/docs/reference_behavior_attributes#target) attribute is an element id referencing an element on the screen. It's used with the [`action`](/docs/reference_behavior_attributes#action) attribute to determine which element should be affected by the action.
+
 ```
 <doc xmlns="https://hyperview.org/hyperview">
   <screen id="main">
@@ -125,8 +145,10 @@ In HXML, the [`target`](/docs/reference_behavior_attributes#target) attribute is
 ```
 
 ### trigger
+
 In HTML, `<a>` elements will only be triggered by a click on the anchor element.
 In HXML, elements with an `href` attribute can have all kinds of triggers, including different types of presses, on item visibility, or on element load.
+
 ```xml
 <doc xmlns="https://hyperview.org/hyperview">
   <screen id="main">
@@ -141,8 +163,10 @@ In HXML, elements with an `href` attribute can have all kinds of triggers, inclu
 ```
 
 ### Multiple behaviors
+
 In HTML, `<a>` elements can only open one page, and they cannot be nested.
 In HXML, an element can specify multiple behaviors using the [`<behavior>`](/docs/reference_behavior) element.
+
 ```xml
 <doc xmlns="https://hyperview.org/hyperview">
   <screen id="main">
@@ -161,7 +185,9 @@ In HXML, an element can specify multiple behaviors using the [`<behavior>`](/doc
 ## Styling
 
 ### Style language
+
 - HTML elements are styled using CSS.
+
 ```html
 <style>
   h1.header {
@@ -170,7 +196,9 @@ In HXML, an element can specify multiple behaviors using the [`<behavior>`](/doc
   }
 </style>
 ```
+
 - HXML does not use CSS. Instead, it uses the [`<styles>`](/docs/reference_styles) tag to define a group of styles, and [`<style>`](/docs/reference_style) to define a specific set of rules.
+
 ```xml
 <styles>
   <style id="Header"
@@ -181,7 +209,9 @@ In HXML, an element can specify multiple behaviors using the [`<behavior>`](/doc
 ```
 
 ### Selectors
+
 In CSS, selectors can be used to target tags, element ids, classes, or more advanced targets.
+
 ```html
 <style>
   #main .container h2 {
@@ -189,12 +219,12 @@ In CSS, selectors can be used to target tags, element ids, classes, or more adva
   }
 </style>
 <div id="main">
-  <div class="container">
-    <h2>Hello</h2>
-  </div>
+  <div class="container"><h2>Hello</h2></div>
 </div>
 ```
+
 In HXML, style rules are identified by id. Selection can only happen by id.
+
 ```xml
 <styles>
   <style id="MainHeader" color="blue" />
@@ -207,12 +237,14 @@ In HXML, style rules are identified by id. Selection can only happen by id.
 ```
 
 ### Applying styles
+
 In CSS, an element can have several styles applied to it by matching multiple selectors. There is a complex hierarchy that determines the order of application of the rules.
+
 ```html
 <style>
   #main {
-    font-size: 12p;x
-    color: red;
+    font-size: 12p;
+    xcolor: red;
   }
   h2 {
     font-size: 16px;
@@ -226,12 +258,12 @@ In CSS, an element can have several styles applied to it by matching multiple se
   }
 </style>
 <div id="main">
-  <div class="container">
-    <h2>Hello</h2>
-  </div>
+  <div class="container"><h2>Hello</h2></div>
 </div>
 ```
+
 In HXML, an element can explicitly reference several style ids. The application of the style rules matches the order of the ids.
+
 ```xml
 <styles>
   <style id="Center" color="black" textAlign="center" />
@@ -246,7 +278,9 @@ In HXML, an element can explicitly reference several style ids. The application 
 ```
 
 ### Cascading rules
+
 In CSS, rules cascade to child elements.
+
 ```html
 <style>
   #main {
@@ -254,12 +288,12 @@ In CSS, rules cascade to child elements.
   }
 </style>
 <div id="main">
-  <div class="container">
-    <h2>This will be red</h2>
-  </div>
+  <div class="container"><h2>This will be red</h2></div>
 </div>
 ```
+
 In HXML, rules only apply to the element.
+
 ```xml
 <styles>
   <style id="Main" color="red" />
@@ -272,7 +306,9 @@ In HXML, rules only apply to the element.
 ```
 
 ### Modifiers
+
 In CSS, the styles for different states are defined using pseudo-selectors:
+
 ```html
 <style>
   a {
@@ -285,6 +321,7 @@ In CSS, the styles for different states are defined using pseudo-selectors:
 ```
 
 In HXML, the styles for different states are defined using the [`<modifier>`](/docs/reference_modifier) element:
+
 ```xml
 <style id="Link" color="blue">
   <modifier pressed="true">
@@ -294,13 +331,14 @@ In HXML, the styles for different states are defined using the [`<modifier>`](/d
 ```
 
 In CSS, pseudo-selector states are local to that element, but can affect other elements through the selector.
+
 ```html
 <style>
   a {
     color: blue;
   }
   a:hover {
-    color:red;
+    color: red;
   }
   a:hover span {
     color: green;
@@ -310,7 +348,9 @@ In CSS, pseudo-selector states are local to that element, but can affect other e
   <a href="#">Hello, <span>world</span>!</a>
 </body>
 ```
+
 In HXML, the modifier state applies to all child elements:
+
 ```xml
 <styles>
   <style id="Link" color="blue">

--- a/docs/guide_installation.md
+++ b/docs/guide_installation.md
@@ -1,7 +1,7 @@
 ---
 id: guide_installation
-title: "Getting started"
-sidebar_label: "Getting started"
+title: Getting started
+sidebar_label: Getting started
 ---
 
 To get started with Hyperview, you need both a Hyperview backend server (that responds to requests with [HXML](/docs/guide_installation)) and a mobile app to host the RN client. The Hyperview codebase includes a demo of the backend and mobile app to help you get started quickly.
@@ -9,27 +9,33 @@ To get started with Hyperview, you need both a Hyperview backend server (that re
 > Make sure [yarn is installed](https://yarnpkg.com/lang/en/docs/install) on your system before continuing.
 
 ## 1. Clone the Github repository
+
 ```
 > git clone https://github.com/instawork/hyperview
 ```
 
 This repository contains:
+
 - The React Native client code for Hyperview
 - An XML server with examples of many Hyperview features
 - A demo Expo project that can connect to the example XML server, or any other Hyperview endpoint.
 - all of the reference docs on this website
 
 ## 2. Run the example server
+
 From the repo root directory:
+
 ```
 > yarn
 > yarn test:xmlserver
 ```
+
 This will start an HTTP server listening on port 8085. You cen verify that the server works by visiting [http://0.0.0.0:8085/index.xml](http://0.0.0.0:8085/index.xml) in a web browser.
 
-
 ## 3. Start the demo app
+
 In a separate shell, install the demo dependencies and start the development server. From the repo root directory:
+
 ```
 > cd demo
 > yarn
@@ -38,21 +44,29 @@ In a separate shell, install the demo dependencies and start the development ser
 The next step depends on whether you want to run the demo app in the iOS simulator, on an Android Virtual Device, or on a physical mobile device.
 
 #### Running on the iOS simulator
+
 From the `demo/` directory:
+
 ```
 > yarn ios
 ```
+
 This will open the iOS simulator and install the demo app in the simulator. It will then start the Expo development server to load the demo app.
 
 #### Running on an Android Virtual Device
+
 From the `demo/` directory:
+
 ```
 > yarn android
 ```
+
 This will open an AVD and install the demo app in the emulator. It will then start the Expo development server to load the demo app.
 
 #### Running on a physical device
+
 On your physical mobile device, install the Expo client
+
 - [iOS App Store](https://itunes.apple.com/us/app/expo-client/id982107779?mt=8)
 - [Google Play Store](https://play.google.com/store/apps/details?id=host.exp.exponent)
 
@@ -61,9 +75,11 @@ Make sure your mobile device and development machine are connected to the same n
 Open [/demo/navigation/AppNavigator.js](https://github.com/Instawork/hyperview/blob/master/demo/navigation/AppNavigator.js#L42) in a text editor. In `initialRouteParams`, replace the host in the url (`http://0.0.0.0:8085/index.xml`) with the IP of your machine. This is needed in order for your physical device to be able to request the example XML files from your development machine.
 
 From the `demo/` directory on your development machine:
+
 ```
 > yarn start
 ```
+
 This command will start an Expo development server and open a webpage (http://localhost:19002). This webpage will display a QR code.
 
 ![expo](/img/guide_installation1.png)
@@ -71,8 +87,8 @@ This command will start an Expo development server and open a webpage (http://lo
 - On your iOS device, open the Camera app and point it at the QR code on your screen. The Camera app should show an "Open in Expo" notification. Tap this notification.
 - On your Android device, use the Expo app to scan the QR code on your screen.
 
-
 ## 4. You're all set!
+
 Whether you're using a physical device or simulator, you should now see a Hyperview screen rendered from the example server:
 
 ![final](/img/guide_installation2.gif)
@@ -80,4 +96,5 @@ Whether you're using a physical device or simulator, you should now see a Hyperv
 The example server responds with files in the [./examples](/examples) directory. You can modify or add files in [./examples](/examples) and the server will update without restarting. to view your changes, simply navigate back to the changed page.
 
 ### Troubleshooting
+
 > This version of the Expo app is out of date. Uninstall the app and run again to upgrade.

--- a/docs/guide_introduction.md
+++ b/docs/guide_introduction.md
@@ -1,18 +1,21 @@
 ---
 id: guide_introduction
-title: "Introduction"
-sidebar_label: "Introduction"
+title: Introduction
+sidebar_label: Introduction
 ---
 
 ### The state of mobile development
+
 At [Instawork](https://instawork.com), we observed a marked difference in developer productivity between our mobile and [web platforms](https://engineering.instawork.com/iterating-with-simplicity-evolving-a-django-app-with-intercooler-js-8ed8e69d8a52).
 
-On *mobile*:
+On _mobile_:
+
 - we released code once a week,
 - it took 2 weeks for 80% of our users to get the update,
 - developer productivity was slowed down by the need to work across backend and frontend codebases.
 
-On *the web*:
+On _the web_:
+
 - we could release updates to our app many times a day,
 - all of our users always saw our updates immediately,
 - developers could build new features quickly by working in a single codebase.
@@ -46,6 +49,7 @@ In other words:
 > On mobile we have **HXML** and the **Hyperview Client**.
 
 Instawork uses Hyperview in our production apps to get all of the benefits of the thin-client paradigm in a mobile world:
+
 - We can update out mobile apps many times a day by deploying our backend
 - All of our users get our updates immediately without needing to download a new binary
 - Developers can be super-productive by building the backend and frontend simultaneously in one codebase
@@ -53,6 +57,7 @@ Instawork uses Hyperview in our production apps to get all of the benefits of th
 Hyperview has been a total game-changer for how we work at Instawork. The improvements to our developer productivity have allowed us to ship new features more quickly, improve our app's performance, and minimize context switching between mobile and web development. For fast-changing networked mobile apps, Hyperview offers an unbeatable set of tradeoffs.
 
 ### Getting started
+
 There are many ways to gets started with Hyperview:
 
 - If you want to learn Hyperview by reading example code, head over to the [Examples](/docs/example_index) section.

--- a/docs/reference_behavior.md
+++ b/docs/reference_behavior.md
@@ -1,7 +1,7 @@
 ---
 id: reference_behavior
-title: "<behavior>"
-sidebar_label: "<behavior>"
+title: <behavior>
+sidebar_label: <behavior>
 ---
 
 The `<behavior>` element allows adding multiple behaviors to UI elements such as `<view>`, `<text>`, `<image>`, etc.
@@ -15,6 +15,7 @@ The `<behavior>` element allows adding multiple behaviors to UI elements such as
 ```
 
 The example above shows a button with two behaviors:
+
 - When the button is pressed, we request "/display" and push the content as a new screen.
 - When the button is long-pressed, we request "/edit" and show the content as a modal.
 
@@ -28,7 +29,9 @@ The example above shows a button with two behaviors:
 ```
 
 ## Structure
+
 A `<behavior>` element defines a behavior that applies to its direct parent element. The following elements can contain `<behavior>` elements as a direct child:
+
 - [`<view>`](/docs/reference_view)
 - [`<text>`](/docs/reference_text)
 - [`<image>`](/docs/reference_image)
@@ -36,10 +39,10 @@ A `<behavior>` element defines a behavior that applies to its direct parent elem
 - [`<section-list>`](/docs/reference_sectionlist)
 - [`<option>`](/docs/reference_option)
 
-
 ## Attributes
-* [Behavior attributes](#behavior-attributes)
 
+- [Behavior attributes](#behavior-attributes)
 
 #### Behavior attributes
+
 A `<behavior>` element accepts the standard [behavior attributes](behaviors). The supported triggers depend on the parent element.

--- a/docs/reference_body.md
+++ b/docs/reference_body.md
@@ -1,12 +1,13 @@
 ---
 id: reference_body
-title: "<body>"
-sidebar_label: "<body>"
+title: <body>
+sidebar_label: <body>
 ---
 
 The `<body>` element represents the body of the UI, meaning everything other than the header and bottom tab. The body can scroll or be of fixed size. Using flexbox styling, the body can represent a variety of top-level layouts. `<body>` elements can handle all of the standard behavior triggers, including "refresh" to provide a pull-to-refresh behavior.
 
 Some examples of views:
+
 ```xml
 <body id="Main" scroll="true">
   <view style="Section1">
@@ -25,42 +26,49 @@ Some examples of views:
 ```
 
 ## Structure
+
 A `<body>` element can only appear as a direct child of a `<screen>` element. There should only be one body per screen.
 
 ## Attributes
-* [Behavior attributes](#behavior-attributes)
-* [`style`](#style)
-* [`scroll`](#scroll)
-* [`scroll-orientation`](#scroll-orientation)
-* [`id`](#id)
+
+- [Behavior attributes](#behavior-attributes)
+- [`style`](#style)
+- [`scroll`](#scroll)
+- [`scroll-orientation`](#scroll-orientation)
+- [`id`](#id)
 
 #### Behavior attributes
+
 A `<body>` element accepts the standard [behavior attributes](/docs/reference_behavior_attributes), including all triggers (press, refresh, visible, etc).
 
 #### `style`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A space-separated list of styles to apply to the element. See [Styles](/docs/reference_style). Note that text style rules will cannot be applied to a `<body>`.
 
 #### `scroll`
-| Type     | Required |
-| -------- | -------- |
-| true, **false** (default)  | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| true, **false** (default) | No       |
 
 An attribute indicating whether the content in the can be scrollable. The style rules of the body will determine the viewport size.
 
 #### `scroll-orientation`
-| Type     | Required |
-| -------- | -------- |
-| **vertical** (default), horizontal  | No       |
+
+| Type                               | Required |
+| ---------------------------------- | -------- |
+| **vertical** (default), horizontal | No       |
 
 An attribute indicating the direction in which the body will scroll.
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.

--- a/docs/reference_client.md
+++ b/docs/reference_client.md
@@ -1,5 +1,5 @@
 ---
 id: reference_client
-title: "Hyperview component"
-sidebar_label: "Hyperview component"
+title: Hyperview component
+sidebar_label: Hyperview component
 ---

--- a/docs/reference_custom_behaviors.md
+++ b/docs/reference_custom_behaviors.md
@@ -1,7 +1,7 @@
 ---
 id: reference_custom_behaviors
-title: "Custom behaviors"
-sidebar_label: "Custom behaviors"
+title: Custom behaviors
+sidebar_label: Custom behaviors
 ---
 
 > **NOTE**: custom behaviors are still under active development. The architecture will be changing in the near future to add more flexibility.
@@ -9,9 +9,11 @@ sidebar_label: "Custom behaviors"
 The Hyperview client currently supports a limited number of custom behaviors for deeper integrations with mobile app functionality. These custom behaviors are configured by passing callback props to the `Hyperview` component.
 
 ## Event logging
+
 If you have support for event tracking (via Amplitude or another service) available in your React Native code, you can specify when to log events with a custom behavior in HXML. Instawork uses Amplitude (hence the Amplitude naming conventions), but any logging system can be exposed in HXML using this technique.
 
 #### Configuring the client
+
 To hook into Amplitude, add a `logEvent` callback prop to the `Hyperview` component:
 
 ```es6
@@ -28,14 +30,15 @@ function screen({ url }) => (
 
 The `logEvent` callback takes an object argument with two properties:
 
-| Property    | Type     | Required | Description |
-| ----------- | -------- | -------- | ----------- |
-|  name       | string   | Yes      | The name of the event to log. |
-|  properties | object   | No       | Object containing key/value event properties. |
+| Property   | Type   | Required | Description                                   |
+| ---------- | ------ | -------- | --------------------------------------------- |
+| name       | string | Yes      | The name of the event to log.                 |
+| properties | object | No       | Object containing key/value event properties. |
 
-Note that the `logEvent` callback can attach to any logging service, but at Instawork we use Amplitude. 
+Note that the `logEvent` callback can attach to any logging service, but at Instawork we use Amplitude.
 
 #### Using in HXML
+
 Add a `<behavior>` element with `action="amplitude"`. The attributes `amp:event` and `amp:event-props` specify the event name and event properties to log when the behavior executes.
 
 ```xml
@@ -63,9 +66,11 @@ In this example, we log `main-screen/view` to Amplitude when the view loads. Whe
 Note that amplitude behaviors require that the HXML doc define a namespace for `https://instawork.com/hyperview-amplitude`.
 
 ## Phone calls
+
 HXML behaviors can trigger calling or sending an SMS to a given phone number via a callback passed to the `Hyperview` component.
 
 #### Configuring the client
+
 To hook into calling functionality, add an `onCall` callback prop to the `Hyperview` component:
 
 ```es6
@@ -82,13 +87,14 @@ function screen({ url }) => (
 
 The `onCall` prop takes a function with one parameter:
 
-| Parameter   | Type     | Required | Description |
-| ----------- | -------- | -------- | ----------- |
-|  num        | string   | Yes      | The phone number to call. |
+| Parameter | Type   | Required | Description               |
+| --------- | ------ | -------- | ------------------------- |
+| num       | string | Yes      | The phone number to call. |
 
 Note that the `onCall` callback can trigger any sort of UI or call capability implemented in React Native.
 
 #### Using in HXML
+
 Add a `<behavior>` element with `action="phone"`. The attributes `phone:number` specifies the number to call.
 
 ```xml
@@ -106,11 +112,12 @@ Add a `<behavior>` element with `action="phone"`. The attributes `phone:number` 
 
 The above example would show a UI to confirm the call to the given number.
 
-
 ## Share sheet
+
 Share buttons are common in mobile apps. To hook into the mobile device's native sharing functionality, you can use the custom share behavior.
 
 #### Configuring the client
+
 To hook into the system's share functionality, add an `onShare` callback prop to the `Hyperview` component:
 
 ```es6
@@ -126,6 +133,7 @@ function screen({ url }) => (
 ```
 
 #### Using in HXML
+
 Add a `<behavior>` element with `action="share"`. The attributes `share:dialog-title`, `share:message`, `share:subject`, and `share:url` cnofigure the share dialog. `share:message` and `share:url` are the required attributes.
 
 ```xml
@@ -146,11 +154,12 @@ Add a `<behavior>` element with `action="share"`. The attributes `share:dialog-t
 
 The above example would trigger the system share dialog with options to share the title/message/subject/url on a social platform of choice.
 
-
 ## Redux actions
+
 If you're adding Hyperview to an existing React Native + Redux app, it can be useful to dispatch Redux actions from Hyperview screens. A custom behavior supports Redux action dispatch by adding a callback to the `Hyperview` components.
 
 #### Configuring the client
+
 To hook into Redux, add a `dispatchReduxAction` callback prop to the `Hyperview` component:
 
 ```es6
@@ -168,6 +177,7 @@ function screen({ url }) => (
 The `dispatchReduxAction` prop takes a function with one parameter, the Redux action. Reduct actions must contains a `type` property, and can optionally contain additional properties to customize the action.
 
 #### Using in HXML
+
 Add a `<behavior>` element with `action="redux"`. The attributes `redux:action` specifies the action type, and `redux:extra` contains an encoded JSON object of action prioerties.
 
 ```xml

--- a/docs/reference_custom_elements.md
+++ b/docs/reference_custom_elements.md
@@ -1,7 +1,7 @@
 ---
 id: reference_custom_elements
-title: "Custom elements"
-sidebar_label: "Custom elements"
+title: Custom elements
+sidebar_label: Custom elements
 ---
 
 > **NOTE**: custom elements are still under active development. The architecture will be changing in the near future to add more flexibility.
@@ -9,21 +9,22 @@ sidebar_label: "Custom elements"
 The `Hyperview` can be extended with custom elements that can be referenced and configured via HXML. Custom elements allow you to create rich, interactive client-side components, while controlling the layout of these elements from the backend server.
 
 #### Creating custom elements
+
 Custom Hyperview elements are backed by a React Native component. Any React Native component can be a custom element. There are only two required static class properties for custom components:
 
-| Property      | Type   | Required | Description |
-| ------------- | -------| -------- | ----------- |
-|  namespaceURI | string | Yes      | The XML namespace for the element |
-|  localName    | string | Yes      | The local tag name (within the XML namespace) for the element |
+| Property     | Type   | Required | Description                                                   |
+| ------------ | ------ | -------- | ------------------------------------------------------------- |
+| namespaceURI | string | Yes      | The XML namespace for the element                             |
+| localName    | string | Yes      | The local tag name (within the XML namespace) for the element |
 
 When rendering the component, Hyperview will pass screen context to `render()` as props. The component is free to use these props if it wants to render sub-children:
 
-| Prop          | Type   | Description |
-| ------------- | -------| ----------- |
-| element       | xmldom Element object | The element DOM object from the HXML |
-| stylesheets   | object | RN Stylesheets defined in the screen's HXML |
-| animations   | object | Unsupported object defining animated values |
-| onUpdates   | function | Callback that triggers a behavior |
+| Prop        | Type                  | Description                                 |
+| ----------- | --------------------- | ------------------------------------------- |
+| element     | xmldom Element object | The element DOM object from the HXML        |
+| stylesheets | object                | RN Stylesheets defined in the screen's HXML |
+| animations  | object                | Unsupported object defining animated values |
+| onUpdates   | function              | Callback that triggers a behavior           |
 
 For example, if we wanted to expose a map element within Hyperview, we can wrap `MapView` from `react-native-maps` in a class that adds the two required properties:
 
@@ -36,7 +37,6 @@ export default class HyperviewMap extends PureComponent<Props> {
   static localName = 'map';
 
   render() {
-
     // Parses the HXML elements attributes.
     // Returns styles and custom props.
     const props = Hyperview.createProps(
@@ -62,14 +62,10 @@ export default class HyperviewMap extends PureComponent<Props> {
     };
 
     return (
-      <MapView
-        {...props}
-        region={region}
-        liteMode
-      >
+      <MapView {...props} region={region} liteMode>
         {children}
       </MapView>
-    )
+    );
   }
 }
 ```
@@ -89,6 +85,7 @@ function screen({ url }) => (
 ```
 
 #### Using in HXML
+
 Now that the custom element is registered with the Hyperview component, you can reference it in HXML using the provided namespace and tag name:
 
 ```xml

--- a/docs/reference_doc.md
+++ b/docs/reference_doc.md
@@ -1,7 +1,7 @@
 ---
 id: reference_doc
-title: "<doc>"
-sidebar_label: "<doc>"
+title: <doc>
+sidebar_label: <doc>
 ---
 
 The `<doc>` element represents the root of a Hyperview payload.
@@ -20,12 +20,14 @@ The `<doc>` element represents the root of a Hyperview payload.
 </doc>
 ```
 
-In the example above, the screen with id "main" will be displayed.  The screen with id "preloadScreen" will not be rendered, but can be used to display subsequent screens or to serve as a loading state for subsequent screens.
+In the example above, the screen with id "main" will be displayed. The screen with id "preloadScreen" will not be rendered, but can be used to display subsequent screens or to serve as a loading state for subsequent screens.
 
 ## Structure
+
 A `<doc>` element can only appear at the root of a Hyperview XML document. A doc can contain many `<screen>` elements, but only the first one will be rendered in the current screen. The other `<screen>` elements can be used to prefetch subsequent screens or indicators.
 
 ## Attributes
+
 The `<doc>` does not take any attributes. It's good to set the default XML namespace on the doc so that it applies as the default to all of the children:
 
 ```xml

--- a/docs/reference_form.md
+++ b/docs/reference_form.md
@@ -1,7 +1,7 @@
 ---
 id: reference_form
-title: "<form>"
-sidebar_label: "<form>"
+title: <form>
+sidebar_label: <form>
 ---
 
 The `<form>` element represents a group of input elements that should be serialized into the request. Any behaviors within the `<form>` that result in a remote request will include the form's input values. The encoding of the input values depend on the request method:
@@ -31,6 +31,7 @@ The `<form>` element represents a group of input elements that should be seriali
 ```
 
 In the example above, when the user presses the "Submit" label, Hyperview will make the following request (with headers and body):
+
 ```
 POST /feedback
 
@@ -48,32 +49,36 @@ Content-Disposition: form-data; name="feedback"
 Great work!
 ```
 
-
 ## Structure
+
 A `<form>` element can appear anywhere within a `<screen>` element. It can contain any type of element, but it should contain some input elements to serve as a grouping.
 
 ## Attributes
-* [`style`](#style)
-* [`id`](#id)
-* [`hide`](#hide)
+
+- [`style`](#style)
+- [`id`](#id)
+- [`hide`](#hide)
 
 #### `style`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A space-separated list of styles to apply to the element. See [Styles](/docs/reference_style). Note that text style rules cannot be applied to a `<form>`.
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.
 
 #### `hide`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.

--- a/docs/reference_header.md
+++ b/docs/reference_header.md
@@ -1,12 +1,13 @@
 ---
 id: reference_header
-title: "<header>"
-sidebar_label: "<header>"
+title: <header>
+sidebar_label: <header>
 ---
 
 The `<header>` element represents the header of a screen in the app. Typically, the header shows a title and navigation elements
 
 An example header on a screen with a scrolling body.
+
 ```xml
 <screen>
   <header style="MyHeader">
@@ -23,34 +24,40 @@ An example header on a screen with a scrolling body.
 ```
 
 ## Structure
+
 A `<header>` element can only appear as a direct child of a `<screen>` element.
 
 ## Attributes
-* [Behavior attributes](#behavior-attributes)
-* [`style`](#style)
-* [`id`](#id)
-* [`hide`](#hide)
+
+- [Behavior attributes](#behavior-attributes)
+- [`style`](#style)
+- [`id`](#id)
+- [`hide`](#hide)
 
 #### Behavior attributes
+
 A `<header>` element accepts the standard [behavior attributes](/docs/reference_behavior_attributes), except for the "refresh" trigger.
 
 #### `style`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A space-separated list of styles to apply to the element. See [Styles](/docs/reference_style). Note that text style rules will cannot be applied to a `<header>`.
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.
 
 #### `hide`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.

--- a/docs/reference_hyperview_component.md
+++ b/docs/reference_hyperview_component.md
@@ -1,7 +1,7 @@
 ---
 id: reference_hyperview_component
-title: "Hyperview component"
-sidebar_label: "Hyperview component"
+title: Hyperview component
+sidebar_label: Hyperview component
 ---
 
 The `hyperview` npm module exports the `Hyperview` React Native component. `Hyperview` takes props to load a particular URL (with an HXML response).

--- a/docs/reference_image.md
+++ b/docs/reference_image.md
@@ -1,7 +1,7 @@
 ---
 id: reference_image
-title: "<image>"
-sidebar_label: "<image>"
+title: <image>
+sidebar_label: <image>
 ---
 
 The `<image>` element displays an image on the screen. Image data can be provided as a local resource (bundled with the mobile app), a remote resource fetched from a server, or a image encoded into the URI.
@@ -29,48 +29,56 @@ The `<image>` element displays an image on the screen. Image data can be provide
 ```
 
 ## Structure
+
 An `<image>` element can appear anywhere within a `<screen>` element (including in the body or header).
 
 ## Attributes
-* [Behavior attributes](#behavior-attributes)
-* [`source`](#source)
-* [`style`](#style)
-* [`id`](#id)
-* [`hide`](#hide)
+
+- [Behavior attributes](#behavior-attributes)
+- [`source`](#source)
+- [`style`](#style)
+- [`id`](#id)
+- [`hide`](#hide)
 
 #### Behavior attributes
+
 An `<image>` element accepts the standard [behavior attributes](/docs/reference_behavior_attributes), including all triggers (press, refresh, visible, etc).
 
 #### `source`
-| Type     | Required |
-| -------- | -------- |
-| string   | **Yes**  |
+
+| Type   | Required |
+| ------ | -------- |
+| string | **Yes**  |
 
 A URI specifying the resource with image data. The URI must follow one of the following formats:
+
 - **Absolute URL**: eg `http://s3.amazonaws.com/instawork/profile.png`. The image will be requested from the remote server.
-- **Relative URL**: eg `/img/profile.png`. The image will be requested from a remote server. The host will be the same as the screen's host. For example, if the screen was loaded from `https://instawork.com/about`, the image would be requested from `https://instawork.com/img/profile.png `.
+- **Relative URL**: eg `/img/profile.png`. The image will be requested from a remote server. The host will be the same as the screen's host. For example, if the screen was loaded from `https://instawork.com/about`, the image would be requested from `https://instawork.com/img/profile.png`.
 - **Local URL**: eg `./profile.png`. This image must be bundled as an asset in the mobile app.
 - **Data URI**: eg `data:image/png;base64,iVBORw`. The image data is encoded in the attribute, so no requests will need to be made.
 
 #### `style`
-| Type     | Required |
-| -------- | -------- |
-| string   | **Yes**  |
+
+| Type   | Required |
+| ------ | -------- |
+| string | **Yes**  |
 
 A space-separated list of styles to apply to the element. See [Styles](/docs/reference_style). Note that text style rules cannot be applied to an `<image>`.
 
 > **NOTE**: Most elements in Hyperview do not require an applied style, but images require a style with rules that specify `width` and `height`. Without a style that specifies image dimensions, the image will render as using 0x0 dimensions and won't appear on the screen.
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.
 
 #### `hide`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.

--- a/docs/reference_index.md
+++ b/docs/reference_index.md
@@ -1,19 +1,24 @@
 ---
 id: reference_index
-title: "Reference"
-sidebar_label: "Index"
+title: Reference
+sidebar_label: Index
 ---
 
 ### Hyperview XML
+
 Hyperview XML (HXML) is a hypermedia, XML-based format used to define mobile app screens. HXML provides a set of tags and attributes that define a screen's layout, styling, and available user interactions.
 
 #### Behaviors
+
 Behaviors in HXML define actions that should happen in the app, in response to a user-based trigger. Behaviors can either be specified as attributes on other HXML elements, or as a child `<behavior>` element.
+
 - [Behavior attributes](/docs/reference_behavior_attributes) Goes in-depth about the HXML attributes used to define a behavior.
 - [`<behavior>`](/docs/reference_behavior): An element that accepts behavior attributes and applies the behavior to the parent element. Often used when an element needs to define multiple behaviors.
 
 #### Display Elements
+
 Display elements in HXML can be combined to define the layout of a screen.
+
 - [`<doc>`](/docs/reference_doc): The top-level element in HXML, used to include multiple screens in one response.
 - [`<screen>`](/docs/reference_screen): A single screen of a mobile app.
 - [`<header>`](/docs/reference_header): The header of a mobile app screen.
@@ -29,6 +34,7 @@ Display elements in HXML can be combined to define the layout of a screen.
 - [`<spinner>`](/docs/reference_spinner): Activity indicator element.
 
 #### Input Elements
+
 Input elements in HXML allow users to set local state on a Hyperview screen. This state can be serialized with backend requests, or used for client-side interactions.
 
 - [`<form>`](/docs/reference_form): An element used to group together several inputs for request serialization.
@@ -39,6 +45,7 @@ Input elements in HXML allow users to set local state on a Hyperview screen. Thi
 - [`<option>`](/docs/reference_option): An element that groups many `<option>` elements, and allows any number of options to be selected/deselected.
 
 #### Style Elements
+
 Style elements in HXML define rules for the appearance of display and input elements.o
 
 - [`<styles>`](/docs/reference_styles): Groups together all of the `<style>` rules for a screen.
@@ -46,7 +53,9 @@ Style elements in HXML define rules for the appearance of display and input elem
 - [`<modifier>`](/docs/reference_modifier): Defines an appearance that should override the default for a style under certain local conditions, such as a user tap, selection, etc.
 
 ### React Native Client
+
 The Hyperview RN Client is a library that can parse and render HXML in a React Native app.
+
 - The [`Hyperview`](/docs/reference_hyperview_component) class defines a component that takes an endpoint URL and configuration props to render Hyperview screens in an app.
 - [Custom Elements](/docs/reference_custom_elements): The Hyperview client can be extended by registering custom HXML elements and tags with custom RN components. This can be used to add elements with rich interactions, such as maps.
 - [Custom Behaviors](/docs/reference_custom_behaviors): The Hyperview client can be extended by registering custom callbacks that can be triggered via `<behavior>` elements in the HXML. Supports features like dispatching Redux actions, triggering phone calls and share sheets, event logging, etc.

--- a/docs/reference_item.md
+++ b/docs/reference_item.md
@@ -1,12 +1,13 @@
 ---
 id: reference_item
-title: "<item>"
-sidebar_label: "<item>"
+title: <item>
+sidebar_label: <item>
 ---
 
 The `<item>` element represents an item in a `<list>` or `<section>`. The structure and attributes of an `<item>` match the `<view>` element.
 
 Here's a single item in a list:
+
 ```xml
 <list style="List">
   <item key="a" style="Item">
@@ -22,6 +23,7 @@ Here's a single item in a list:
 ```
 
 Here's a single item in a section list:
+
 ```xml
 <section-list style="List">
   <section>
@@ -45,42 +47,49 @@ Here's a single item in a section list:
 Note that the `key` attribute is required and must be unique among items in the parent list.
 
 ## Structure
+
 An `<item>` element can only apear as a direct child of a `<list>` or `<section>` element. It can contain any non-list element as a child.
 
 ## Attributes
-* [Behavior attributes](#behavior-attributes)
-* [`key`](#key)
-* [`style`](#style)
-* [`id`](#id)
-* [`hide`](#hide)
+
+- [Behavior attributes](#behavior-attributes)
+- [`key`](#key)
+- [`style`](#style)
+- [`id`](#id)
+- [`hide`](#hide)
 
 #### Behavior attributes
+
 An `<item>` element accepts the standard [behavior attributes](/docs/reference_behavior_attributes). However, since `<item>` elements can only be children of scrollable `<list>` elements, the pull-to-refresh gesture will never trigger on an `<item>`. Thus, `refresh` triggers should only be added to the parent list element.
 
 #### `key`
-| Type     | Required |
-| -------- | -------- |
-| string   | **Yes**  |
+
+| Type   | Required |
+| ------ | -------- |
+| string | **Yes**  |
 
 A unique key identifying the item in the list. This key is used to efficiently update the list when items are added or removed.
 
 #### `style`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A space-separated list of styles to apply to the element. See [Styles](/docs/reference_style).
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.
 
 #### `hide`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.

--- a/docs/reference_list.md
+++ b/docs/reference_list.md
@@ -1,7 +1,7 @@
 ---
 id: reference_list
-title: "<list>"
-sidebar_label: "<list>"
+title: <list>
+sidebar_label: <list>
 ---
 
 The `<list>` element represents a list of items. Unlike child elements of a `<view>`, children of a `<list>` element undergo optimizations to efficiently render hundreds of items.
@@ -23,43 +23,49 @@ The `<list>` element represents a list of items. Unlike child elements of a `<vi
 ```
 
 ## Structure
+
 A `<list>` element will only render `<item>` children elements. Other elements will be ignored during rendering.
 
 ## Attributes
-* [Behavior attributes](#behavior-attributes)
-* [`style`](#style)
-* [`itemHeight`](#itemheight)
-* [`id`](#id)
-* [`hide`](#hide)
 
+- [Behavior attributes](#behavior-attributes)
+- [`style`](#style)
+- [`itemHeight`](#itemheight)
+- [`id`](#id)
+- [`hide`](#hide)
 
 #### Behavior attributes
+
 A list will accept the standard [behavior attributes](/docs/reference_behavior_attributes). However, a list will only trigger the `refresh` behavior (through the pull-to-refresh gesture). Other behaviors, such as presses, should be handled by the `<item>` elements in the list.
 
 #### `style`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A space-separated list of styles to apply to the text. See [Styles](/docs/reference_style).
 
 #### `itemHeight`
-| Type     | Required |
-| -------- | -------- |
-| integer  | No       |
+
+| Type    | Required |
+| ------- | -------- |
+| integer | No       |
 
 An optional number that fixes the height of every item in the list. The presence of this property helps optimize layout for very long lists, by simplifying the calculation for which items are on screen.
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.
 
 #### `hide`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.

--- a/docs/reference_modifier.md
+++ b/docs/reference_modifier.md
@@ -1,7 +1,7 @@
 ---
 id: reference_modifier
-title: "<modifier>"
-sidebar_label: "<modifier>"
+title: <modifier>
+sidebar_label: <modifier>
 ---
 
 The `<modifier>` element defines temporary overrides of a style rule, given some local state of interactive UI elements.
@@ -33,6 +33,7 @@ The `<modifier>` element defines temporary overrides of a style rule, given some
 The `<style id="Input">` element above contains a `<modifier>` with attribute `focused="true"`. When the style is applied to a focusable element (in this case, a `<text-field>`) and the element is focused, the style rule attributes in the modifier will be merged with the default style rules. In the example above, the bottom border of the text field will change from `#E1E1E1` to `#4778FF` when the field is focused.
 
 The modifier state applies to all child elements of the parent:
+
 ```
 <doc xmlns="https://hyperview.org/hyperview">
   <screen id="main">
@@ -68,65 +69,80 @@ The modifier state applies to all child elements of the parent:
 In the example above, when touching the button, the `<view>` element will get the "pressed" state. The "pressed" style modifier will kick in, changing the color of the `<view>` to "#AAA". However, the "pressed" state will also apply to the child `<text>` element. Since the text element's style rule also has a "pressed" modifier, then the text color will change to red.
 
 ## Structure
+
 A `<modifier>` element should only appear as a direct child of a `<style>` element. A `<style>` element can contain several `<modifier>` elements.
 
 ## Attributes
-* [focused](#focused)
-* [pressed](#pressed)
-* [selected](#selected)
+
+- [focused](#focused)
+- [pressed](#pressed)
+- [selected](#selected)
 
 #### `focused`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 Setting this attribute to "true" means the modifier rules will only be applied when the element is focused. This attribute can be combined with `pressed`. For example, we can define a modifier to apply when pressing a focused element:
+
 ```xml
 <modifier focused="true" pressed="true" />
 ```
+
 Or when pressing a blurred element:
+
 ```xml
 <modifier focused="false" pressed="true" />
 ```
 
 The "focused" modifier only applies to elements that can be focused:
+
 - [`<text-field>`](/docs/reference_textfield)
 - [`<text-area>`](/docs/reference_textarea)
 
 #### `pressed`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 Setting this attribute to "true" means the modifier rules will only be applied when the element is being pressed. This attribute can be combined with `focused` or `selected`. For example, we can define a modifier to apply when a focused element is pressed:
+
 ```xml
 <modifier focused="true" pressed="true" />
 ```
+
 Or when a focused element is not pressed:
+
 ```xml
 <modifier focused="true" pressed="false" />
 ```
 
 The "pressed" modifier applies to any elements that can be triggered by a `pressIn`:
+
 - [`<view>`](/docs/reference_view)
 - [`<text>`](/docs/reference_text)
 - [`<image>`](/docs/reference_image)
 
 #### `selected`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 Setting this attribute to "true" means the modifier rules will only be applied when the element is "Selected". This attribute can be combined with `pressed`. For example, we can define a modifier to apply when a selected element is pressed:
+
 ```xml
 <modifier selected="true" pressed="true" />
 ```
+
 Or when a selected element is not pressed:
+
 ```xml
 <modifier selected="true" pressed="false" />
 ```
 
 The "pressed" modifier applies to any elements that can be triggered by a `select`:
+
 - [`<option>`](/docs/reference_option)
-
-

--- a/docs/reference_option.md
+++ b/docs/reference_option.md
@@ -1,7 +1,7 @@
 ---
 id: reference_option
-title: "<option>"
-sidebar_label: "<option>"
+title: <option>
+sidebar_label: <option>
 ---
 
 The `<option>` element represents an input choice within a `<select-single>` or `<select-multiple>`. Options can be selected or deselected, which can be expressed visually using the "selected" style modifier.
@@ -25,41 +25,46 @@ The `<option>` element represents an input choice within a `<select-single>` or 
 ```
 
 ## Structure
+
 A `<option>` element can appear anywhere within a `<select-single>` or `<select-multiple>` element.
 
 ## Attributes
-* [`value`](#value)
-* [`style`](#style)
-* [`id`](#id)
-* [`hide`](#hide)
 
+- [`value`](#value)
+- [`style`](#style)
+- [`id`](#id)
+- [`hide`](#hide)
 
 #### `value`
-| Type     | Required |
-| -------- | -------- |
-| string   | No (defaults to blank) |
+
+| Type   | Required               |
+| ------ | ---------------------- |
+| string | No (defaults to blank) |
 
 The value of the option. When selected, this value will be included in the [`<form>`](reference_form) data sent with remote requests.
 
 #### `style`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A space-separated list of styles to apply to the element. See [Styles](/docs/reference_style). Note that text style rules cannot be applied to an `<option>` element.
 
 `<option>` supports the `selected` style modifier. See [Modifiers](modifiers) for more details.
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.
 
 #### `hide`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.

--- a/docs/reference_screen.md
+++ b/docs/reference_screen.md
@@ -1,7 +1,7 @@
 ---
 id: reference_screen
-title: "<screen>"
-sidebar_label: "<screen>"
+title: <screen>
+sidebar_label: <screen>
 ---
 
 The `<screen>` element represents the UI that gets rendered on a single screen of a mobile app.
@@ -23,14 +23,17 @@ The `<screen>` element represents the UI that gets rendered on a single screen o
 The example above contains two screens in a Hyperview doc. The first `<screen>` will be rendered on the device. The second `<screen>` can be used on subsequent screens, or as a temporary indicator screen while a subsequent screen loads.
 
 ## Structure
+
 A `<screen>` element can only appear as a direct child of a `<doc>` element.
 
 ## Attributes
-* [`id`](#id)
+
+- [`id`](#id)
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.

--- a/docs/reference_section.md
+++ b/docs/reference_section.md
@@ -1,7 +1,7 @@
 ---
 id: reference_section
-title: "<section>"
-sidebar_label: "<section>"
+title: <section>
+sidebar_label: <section>
 ---
 
 The `<section>` element represents a group of items in a `<section-list>`. A section contains a title and items. The section itself does not have any visible style, it just serves as a grouping within the section list.
@@ -31,24 +31,28 @@ The `<section>` element represents a group of items in a `<section-list>`. A sec
 ```
 
 ## Structure
+
 A `<section>` element will only render `<section-title>` and `<item>` children elements. Other elements will be ignored during rendering.
 
 A `<section>` element can only appear as a direct child of a `<section-list>` element. It will not render on the screen in other contexts.
 
 ## Attributes
-* [`id`](#id)
-* [`hide`](#hide)
+
+- [`id`](#id)
+- [`hide`](#hide)
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.
 
 #### `hide`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.

--- a/docs/reference_sectionlist.md
+++ b/docs/reference_sectionlist.md
@@ -1,7 +1,7 @@
 ---
 id: reference_sectionlist
-title: "<section-list>"
-sidebar_label: "<section-list>"
+title: <section-list>
+sidebar_label: <section-list>
 ---
 
 The `<section-list>` element represents a sectioned list of items. Each section of the list has a sticky title bar, followed by a list of items. Unlike child elements of s `<view>`, children in a `<section-list>` undergo optimizations to efficiently render hundres of items.
@@ -31,34 +31,40 @@ The `<section-list>` element represents a sectioned list of items. Each section 
 ```
 
 ## Structure
+
 A `<section-list>` element will only render `<section>` children elements. Other elements will be ignored during rendering.
 
 ## Attributes
-* [Behavior attributes](#behavior-attributes)
-* [`style`](#style)
-* [`id`](#id)
-* [`hide`](#hide)
+
+- [Behavior attributes](#behavior-attributes)
+- [`style`](#style)
+- [`id`](#id)
+- [`hide`](#hide)
 
 #### Behavior attributes
+
 A sectino list will accept the standard [behavior attributes](/docs/reference_behavior_attributes). However, a section list will only trigger the `refresh` behavior (through the pull-to-refresh gesture). Other behaviors, such as presses, should be handled by the `<item>` elements in the section list.
 
 #### `style`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A space-separated list of styles to apply to the text. See [Styles](/docs/reference_style).
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.
 
 #### `hide`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.

--- a/docs/reference_sectiontitle.md
+++ b/docs/reference_sectiontitle.md
@@ -1,7 +1,7 @@
 ---
 id: reference_sectiontitle
-title: "<section-title>"
-sidebar_label: "<section-title>"
+title: <section-title>
+sidebar_label: <section-title>
 ---
 
 The `<section-title>` element represents the title of a section group within a `<sectinon-list>`. It renders as a sticky element that stays at the top of the list while the user scrolls through items in that section.
@@ -31,34 +31,40 @@ The `<section-title>` element represents the title of a section group within a `
 ```
 
 ## Structure
+
 A `<section-title>` element can only appear as a direct child of a `<section>` element.
 
 ## Attributes
-* [Behavior attributes](#behavior-attributes)
-* [`style`](#style)
-* [`id`](#id)
-* [`hide`](#hide)
+
+- [Behavior attributes](#behavior-attributes)
+- [`style`](#style)
+- [`id`](#id)
+- [`hide`](#hide)
 
 #### Behavior attributes
+
 A `<section-title>` element accepts the standard [behavior attributes](/docs/reference_behavior_attributes). However, since `<section-title>` elements can only be children of scrollable `<section-list>` elements, the pull-to-refresh gesture will never trigger on a `<section-title>`. Thus, `refresh` triggers should only be added to the parent section list element.
 
 #### `style`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A space-separated list of styles to apply to the element. See [Styles](/docs/reference_style).
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.
 
 #### `hide`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.

--- a/docs/reference_selectmultiple.md
+++ b/docs/reference_selectmultiple.md
@@ -1,7 +1,7 @@
 ---
 id: reference_selectmultiple
-title: "<select-multiple>"
-sidebar_label: "<select-multiple>"
+title: <select-multiple>
+sidebar_label: <select-multiple>
 ---
 
 The `<select-multiple>` element represents a user input widget that allows multiple selected options. `<select-multiple>` contains `<option>` elements.
@@ -27,38 +27,44 @@ The `<select-multiple>` element represents a user input widget that allows multi
 If the user presses "2nd grade", the `<option>` element with `value="2"` will get the attribute `selected="true"`, and the first option will remain as `selected="true"`. Pressing either option will change their attribute to `selected="true"`.
 
 ## Structure
+
 A `<select-multiple>` element most often appears within a `<form>` element. However, this is not a requirement, and the element can be used for local interactions that don't get serialized in a form.
 
 ## Attributes
-* [`name`](#name)
-* [`style`](#style)
-* [`id`](#id)
-* [`hide`](#hide)
+
+- [`name`](#name)
+- [`style`](#style)
+- [`id`](#id)
+- [`hide`](#hide)
 
 #### `name`
-| Type     | Required |
-| -------- | -------- |
-| string   | **Yes**  |
+
+| Type   | Required |
+| ------ | -------- |
+| string | **Yes**  |
 
 The name of the selection input within a `<form>` element. This name will be used when serializing a form to form data that gets sent in a server request.
 
 #### `style`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A space-separated list of styles to apply to the element. See [Styles](/docs/reference_style). Note that text style rules cannot be applied to a `<select-multiple>`.
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.
 
 #### `hide`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.

--- a/docs/reference_selectsingle.md
+++ b/docs/reference_selectsingle.md
@@ -1,7 +1,7 @@
 ---
 id: reference_selectsingle
-title: "<select-single>"
-sidebar_label: "<select-single>"
+title: <select-single>
+sidebar_label: <select-single>
 ---
 
 The `<select-single>` element represents a user input widget that allows one option to be selected. `<select-single>` contains `<option>` elements and ensures that only one of those options can be selected at any given time.
@@ -27,38 +27,44 @@ The `<select-single>` element represents a user input widget that allows one opt
 If the user presses "2nd grade", the `<option>` element with `value="2"` will get the attribute `selected="true"`, while the first option will get `selected="false"`.
 
 ## Structure
+
 A `<select-single>` element most often appears within a `<form>` element. However, this is not a requirement, and the element can be used for local interactions that don't get serialized in a form (for example, to implement a tab interface).
 
 ## Attributes
-* [`name`](#name)
-* [`style`](#style)
-* [`id`](#id)
-* [`hide`](#hide)
+
+- [`name`](#name)
+- [`style`](#style)
+- [`id`](#id)
+- [`hide`](#hide)
 
 #### `name`
-| Type     | Required |
-| -------- | -------- |
-| string   | **Yes**  |
+
+| Type   | Required |
+| ------ | -------- |
+| string | **Yes**  |
 
 The name of the selection input within a `<form>` element. This name will be used when serializing a form to form data that gets sent in a server request.
 
 #### `style`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A space-separated list of styles to apply to the element. See [Styles](/docs/reference_style). Note that text style rules cannot be applied to a `<select-single>`.
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.
 
 #### `hide`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.

--- a/docs/reference_spinner.md
+++ b/docs/reference_spinner.md
@@ -1,7 +1,7 @@
 ---
 id: reference_spinner
-title: "<spinner>"
-sidebar_label: "<spinner>"
+title: <spinner>
+sidebar_label: <spinner>
 ---
 
 The `<spinner>` element shows a spinner to represent loading content.
@@ -13,30 +13,35 @@ The `<spinner>` element shows a spinner to represent loading content.
 ```
 
 ## Structure
+
 A `<spinner>` element can appear anywhere within a `<screen>` element.
 
 ## Attributes
-* [`color`](#color)
-* [`id`](#id)
-* [`hide`](#hide)
+
+- [`color`](#color)
+- [`id`](#id)
+- [`hide`](#hide)
 
 #### `color`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A hexadecimal string indicating the color of the spinner.
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.
 
 #### `hide`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.

--- a/docs/reference_style.md
+++ b/docs/reference_style.md
@@ -1,7 +1,7 @@
 ---
 id: reference_style
-title: "<style>"
-sidebar_label: "<style>"
+title: <style>
+sidebar_label: <style>
 ---
 
 The `<style>` element defines specific style rules that can be used by elements of a screen.
@@ -25,89 +25,96 @@ The `<style>` element defines specific style rules that can be used by elements 
 The `<styles>` element above contains one [`<style>`](/docs/reference_style) with id "Main". The view in the body of the screen uses that style.
 
 ## Structure
+
 A `<style>` element should only appear as a direct child of a `<styles>` element or `<modifier>` element.
 
 ## Attributes
-* [`id`](#id)
-* [Layout rules](#layout-rules)
-  * [`alignContent`](#aligncontent)
-  * [`alignItems`](#alignitems)
-  * [`alignSelf`](#alignself)
-  * [`borderBottomWidth`](#borderbottomwidth)
-  * [`borderLeftWidth`](#borderleftwidth)
-  * [`borderRightWidth`](#borderrightwidth)
-  * [`borderTopWidth`](#bordertopwidth)
-  * [`borderWidth`](#borderwidth)
-  * [`bottom`](#bottom)
-  * [`display`](#display)
-  * [`flex`](#flex)
-  * [`flexBasis`](#flexbasis)
-  * [`flexDirection`](#flexdirection)
-  * [`flexGrow`](#flexgrow)
-  * [`flexShrink`](#flexshrink)
-  * [`flexWrap`](#flexwrap)
-  * [`height`](#height)
-  * [`justifyContent`](#justifycontent)
-  * [`left`](#left)
-  * [`margin`](#margin)
-  * [`marginBottom`](#marginbottom)
-  * [`marginHorizontal`](#marginhorizontal)
-  * [`marginLeft`](#marginleft)
-  * [`marginRight`](#marginright)
-  * [`marginTop`](#margintop)
-  * [`marginVertical`](#marginvertical)
-  * [`maxHeight`](#maxheight)
-  * [`maxWidth`](#maxwidth)
-  * [`minHeight`](#minheight)
-  * [`minWidth`](#minwidth)
-  * [`overflow`](#overflow)
-  * [`padding`](#padding)
-  * [`paddingBottom`](#paddingbottom)
-  * [`paddingHorizontal`](#paddinghorizontal)
-  * [`paddingLeft`](#paddingleft)
-  * [`paddingRight`](#paddingright)
-  * [`paddingTop`](#paddingtop)
-  * [`paddingVertical`](#paddingvertical)
-  * [`position`](#position)
-  * [`right`](#right)
-  * [`top`](#top)
-  * [`width`](#width)
 
-* [View & image rules](#view-image-rules)
-  * [`borderRightColor`](#borderrightcolor)
-  * [`borderBottomColor`](#borderbottomcolor)
-  * [`borderBottomLeftRadius`](#borderbottomleftradius)
-  * [`borderBottomRightRadius`](#borderbottomrightradius)
-  * [`borderColor`](#bordercolor)
-  * [`borderLeftColor`](#borderleftcolor)
-  * [`borderRadius`](#borderradius)
-  * [`backgroundColor`](#backgroundcolor)
-  * [`borderStyle`](#borderstyle)
-  * [`borderTopColor`](#bordertopcolor)
-  * [`borderTopLeftRadius`](#bordertopleftradius)
-  * [`borderTopRightRadius`](#bordertoprightradius)
-  * [`opacity`](#opacity)
+- [`id`](#id)
+- [Layout rules](#layout-rules)
 
-* [Text rules](#text-rules)
-  * [`color`](#color)
-  * [`fontSize`](#fontsize)
-  * [`fontStyle`](#fontstyle)
-  * [`fontWeight`](#fontweight)
-  * [`lineHeight`](#lineheight)
-  * [`textAlign`](#textalign)
-  * [`textShadowColor`](#textshadowcolor)
-  * [`fontFamily`](#fontfamily)
-  * [`textShadowRadius`](#textshadowradius)
+  - [`alignContent`](#aligncontent)
+  - [`alignItems`](#alignitems)
+  - [`alignSelf`](#alignself)
+  - [`borderBottomWidth`](#borderbottomwidth)
+  - [`borderLeftWidth`](#borderleftwidth)
+  - [`borderRightWidth`](#borderrightwidth)
+  - [`borderTopWidth`](#bordertopwidth)
+  - [`borderWidth`](#borderwidth)
+  - [`bottom`](#bottom)
+  - [`display`](#display)
+  - [`flex`](#flex)
+  - [`flexBasis`](#flexbasis)
+  - [`flexDirection`](#flexdirection)
+  - [`flexGrow`](#flexgrow)
+  - [`flexShrink`](#flexshrink)
+  - [`flexWrap`](#flexwrap)
+  - [`height`](#height)
+  - [`justifyContent`](#justifycontent)
+  - [`left`](#left)
+  - [`margin`](#margin)
+  - [`marginBottom`](#marginbottom)
+  - [`marginHorizontal`](#marginhorizontal)
+  - [`marginLeft`](#marginleft)
+  - [`marginRight`](#marginright)
+  - [`marginTop`](#margintop)
+  - [`marginVertical`](#marginvertical)
+  - [`maxHeight`](#maxheight)
+  - [`maxWidth`](#maxwidth)
+  - [`minHeight`](#minheight)
+  - [`minWidth`](#minwidth)
+  - [`overflow`](#overflow)
+  - [`padding`](#padding)
+  - [`paddingBottom`](#paddingbottom)
+  - [`paddingHorizontal`](#paddinghorizontal)
+  - [`paddingLeft`](#paddingleft)
+  - [`paddingRight`](#paddingright)
+  - [`paddingTop`](#paddingtop)
+  - [`paddingVertical`](#paddingvertical)
+  - [`position`](#position)
+  - [`right`](#right)
+  - [`top`](#top)
+  - [`width`](#width)
+
+- [View & image rules](#view-image-rules)
+
+  - [`borderRightColor`](#borderrightcolor)
+  - [`borderBottomColor`](#borderbottomcolor)
+  - [`borderBottomLeftRadius`](#borderbottomleftradius)
+  - [`borderBottomRightRadius`](#borderbottomrightradius)
+  - [`borderColor`](#bordercolor)
+  - [`borderLeftColor`](#borderleftcolor)
+  - [`borderRadius`](#borderradius)
+  - [`backgroundColor`](#backgroundcolor)
+  - [`borderStyle`](#borderstyle)
+  - [`borderTopColor`](#bordertopcolor)
+  - [`borderTopLeftRadius`](#bordertopleftradius)
+  - [`borderTopRightRadius`](#bordertoprightradius)
+  - [`opacity`](#opacity)
+
+- [Text rules](#text-rules)
+  - [`color`](#color)
+  - [`fontSize`](#fontsize)
+  - [`fontStyle`](#fontstyle)
+  - [`fontWeight`](#fontweight)
+  - [`lineHeight`](#lineheight)
+  - [`textAlign`](#textalign)
+  - [`textShadowColor`](#textshadowcolor)
+  - [`fontFamily`](#fontfamily)
+  - [`textShadowRadius`](#textshadowradius)
 
 ### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document. This id is used by elements in the `<screen>` to apply styles.
+
 > `id` is required when `<style>` is a direct child of a `<styles>` element. `id` will be ignored if the `<style>` is a direct child of a `<modifier>` element.
 
 ### Layout rules
+
 `<style>` attributes support the following [layout props](https://facebook.github.io/react-native/docs/layout-props) from React Native.
 
 > Layout rules can only be applied to most elements with a few exceptions (such as `<spinner>`).
@@ -116,24 +123,24 @@ A global attribute uniquely identifying the element in the whole document. This 
 
 `alignContent` controls how rows align in the cross direction, overriding the `alignContent` of the parent. See https://developer.mozilla.org/en-US/docs/Web/CSS/align-content for more details.
 
-| Type                                                                                 | Required |
-| ------------------------------------------------------------------------------------ | -------- |
+| Type                                                                           | Required |
+| ------------------------------------------------------------------------------ | -------- |
 | 'flex-start', 'flex-end', 'center', 'stretch', 'space-between', 'space-around' | No       |
 
 #### `alignItems`
 
 `alignItems` aligns children in the cross direction. For example, if children are flowing vertically, `alignItems` controls how they align horizontally. It works like `align-items` in CSS (default: stretch). See https://developer.mozilla.org/en-US/docs/Web/CSS/align-items for more details.
 
-| Type                                                            | Required |
-| --------------------------------------------------------------- | -------- |
+| Type                                                      | Required |
+| --------------------------------------------------------- | -------- |
 | 'flex-start', 'flex-end', 'center', 'stretch', 'baseline' | No       |
 
 #### `alignSelf`
 
 `alignSelf` controls how a child aligns in the cross direction, overriding the `alignItems` of the parent. It works like `align-self` in CSS (default: auto). See https://developer.mozilla.org/en-US/docs/Web/CSS/align-self for more details.
 
-| Type                                                                    | Required |
-| ----------------------------------------------------------------------- | -------- |
+| Type                                                              | Required |
+| ----------------------------------------------------------------- | -------- |
 | 'auto', 'flex-start', 'flex-end', 'center', 'stretch', 'baseline' | No       |
 
 #### `borderBottomWidth`
@@ -194,8 +201,8 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/bottom for more details of 
 
 It works similarly to `display` in CSS, but only support 'flex' and 'none'. 'flex' is the default.
 
-| Type                 | Required |
-| -------------------- | -------- |
+| Type           | Required |
+| -------------- | -------- |
 | 'none', 'flex' | No       |
 
 #### `flex`
@@ -214,16 +221,16 @@ flexGrow, flexShrink, and flexBasis work the same as in CSS.
 
 #### `flexBasis`
 
-| Type           | Required |
-| -------------- | -------- |
-| number         | No       |
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
 
 #### `flexDirection`
 
 `flexDirection` controls which directions children of a container go. `row` goes left to right, `column` goes top to bottom, and you may be able to guess what the other two do. It works like `flex-direction` in CSS, except the default is `column`. See https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction for more details.
 
-| Type                                                   | Required |
-| ------------------------------------------------------ | -------- |
+| Type                                             | Required |
+| ------------------------------------------------ | -------- |
 | 'row', 'row-reverse', 'column', 'column-reverse' | No       |
 
 #### `flexGrow`
@@ -242,8 +249,8 @@ flexGrow, flexShrink, and flexBasis work the same as in CSS.
 
 `flexWrap` controls whether children can wrap around after they hit the end of a flex container. It works like `flex-wrap` in CSS (default: nowrap). See https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap for more details. Note it does not work anymore with `alignItems: stretch` (the default), so you may want to use `alignItems: flex-start` for example.
 
-| Type                   | Required |
-| ---------------------- | -------- |
+| Type             | Required |
+| ---------------- | -------- |
 | 'wrap', 'nowrap' | No       |
 
 #### `height`
@@ -260,8 +267,8 @@ It works similarly to `height` in CSS, but in Hyperview you must use points or p
 
 `justifyContent` aligns children in the main direction. For example, if children are flowing vertically, `justifyContent` controls how they align vertically. It works like `justify-content` in CSS (default: flex-start). See https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content for more details.
 
-| Type                                                                                      | Required |
-| ----------------------------------------------------------------------------------------- | -------- |
+| Type                                                                                | Required |
+| ----------------------------------------------------------------------------------- | -------- |
 | 'flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'space-evenly' | No       |
 
 #### `left`
@@ -384,8 +391,8 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/min-width for more details.
 
 `overflow` controls how children are measured and displayed. `overflow: hidden` causes views to be clipped while `overflow: scroll` causes views to be measured independently of their parents main axis. It works like `overflow` in CSS (default: visible). See https://developer.mozilla.org/en/docs/Web/CSS/overflow for more details. `overflow: visible` only works on iOS. On Android, all views will clip their children.
 
-| Type                                | Required |
-| ----------------------------------- | -------- |
+| Type                          | Required |
+| ----------------------------- | -------- |
 | 'visible', 'hidden', 'scroll' | No       |
 
 #### `padding`
@@ -432,8 +439,8 @@ Setting `paddingHorizontal` is like setting both of `paddingLeft` and `paddingRi
 
 `paddingTop` works like `padding-top` in CSS. See https://developer.mozilla.org/en-US/docs/Web/CSS/padding-top for more details.
 
-| Type            | Required |
-| --------------- | -------- |
+| Type           | Required |
+| -------------- | -------- |
 | number, string | No       |
 
 #### `paddingVertical`
@@ -452,8 +459,8 @@ If you want to position a child using specific numbers of logical pixels relativ
 
 If you want to position a child relative to something that is not its parent, just don't use styles for that. Use the component tree.
 
-| Type                         | Required |
-| ---------------------------- | -------- |
+| Type                   | Required |
+| ---------------------- | -------- |
 | 'absolute', 'relative' | No       |
 
 #### `right`
@@ -491,20 +498,21 @@ It works similarly to `width` in CSS, but in Hyperview you must use points or pe
 | number, string | No       |
 
 ### View & image rules
+
 `<style>` elements support the following attributes for `<view>` and `<image>` as defined in [React Native](https://facebook.github.io/react-native/docs/view-style-props).
 
 > View rules will only be applied to `<view>` and `<image>` elements. Adding these rules to other elements will cause a warning in the client.
 
 #### `borderRightColor`
 
-| Type               | Required |
-| ------------------ | -------- |
+| Type  | Required |
+| ----- | -------- |
 | color | No       |
 
 #### `borderBottomColor`
 
-| Type               | Required |
-| ------------------ | -------- |
+| Type  | Required |
+| ----- | -------- |
 | color | No       |
 
 #### `borderBottomLeftRadius`
@@ -521,14 +529,14 @@ It works similarly to `width` in CSS, but in Hyperview you must use points or pe
 
 #### `borderColor`
 
-| Type               | Required |
-| ------------------ | -------- |
+| Type  | Required |
+| ----- | -------- |
 | color | No       |
 
 #### `borderLeftColor`
 
-| Type               | Required |
-| ------------------ | -------- |
+| Type  | Required |
+| ----- | -------- |
 | color | No       |
 
 #### `borderRadius`
@@ -539,20 +547,20 @@ It works similarly to `width` in CSS, but in Hyperview you must use points or pe
 
 #### `backgroundColor`
 
-| Type               | Required |
-| ------------------ | -------- |
+| Type  | Required |
+| ----- | -------- |
 | color | No       |
 
 #### `borderStyle`
 
-| Type                              | Required |
-| --------------------------------- | -------- |
+| Type                        | Required |
+| --------------------------- | -------- |
 | 'solid', 'dotted', 'dashed' | No       |
 
 #### `borderTopColor`
 
-| Type               | Required |
-| ------------------ | -------- |
+| Type  | Required |
+| ----- | -------- |
 | color | No       |
 
 #### `borderTopLeftRadius`
@@ -573,17 +581,17 @@ It works similarly to `width` in CSS, but in Hyperview you must use points or pe
 | ------ | -------- |
 | number | No       |
 
-
 ### Text rules
+
 `<style>` elements support the following attributes for `<text>` as defined in [React Native](https://facebook.github.io/react-native/docs/text-style-props).
 
 > Text rules will only be applied to `<text>` elements. Adding these rules to other elements will cause a warning in the client.
 
 #### `color`
 
-| Type               | Required |
-| ------------------ | -------- |
-| color              | No       |
+| Type  | Required |
+| ----- | -------- |
+| color | No       |
 
 #### `fontSize`
 
@@ -593,15 +601,16 @@ It works similarly to `width` in CSS, but in Hyperview you must use points or pe
 
 #### `fontStyle`
 
-| Type                     | Required |
-| ------------------------ | -------- |
+| Type               | Required |
+| ------------------ | -------- |
 | 'normal', 'italic' | No       |
 
 #### `fontWeight`
+
 fromSpecifies font weight. The values 'normal' and 'bold' are supported for most fonts. Not all fonts have a variant for each of the numeric values, in that case the closest one is chosen.
 
-| Type                                                                                  | Required |
-| ------------------------------------------------------------------------------------- | -------- |
+| Type                                                                            | Required |
+| ------------------------------------------------------------------------------- | -------- |
 | 'normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900' | No       |
 
 #### `lineHeight`
@@ -614,15 +623,15 @@ fromSpecifies font weight. The values 'normal' and 'bold' are supported for most
 
 Specifies text alignment. The value 'justify' is only supported on iOS and fallbacks to `left` on Android.
 
-| Type                                               | Required |
-| -------------------------------------------------- | -------- |
+| Type                                         | Required |
+| -------------------------------------------- | -------- |
 | 'auto', 'left', 'right', 'center', 'justify' | No       |
 
 #### `textShadowColor`
 
-| Type               | Required |
-| ------------------ | -------- |
-|  color             | No       |
+| Type  | Required |
+| ----- | -------- |
+| color | No       |
 
 #### `fontFamily`
 

--- a/docs/reference_styles.md
+++ b/docs/reference_styles.md
@@ -1,7 +1,7 @@
 ---
 id: reference_styles
-title: "<styles>"
-sidebar_label: "<styles>"
+title: <styles>
+sidebar_label: <styles>
 ---
 
 The `<styles>` element contains elements defining the visual appearance of elements in a screen.
@@ -25,7 +25,9 @@ The `<styles>` element contains elements defining the visual appearance of eleme
 The `<styles>` element above contains one [`<style>`](/docs/reference_style) with id "Main". The view in the body of the screen uses that style.
 
 ## Structure
+
 A `<styles>` element should only appear as a direct child of a `<screen>` element. There should be only one `<styles>` child element per screen.
 
 ## Attributes
+
 The `<styles>` element accepts no attributes, since its purpose is to group [`<style>`](/docs/reference_style) elements.

--- a/docs/reference_text.md
+++ b/docs/reference_text.md
@@ -1,12 +1,13 @@
 ---
 id: reference_text
-title: "<text>"
-sidebar_label: "<text>"
+title: <text>
+sidebar_label: <text>
 ---
 
 The `<text>` element is a basic building block to show text content in the UI layout. Text elements can by styled typographically with style rules.
 
 Some examples of styles applied to text (including nested text):
+
 ```xml
 <screen>
   <styles>
@@ -34,8 +35,8 @@ Some examples of styles applied to text (including nested text):
   <body scroll="true">
     <text style="Basic">Hello, world!</text>
 
-    <text style="Basic">Hello, 
-      <text style="Bold">World of 
+    <text style="Basic">Hello,
+      <text style="Bold">World of
         <text style="Color">HyperView!</text>
       </text>
     </text>
@@ -45,42 +46,49 @@ Some examples of styles applied to text (including nested text):
 ```
 
 ## Structure
+
 A `<view>` element can only appear anywhere within a `<screen>` element.
 
 ## Attributes
-* [Behavior attributes](#behavior-attributes)
-* [`style`](#style)
-* [`numberOfLines`](#numberoflines)
-* [`id`](#id)
-* [`hide`](#hide)
+
+- [Behavior attributes](#behavior-attributes)
+- [`style`](#style)
+- [`numberOfLines`](#numberoflines)
+- [`id`](#id)
+- [`hide`](#hide)
 
 #### Behavior attributes
+
 A `<view>` element accepts the standard [behavior attributes](/docs/reference_behavior_attributes), including all triggers (press, refresh, visible, etc).
 
 #### `style`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A space-separated list of styles to apply to the element. See [Styles](/docs/reference_style). Note that text style rules will cannot be applied to a `<view>`.
 
 #### `numberOfLines`
-| Type     | Required |
-| -------- | -------- |
-| integer  | No       |
+
+| Type    | Required |
+| ------- | -------- |
+| integer | No       |
 
 An integer representing the number of lines of text to display before the text content truncates. The width of the element is determined by the applied styles and the dimensions of the device screen.
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.
 
 #### `hide`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.

--- a/docs/reference_textarea.md
+++ b/docs/reference_textarea.md
@@ -1,7 +1,7 @@
 ---
 id: reference_textarea
-title: "<text-area>"
-sidebar_label: "<text-area>"
+title: <text-area>
+sidebar_label: <text-area>
 ---
 
 The `<text-area>` .
@@ -16,56 +16,64 @@ The `<text-area>` .
 ```
 
 ## Structure
+
 A `<text-area>` element can appear anywhere within a `<form>` element.
 
 ## Attributes
-* [`name`](#name)
-* [`value`](#value)
-* [`placeholder`](#placeholder)
-* [`style`](#style)
-* [`id`](#id)
-* [`hide`](#hide)
+
+- [`name`](#name)
+- [`value`](#value)
+- [`placeholder`](#placeholder)
+- [`style`](#style)
+- [`id`](#id)
+- [`hide`](#hide)
 
 #### `name`
-| Type     | Required |
-| -------- | -------- |
-| string   | **Yes**  |
+
+| Type   | Required |
+| ------ | -------- |
+| string | **Yes**  |
 
 The name of the text area within a `<form>` element. This name will be used when serializing a form to form data that gets sent in a server request.
 
 #### `value`
-| Type     | Required |
-| -------- | -------- |
-| string   | No (defaults to blank) |
+
+| Type   | Required               |
+| ------ | ---------------------- |
+| string | No (defaults to blank) |
 
 The value of the text area. This string gets rendered into the string and can be edited by the user. Set this value in the XML to pre-populate the text area.
 
 #### `placeholder`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A label that appears within the text area. The placeholder only appears when the text area is empty.
 
 #### `style`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A space-separated list of styles to apply to the element. See [Styles](/docs/reference_style). Note that text style rules cannot be applied to an `<text-area>`.
 
 `<text-field>` supports the `focused` style modifier. See [Modifiers](/docs/reference_modifier) for more details.
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.
 
 #### `hide`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.

--- a/docs/reference_textfield.md
+++ b/docs/reference_textfield.md
@@ -1,7 +1,7 @@
 ---
 id: reference_textfield
-title: "<text-field>"
-sidebar_label: "<text-field>"
+title: <text-field>
+sidebar_label: <text-field>
 ---
 
 The `<text-field>` element represents a single-line input field. When pressed, the field focuses and a keyboard appears to accept user input. The value entered into the `<text-field>` get serialized as form data when a `<form>` gets submitted.
@@ -23,45 +23,52 @@ The `<text-field>` element represents a single-line input field. When pressed, t
 ```
 
 ## Structure
+
 A `<text-field>` element can appear anywhere within a `<form>` element.
 
 ## Attributes
-* [`name`](#name)
-* [`value`](#value)
-* [`placeholder`](#placeholder)
-* [`keyboard-type`](#keyboard-type)
-* [`mask`](#mask)
-* [`style`](#style)
-* [`id`](#id)
-* [`hide`](#hide)
+
+- [`name`](#name)
+- [`value`](#value)
+- [`placeholder`](#placeholder)
+- [`keyboard-type`](#keyboard-type)
+- [`mask`](#mask)
+- [`style`](#style)
+- [`id`](#id)
+- [`hide`](#hide)
 
 #### `name`
-| Type     | Required |
-| -------- | -------- |
-| string   | **Yes**  |
+
+| Type   | Required |
+| ------ | -------- |
+| string | **Yes**  |
 
 The name of the field within a `<form>` element. This name will be used when serializing a form to form data that gets sent in a server request.
 
 #### `value`
-| Type     | Required |
-| -------- | -------- |
-| string   | No (defaults to blank) |
+
+| Type   | Required               |
+| ------ | ---------------------- |
+| string | No (defaults to blank) |
 
 The value of the field. This string gets rendered into the string and can be edited by the user. Set this value in the XML to pre-populate the text field.
 
 #### `placeholder`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A label that appears within the text field. The placeholder only appears when the field is empty.
 
 #### `keyboard-type`
-| Type     | Required |
-| -------- | -------- |
-| string   | No (defaults to **default**) |
+
+| Type   | Required                     |
+| ------ | ---------------------------- |
+| string | No (defaults to **default**) |
 
 Sets the type of keybaord to show when the user focuses the input. Supported options:
+
 - **default**: Standard alpha-numeric keyboard
 - **number-pad**: Keyboard restricted to 0-9 digits plus decimals
 - **decimal-pad**: Keyboard restricted to 0-9 digits with no decimals
@@ -69,41 +76,48 @@ Sets the type of keybaord to show when the user focuses the input. Supported opt
 - **email-address**: Keyboard adapted for easier email address input (handy @ symbol)
 
 #### `mask`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A mask string that formats the user's input. If specificed, on every keystroke the input will be formatted using the mask, which may add characters to the field or prevent the pressed key from being set. Mask format:
+
 - **9**: Accept numbers
 - **A**: Accept alpha
 - **S**: Accept alphanumerics
 - **\***: Accept all
 
 All other characters will automatically appear in the mask when the format is satisfied. For example:
+
 ```xml
 <text-field name="phone" mask="(999) 999-9999" />
 ```
+
 If the user types a `4`, the field will show `(4`. If the user tries to type the letter `A`, the field will still show `(4`.
 
 #### `style`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A space-separated list of styles to apply to the element. See [Styles](/docs/reference_style). Note that text style rules cannot be applied to an `<text-field>`.
 
 `<text-field>` supports the `focused` style modifier. See [Modifiers](/docs/reference_modifier) for more details.
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.
 
 #### `hide`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.

--- a/docs/reference_view.md
+++ b/docs/reference_view.md
@@ -1,12 +1,13 @@
 ---
 id: reference_view
-title: "<view>"
-sidebar_label: "<view>"
+title: <view>
+sidebar_label: <view>
 ---
 
 The `<view>` element is a basic building block for UI layouts. Using flexbox styling, nested views can create sophisticated components that can scale and adapt to different screen sizes. Views can also serve as a viewport onto scrolling content.
 
 Some examples of views:
+
 ```xml
 <body>
   <view style="FlexHorizontal">
@@ -39,50 +40,58 @@ Some examples of views:
 ```
 
 ## Structure
+
 A `<view>` element can only appear anywhere within a `<screen>` element.
 
 ## Attributes
-* [Behavior attributes](#behavior-attributes)
-* [`style`](#style)
-* [`scroll`](#scroll)
-* [`scroll-orientation`](#scroll-orientation)
-* [`id`](#id)
-* [`hide`](#hide)
+
+- [Behavior attributes](#behavior-attributes)
+- [`style`](#style)
+- [`scroll`](#scroll)
+- [`scroll-orientation`](#scroll-orientation)
+- [`id`](#id)
+- [`hide`](#hide)
 
 #### Behavior attributes
+
 A `<view>` element accepts the standard [behavior attributes](/docs/reference_behavior_attributes), including all triggers (press, refresh, visible, etc).
 
 #### `style`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A space-separated list of styles to apply to the element. See [Styles](/docs/reference_style). Note that text style rules cannot be applied to a `<view>`.
 
 #### `scroll`
-| Type     | Required |
-| -------- | -------- |
-| true, **false** (default)  | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| true, **false** (default) | No       |
 
 An attribute indicating whether the content in the can be scrollable. The style rules of the view will determine the viewport size.
 
 #### `scroll-orientation`
-| Type     | Required |
-| -------- | -------- |
-| **vertical** (default), horizontal  | No       |
+
+| Type                               | Required |
+| ---------------------------------- | -------- |
+| **vertical** (default), horizontal | No       |
 
 An attribute indicating the direction in which the view will scroll.
 
 #### `id`
-| Type     | Required |
-| -------- | -------- |
-| string   | No       |
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 A global attribute uniquely identifying the element in the whole document.
 
 #### `hide`
-| Type     | Required |
-| -------- | -------- |
-| **false** (default), true   | No       |
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.


### PR DESCRIPTION
- Remove double quotes for title and label, this was conflicting with prettier
- Run prettier to fix formatting in Markdown files