### PR TITLE
Make navigation prop optional

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -437,15 +437,15 @@ export default class HyperScreen extends React.Component {
     });
   }
 
-  getNavigationState = () => {
-    if (this.props.navigation) {
-      return this.props.navigation.state;
+  getNavigationState = (props) => {
+    if (props.navigation) {
+      return props.navigation.state;
     }
     return { params: {} };
   }
 
   componentDidMount() {
-    const { params } = this.getNavigationState();
+    const { params } = this.getNavigationState(this.props);
     // The screen may be rendering via a navigation from another HyperScreen.
     // In this case, the url to load in the screen will be passed via navigation props.
     // Otherwise, use the entrypoint URL provided as a prop to the first HyperScreen.
@@ -478,11 +478,13 @@ export default class HyperScreen extends React.Component {
    * preload screen and URL to load.
    */
   componentWillReceiveProps(nextProps) {
-    const { params } = this.getNavigationState();
-    const newUrl = params.url;
-    const oldUrl = params.url;
-    const newPreloadScreen = params.preloadScreen;
-    const oldPreloadScreen = params.preloadScreen;
+    const oldNavigationState = this.getNavigationState(this.props);
+    const newNavigationState = this.getNavigationState(nextProps);
+
+    const newUrl = newNavigationState.params.url;
+    const oldUrl = oldNavigationState.params.url;
+    const newPreloadScreen = newNavigationState.params.preloadScreen;
+    const oldPreloadScreen = oldNavigationState.params.preloadScreen;
 
     if (newPreloadScreen !== oldPreloadScreen) {
       delete PRELOAD_SCREEN[oldPreloadScreen];
@@ -509,7 +511,7 @@ export default class HyperScreen extends React.Component {
    * Clear out the preload screen associated with this screen.
    */
   componentWillUnmount() {
-    const { params } = this.getNavigationState();
+    const { params } = this.getNavigationState(this.props);
     const { preloadScreen } = params;
     if (preloadScreen && PRELOAD_SCREEN[preloadScreen]) {
       delete PRELOAD_SCREEN[preloadScreen];
@@ -530,7 +532,7 @@ export default class HyperScreen extends React.Component {
    * Performs a full load of the screen.
    */
   load = () => {
-    const { params, key: routeKey } = this.getNavigationState();
+    const { params, key: routeKey } = this.getNavigationState(this.props);
     const { delay } = params;
     const url = this.state.url;
 

--- a/src/index.js
+++ b/src/index.js
@@ -437,14 +437,22 @@ export default class HyperScreen extends React.Component {
     });
   }
 
+  getNavigationState = () => {
+    if (this.props.navigation) {
+      return this.props.navigation.state;
+    }
+    return { params: {} };
+  }
+
   componentDidMount() {
+    const { params } = this.getNavigationState();
     // The screen may be rendering via a navigation from another HyperScreen.
     // In this case, the url to load in the screen will be passed via navigation props.
     // Otherwise, use the entrypoint URL provided as a prop to the first HyperScreen.
-    const url = this.props.navigation.state.params.url || this.props.entrypointUrl || null;
+    const url = params.url || this.props.entrypointUrl || null;
 
-    const preloadScreen = this.props.navigation.state.params.preloadScreen
-      ? PRELOAD_SCREEN[this.props.navigation.state.params.preloadScreen]
+    const preloadScreen = params.preloadScreen
+      ? PRELOAD_SCREEN[params.preloadScreen]
       : null;
     const preloadStyles = preloadScreen ? Stylesheets.createStylesheets(preloadScreen) : {};
 
@@ -470,10 +478,11 @@ export default class HyperScreen extends React.Component {
    * preload screen and URL to load.
    */
   componentWillReceiveProps(nextProps) {
-    const newUrl = nextProps.navigation.state.params.url;
-    const oldUrl = this.props.navigation.state.params.url;
-    const newPreloadScreen = nextProps.navigation.state.params.preloadScreen;
-    const oldPreloadScreen = this.props.navigation.state.params.preloadScreen;
+    const { params } = this.getNavigationState();
+    const newUrl = params.url;
+    const oldUrl = params.url;
+    const newPreloadScreen = params.preloadScreen;
+    const oldPreloadScreen = params.preloadScreen;
 
     if (newPreloadScreen !== oldPreloadScreen) {
       delete PRELOAD_SCREEN[oldPreloadScreen];
@@ -500,7 +509,8 @@ export default class HyperScreen extends React.Component {
    * Clear out the preload screen associated with this screen.
    */
   componentWillUnmount() {
-    const { preloadScreen } = this.props.navigation.state.params;
+    const { params } = this.getNavigationState();
+    const { preloadScreen } = params;
     if (preloadScreen && PRELOAD_SCREEN[preloadScreen]) {
       delete PRELOAD_SCREEN[preloadScreen];
     }
@@ -520,7 +530,8 @@ export default class HyperScreen extends React.Component {
    * Performs a full load of the screen.
    */
   load = () => {
-    const delay = this.props.navigation.state.params.delay;
+    const { params, key: routeKey } = this.getNavigationState();
+    const { delay } = params;
     const url = this.state.url;
 
     const fetchPromise = () => this.props.fetch(url, { headers: getHyperviewHeaders() })
@@ -534,7 +545,7 @@ export default class HyperScreen extends React.Component {
         let doc = this.parser.parseFromString(responseText);
         let error = false;
         const stylesheets = Stylesheets.createStylesheets(doc);
-        ROUTE_KEYS[getHrefKey(url)] = this.props.navigation.state.key;
+        ROUTE_KEYS[getHrefKey(url)] = routeKey;
 
         // Make sure the XML has the required elements: <doc>, <screen>, <body>.
         const docElement = getFirstTag(doc, 'doc');


### PR DESCRIPTION
This allows to use the root Hyperview component in a context that is not aware of react-navigation. For now, the implementation consist in defaulting the `params` property to an object so that code accessing keys without checking existance first does not crash. This should be better addressed with added typing when refactoring the component in https://app.asana.com/0/923014529014430/933532962114370/f.