### PR TITLE
Fix: Share behavior

### DIFF
--- a/src/behaviors/hv-share/index.js
+++ b/src/behaviors/hv-share/index.js
@@ -19,15 +19,14 @@ const getContent = (
   url: ?DOMString,
 ): ?Content => {
   if (message) {
-    if (title) {
+    if (title && url) {
+      return { message, title, url };
+    } else if (title) {
       return { message, title };
+    } else if (url) {
+      return { message, url };
     }
     return { message };
-  } else if (url) {
-    if (title) {
-      return { url, title };
-    }
-    return { url };
   }
   return null;
 };

--- a/src/behaviors/hv-share/types.js
+++ b/src/behaviors/hv-share/types.js
@@ -8,12 +8,13 @@
  *
  */
 
+export type Content = {
+  message: string,
+  title?: string,
+  url?: string,
+};
+
 // copied from react-native/Share/Share.js
-
-export type Content =
-  | { title?: string, message: string }
-  | { title?: string, url: string };
-
 export type Options = {
   dialogTitle?: string,
   excludedActivityTypes?: Array<string>,


### PR DESCRIPTION
Allow both title and url to be optional - but leave message as non-optional. It appears that [the flow type definition](https://github.com/facebook/react-native/blob/67e7f16944530aa0d1a4d375b0de5efd5c432865/Libraries/Share/Share.js#L20-L22) for RN `Share.share` is incorrect, as the backing [objective-c class is trying to read both `message` and `url` keys](https://github.com/facebook/react-native/blob/67e7f16944530aa0d1a4d375b0de5efd5c432865/Libraries/ActionSheetIOS/RCTActionSheetManager.m#L128-L132) of the `content` object.

Fixes https://app.asana.com/0/244065166232575/1116739059560742/f