### PR TITLE
Tools: `yarn build:demo` -> `yarn sync [path]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,16 @@ This command will start an Expo development server and open a webpage (http://lo
 As you're developing new features for hyperview core, you can use the demo app along with this special command to help you quickly test your changes:
 
 ```sh
-yarn build:demo
+yarn sync
 ```
 
 This command will update the installed hyperview package to use the untransformed code (so that it can easily be debugged), watch any changes made to `src/` and copy them into `demo/node_modules/hyperview/src`.
+
+You can also pass as an additional argument the root path of your own react-native app where you've installed hyperview to perform the same sync/watch operation. e.g.
+
+```sh
+yarn sync ../projects/my-cool-app
+```
 
 > **Tip**
 >

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "babel src --out-dir lib",
-    "build:demo": "babel-node ./scripts/build-demo",
+    "sync": "babel-node ./scripts/sync",
     "generate": "babel-node ./scripts/generate",
     "preversion": "yarn test && yarn build",
     "prettify": "pretty-quick",

--- a/scripts/sync/index.js
+++ b/scripts/sync/index.js
@@ -6,9 +6,11 @@ const pathModule = require('path');
 
 const PROJECT_DIR = pathModule.join(__dirname, '../..');
 const SRC_DIR = pathModule.join(PROJECT_DIR, 'src');
+const DEST_PROJECT_REL_PATH = process.argv[2] || './demo';
 const HYPERVIEW_DIR = pathModule.join(
   PROJECT_DIR,
-  'demo/node_modules/hyperview',
+  DEST_PROJECT_REL_PATH,
+  '/node_modules/hyperview',
 );
 
 const updatePackageJson = () => {
@@ -18,7 +20,7 @@ const updatePackageJson = () => {
 };
 
 const syncFiles = (event, path = SRC_DIR) => {
-  console.log(`Syncing ${path}…`);
+  console.log(`Syncing ${path} with ${HYPERVIEW_DIR}…`);
   const cmd = `rsync -v -r --delete ${path} ${HYPERVIEW_DIR}`;
   childProcess.execSync(cmd);
 };


### PR DESCRIPTION
Rename `build-demo` script to `sync`, and add ability to specify the path where to perform sync.