### PR TITLE
Add alert stubs for custom behavior in demo app

### DIFF
--- a/demo/screens/HyperviewScreen.js
+++ b/demo/screens/HyperviewScreen.js
@@ -7,6 +7,7 @@
  */
 
 import React, { PureComponent } from 'react';
+import { Alert } from 'react-native';
 import Hyperview from 'hyperview';
 
 export default class HyperviewScreen extends React.PureComponent {
@@ -62,6 +63,18 @@ export default class HyperviewScreen extends React.PureComponent {
     });
   }
 
+  callPhone = (phoneNumber: string) => {
+    Alert.alert('On a real app, this would call ' + phoneNumber);
+  }
+
+  askRating = () => {
+    Alert.alert('On a real app, this would ask for app store rating');
+  }
+
+  sendSms = (phoneNumber: string) => {
+    Alert.alert('On a real app, this would send an SMS to ' + phoneNumber);
+  }
+
   render() {
     const navigation = this.props.navigation;
     const entrypointUrl = navigation.state.params.url;
@@ -74,6 +87,9 @@ export default class HyperviewScreen extends React.PureComponent {
         fetch={this.fetchWrapper}
         navigate={this.navigate}
         navigation={navigation}
+        onAskRating={this.askRating}
+        onCall={this.callPhone}
+        onSms={this.sendSms}
         openModal={this.openModal}
         push={this.push}
         replace={navigation.replace}


### PR DESCRIPTION
Makes the demo app display an alert when the phone/rating/sms actions are triggered. This helps us make sure that these behaviors are properly triggered.

| Ask rating | Phone | SMS |
| - | - | - |
| <img width="372" alt="screen shot 2019-03-05 at 4 32 05 pm" src="https://user-images.githubusercontent.com/15131271/53847089-4a756d80-3f64-11e9-949e-9a182302693b.png"> | <img width="372" alt="screen shot 2019-03-05 at 4 31 58 pm" src="https://user-images.githubusercontent.com/15131271/53847092-4c3f3100-3f64-11e9-9016-af8f6260b1b3.png"> | <img width="374" alt="screen shot 2019-03-05 at 4 32 15 pm" src="https://user-images.githubusercontent.com/15131271/53847093-4d705e00-3f64-11e9-9c96-a9a7981d7cb8.png"> |

**Test plan**

- [x] Try running phone, rating, and sms examples