### PR TITLE
Fix link to reference_behavior_attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ website/i18n/*
 .yalc
 .yalcignore
 demo/yalc.lock
+
+.idea/

--- a/docs/reference_behavior.md
+++ b/docs/reference_behavior.md
@@ -45,4 +45,4 @@ A `<behavior>` element defines a behavior that applies to its direct parent elem
 
 #### Behavior attributes
 
-A `<behavior>` element accepts the standard [behavior attributes](behaviors). The supported triggers depend on the parent element.
+A `<behavior>` element accepts the standard [behavior attributes](/docs/reference_behavior_attributes). The supported triggers depend on the parent element.


### PR DESCRIPTION
The "behavior attributes" link was broken at https://hyperview.org/docs/reference_behavior#behavior-attributes
This PR fixes it.