### PR TITLE
Fix: Form with GET methods and pre-existing query string params bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import * as Components from 'hyperview/src/services/components';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
 import * as Stylesheets from 'hyperview/src/services/stylesheets';
+import * as UrlService from 'hyperview/src/services/url';
 import {
   ActivityIndicator,
   Alert,
@@ -28,7 +29,7 @@ import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scrollview'
 import Navigation from 'hyperview/src/services/navigation';
 import React from 'react';
 import VisibilityDetectingView from './VisibilityDetectingView.js';
-import { addHref, createProps, getBehaviorElements, getFirstTag, getUrlFromHref, later } from 'hyperview/src/services';
+import { addHref, createProps, getBehaviorElements, getFirstTag, later } from 'hyperview/src/services';
 import { version } from '../package.json';
 import { ACTIONS, NAV_ACTIONS, UPDATE_ACTIONS } from 'hyperview/src/types';
 import urlParse from 'url-parse';
@@ -412,14 +413,18 @@ export default class HyperScreen extends React.Component {
       });
     }
 
-    let url = getUrlFromHref(href, this.state.url);
-    if (verb === 'GET' && formData) {
-      // For GET requests, we can't include a body so we encode the form data as a query
-      // string in the URL.
-      const queryString = formData.getParts().map(
-        e => `${encodeURIComponent(e.fieldName)}=${encodeURIComponent(e.string)}`).join('&');
-      url = `${url}?${queryString}`;
-    }
+    // For GET requests, we can't include a body so we encode the form data as a query
+    // string in the URL.
+    const url = verb === 'GET' && formData
+      ? UrlService.addParamsToUrl(
+          UrlService.getUrlFromHref(href, this.state.url),
+          formData.getParts().map(p => ({
+            name: p.fieldName,
+            value: p.string,
+          })),
+      )
+      : UrlService.getUrlFromHref(href, this.state.url);
+
     const options = {
       method: verb,
       headers: getHyperviewHeaders(),

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -20,7 +20,6 @@ import type {
 } from 'hyperview/src/types';
 import HyperRef from 'hyperview/src/core/hyper-ref';
 import React from 'react';
-import urlParse from 'url-parse';
 
 /**
  * This file is currently a dumping place for every functions used accross
@@ -147,14 +146,4 @@ export const addHref = (
     { element, stylesheets, onUpdate, options },
     ...Render.renderChildren(element, stylesheets, onUpdate, options),
   );
-};
-
-/**
- * Turns the href into a fetchable URL.
- * If the href is fully qualified, return it.
- * Otherwise, pull the protocol/domain/port from base URL and append the href.
- */
-export const getUrlFromHref = (href: string, baseUrl: string): string => {
-  const rootUrl = urlParse(href, baseUrl, true);
-  return rootUrl.toString();
 };

--- a/src/services/navigation/index.js
+++ b/src/services/navigation/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as Namespaces from 'hyperview/src/services/namespaces';
+import * as UrlService from 'hyperview/src/services/url';
 import type {
   BehaviorOptions,
   Document,
@@ -10,7 +11,6 @@ import type {
   NodeList,
 } from 'hyperview/src/types';
 import { NAV_ACTIONS } from 'hyperview/src/types';
-import { getUrlFromHref } from 'hyperview/src/services';
 
 const ANCHOR_ID_SEPARATOR = '#';
 const QUERY_SEPARATOR = '?';
@@ -61,7 +61,7 @@ export default class Navigation {
     opts: BehaviorOptions,
   ): void => {
     const { showIndicatorId, delay } = opts;
-    const url = getUrlFromHref(href, this.url);
+    const url = UrlService.getUrlFromHref(href, this.url);
 
     let preloadScreen = null;
     if (showIndicatorId) {

--- a/src/services/url/index.js
+++ b/src/services/url/index.js
@@ -1,0 +1,43 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import urlParse from 'url-parse';
+
+const QUERY_SEPARATOR = '?';
+const QUERY_PARAM_SEPARATOR = '&';
+
+/**
+ * Turns the href into a fetchable URL.
+ * If the href is fully qualified, return it.
+ * Otherwise, pull the protocol/domain/port from base URL and append the href.
+ */
+export const getUrlFromHref = (href: string, baseUrl: string): string => {
+  const rootUrl = urlParse(href, baseUrl, true);
+  return rootUrl.toString();
+};
+
+/**
+ * Add dictionary of parameters to an url
+ */
+export const addParamsToUrl = (
+  url: string,
+  params: Array<{ name: string, value: string }>,
+): string => {
+  const [baseUrl, existingParams] = url.split(QUERY_SEPARATOR);
+  const query = (existingParams
+    ? existingParams.split(QUERY_PARAM_SEPARATOR)
+    : []
+  ).concat(
+    params.map(
+      p => `${encodeURIComponent(p.name)}=${encodeURIComponent(p.value)}`,
+    ),
+  );
+  return `${baseUrl}${QUERY_SEPARATOR}${query.join(QUERY_PARAM_SEPARATOR)}`;
+};

--- a/src/services/url/index.test.js
+++ b/src/services/url/index.test.js
@@ -1,0 +1,48 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import * as Url from '.';
+
+describe('getUrlFromHref', () => {
+  it('returns href when href is a fully qualified url', () => {
+    const href = 'http://foo/bar';
+    const baseUrl = 'http://baz';
+    expect(Url.getUrlFromHref(href, baseUrl)).toEqual(href);
+  });
+  it('composes url from href and baseUrl when href is not a fully qualified url', () => {
+    const href = '/bar';
+    const baseUrl = 'http://baz';
+    expect(Url.getUrlFromHref(href, baseUrl)).toEqual('http://baz/bar');
+  });
+});
+
+describe('addParamsToUrl', () => {
+  it('adds params to an url without query string', () => {
+    const url = 'http://foo/bar';
+    const params = [
+      { name: 'foo', value: 'bar' },
+      { name: 'bar', value: 'baz' },
+      { name: 'bar', value: 'abc' },
+    ];
+    expect(Url.addParamsToUrl(url, params)).toEqual(
+      'http://foo/bar?foo=bar&bar=baz&bar=abc',
+    );
+  });
+  it('adds params to an url with pre-existing query string', () => {
+    const url = 'http://foo/bar?foo=abc';
+    const params = [
+      { name: 'foo', value: 'bar' },
+      { name: 'bar', value: 'baz' },
+    ];
+    expect(Url.addParamsToUrl(url, params)).toEqual(
+      'http://foo/bar?foo=abc&foo=bar&bar=baz',
+    );
+  });
+});


### PR DESCRIPTION
Correctly generate URL when form method is `GET` and url already contains query params. Also extract URL code into a separate/tested module.