### PR TITLE
Infra: improve build:demo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It also contains a demo Expo project that can connect to the example XML server,
 
 From the repo root directory:
 
-```
+```sh
 yarn
 yarn test:xmlserver
 ```
@@ -55,28 +55,18 @@ This will start an HTTP server listening on port 8085.
 
 In a separate shell, install the demo dependencies and start the development server. From the repo root directory:
 
-```
+```sh
 cd demo
 yarn
 ```
 
 The next step depends on whether you want to run the demo app in the iOS simulator, on an Android Virtual Device, or on a physical mobile device.
 
-While developing hyperview features using the demo app you may also run hyperview builds in watch mode. This will directly reflect the changes in the `demo/` app as you make changes to hyperview `src`. From the project root run:
-
-```sh
-yarn build:demo
-```
-
-> **Tip**
->
-> You may stop this with <kbd>Ctrl</kbd> + <kbd>C</kbd>
-
 ##### Running on the iOS simulator
 
 From the `demo/` directory:
 
-```
+```sh
 yarn ios
 ```
 
@@ -86,7 +76,7 @@ This will open the iOS simulator and install the demo app in the simulator. It w
 
 From the `demo/` directory:
 
-```
+```sh
 adb reverse tcp:8085 tcp:8085
 yarn android
 ```
@@ -106,7 +96,7 @@ Open [/demo/navigation/AppNavigator.js](/demo/navigation/AppNavigator.js) in a t
 
 From the `demo/` directory on your development machine:
 
-```
+```sh
 yarn start
 ```
 
@@ -114,6 +104,20 @@ This command will start an Expo development server and open a webpage (http://lo
 
 - On your iOS device, open the Camera app and point it at the QR code on your screen. The Camera app should show an "Open in Expo" notification. Tap this notification.
 - On your Android device, use the Expo app to scan the QR code on your screen.
+
+#### Developing hyperview core features
+
+As you're developing new features for hyperview core, you can use the demo app along with this special command to help you quickly test your changes:
+
+```sh
+yarn build:demo
+```
+
+This command will update the installed hyperview package to use the untransformed code (so that it can easily be debugged), watch any changes made to `src/` and copy them into `demo/node_modules/hyperview/src`.
+
+> **Tip**
+>
+> You may stop this with <kbd>Ctrl</kbd> + <kbd>C</kbd>
 
 #### 3. You're all set!
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -14,7 +14,7 @@
     "@expo/samples": "2.1.1",
     "expo": "^31.0.2",
     "expo-cli": "^2.11.6",
-    "hyperview": "file:../",
+    "hyperview": "*",
     "react": "16.5.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-31.0.0.tar.gz",
     "react-native-keyboard-aware-scrollview": "^2.0.0",

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -3873,8 +3873,10 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-"hyperview@file:..":
-  version "0.9.0"
+hyperview@*:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/hyperview/-/hyperview-0.10.0.tgz#8906e3331edd4fc65babfe10e759ee059a32e600"
+  integrity sha512-gi7vrGfU8VLh6PiBVt2d613sl51R+2aN/BM2i0oh339oT6jSbhIaETlfA8MwKp/ptjuYMhAQEwnmd0nlzAxczQ==
   dependencies:
     url-parse "1.4.3"
     xmldom "0.1.27"

--- a/scripts/build-demo/index.js
+++ b/scripts/build-demo/index.js
@@ -2,26 +2,26 @@
 
 const childProcess = require('child_process');
 const chokidar = require('chokidar');
-const path = require('path');
+const pathModule = require('path');
 
-const PROJECT_DIR = path.join(__dirname, '../..');
-const SRC_DIR = path.join(PROJECT_DIR, 'src');
-const HYPERVIEW_DIR = path.join(PROJECT_DIR, 'demo/node_modules/hyperview');
+const PROJECT_DIR = pathModule.join(__dirname, '../..');
+const SRC_DIR = pathModule.join(PROJECT_DIR, 'src');
+const HYPERVIEW_DIR = pathModule.join(
+  PROJECT_DIR,
+  'demo/node_modules/hyperview',
+);
 
 const updatePackageJson = () => {
-  console.log('Updating package.json...');
+  console.log('Updating package.json…');
   const cmd = `sed -i.bak 's/lib\\/index.js/src\\/index.js/g' ${HYPERVIEW_DIR}/package.json`;
   childProcess.execSync(cmd);
-  console.log('Done!');
 };
 
-const syncFiles = () => {
-  console.log('Syncing files...');
-  const cmd = `rsync -v -r --delete ${SRC_DIR} ${HYPERVIEW_DIR}`;
+const syncFiles = (event, path = SRC_DIR) => {
+  console.log(`Syncing ${path}…`);
+  const cmd = `rsync -v -r --delete ${path} ${HYPERVIEW_DIR}`;
   childProcess.execSync(cmd);
-  console.log('Done!');
 };
 
 updatePackageJson();
-syncFiles();
 chokidar.watch(SRC_DIR).on('all', syncFiles);


### PR DESCRIPTION
- Demo app: revert back to using the latest version of hyperview on NPM (prevents running into `@providesModule naming collision` issue)
- `build:demo` command: Simplify output, remove unecessary initial sync (already handled by chokidar watcher)
- Improve README for clarity

https://app.asana.com/0/923014529014430/1114001676407597/f