### PR TITLE
Fix: Handle `href` starting with `#` correctly on Android

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -656,7 +656,7 @@ export default class HyperScreen extends React.Component {
    */
   fetchElement = (href, verb, root, formData) => {
     verb = verb || 'GET';
-    if (href.startsWith('#')) {
+    if (href[0] === '#') {
       return new Promise((resolve, reject) => {
         const element = root.getElementById(href.slice(1));
         if (element) {


### PR DESCRIPTION
Replace `startsWith` string function call (unsupported on some Android versions) with simple "char at index 0" comparison.

https://app.asana.com/0/244065166232575/1116714831280745/f