### PR TITLE
Fix: later is not defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ import { DOMParser, XMLSerializer } from 'xmldom';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scrollview';
 import React from 'react';
 import VisibilityDetectingView from './VisibilityDetectingView.js';
-import { createProps, getBehaviorElements, getFirstTag } from 'hyperview/src/services';
+import { createProps, getBehaviorElements, getFirstTag, later } from 'hyperview/src/services';
 import { version } from '../package.json';
 import urlParse from 'url-parse';
 


### PR DESCRIPTION
Fix a crash where `delay` attribute would not longer work as `later` helper was not correctly imported