### PR TITLE
More warnings when parsing fails

### DIFF
--- a/src/services/render/index.js
+++ b/src/services/render/index.js
@@ -65,11 +65,16 @@ export const renderElement = (
     }
   }
 
-  if (
-    element.nodeType === NODE_TYPE.ELEMENT_NODE &&
-    element.namespaceURI &&
-    element.localName
-  ) {
+  if (element.nodeType === NODE_TYPE.ELEMENT_NODE) {
+    if (!element.namespaceURI) {
+      console.warn('`namespaceURI` missing for node:', element.toString());
+      return null;
+    }
+    if (!element.localName) {
+      console.warn('`localName` missing for node:', element.toString());
+      return null;
+    }
+
     if (
       options.componentRegistry &&
       options.componentRegistry[element.namespaceURI] &&


### PR DESCRIPTION
Add warnings when trying to render an element that is either missing its `namespaceURI` or `localName` props.

Relates to https://github.com/Instawork/instawork/pull/5433