### PR TITLE
Add shadow support to Hyperview

### DIFF
--- a/docs/reference_style.md
+++ b/docs/reference_style.md
@@ -91,6 +91,11 @@ A `<style>` element should only appear as a direct child of a `<styles>` element
   - [`borderTopLeftRadius`](#bordertopleftradius)
   - [`borderTopRightRadius`](#bordertoprightradius)
   - [`opacity`](#opacity)
+  - [`shadowColor`](#shadowcolor)
+  - [`shadowOffsetX`](#shadowoffsetx)
+  - [`shadowOffsetY`](#shadowoffsety)
+  - [`shadowOpacity`](#shadowopacity)
+  - [`shadowRadius`](#shadowradius)
 
 - [Text rules](#text-rules)
   - [`color`](#color)
@@ -576,6 +581,36 @@ It works similarly to `width` in CSS, but in Hyperview you must use points or pe
 | number | No       |
 
 #### `opacity`
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+#### `shadowColor`
+
+| Type  | Required |
+| ----- | -------- |
+| color | No       |
+
+#### `shadowOffsetX`
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+#### `shadowOffsetY`
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+#### `shadowOpacity`
+
+| Type        | Required |
+| ----------- | -------- |
+| float (0-1) | No       |
+
+#### `shadowRadius`
 
 | Type   | Required |
 | ------ | -------- |

--- a/examples/styling/button.xml
+++ b/examples/styling/button.xml
@@ -60,6 +60,17 @@
              fontWeight="bold" />
       <style id="Button--Disabled"
              opacity="0.5" />
+      <style id="Button--Shadow"
+        shadowColor="black"
+        shadowOffsetX="0"
+        shadowOffsetY="4"
+        shadowOpacity="0.5"
+        shadowRadius="4"
+      >
+        <modifier pressed="true">
+          <style shadowOffsetY="1" shadowRadius="1" />
+        </modifier>
+      </style>
     </styles>
     <body style="Body">
       <header style="Header">
@@ -71,12 +82,17 @@
       <view scroll="1"
             style="Main">
         <text style="Description">Regular</text>
-        <view style="Button">
+        <view style="Button" action="reload" href="styling/button.xml">
           <text style="Button__Label">Hello</text>
         </view>
         <text style="Description">Disabled</text>
         <view style="Button Button--Disabled">
           <text style="Button__Label">Disabled</text>
+        </view>
+
+        <text style="Description">Shadow</text>
+        <view style="Button Button--Shadow" action="reload" href="styling/button.xml">
+          <text style="Button__Label">Shadow</text>
         </view>
       </view>
     </body>

--- a/examples/styling/button.xml
+++ b/examples/styling/button.xml
@@ -61,14 +61,14 @@
       <style id="Button--Disabled"
              opacity="0.5" />
       <style id="Button--Shadow"
-        shadowColor="black"
-        shadowOffsetX="0"
-        shadowOffsetY="4"
-        shadowOpacity="0.5"
-        shadowRadius="4"
-      >
+             shadowColor="black"
+             shadowOffsetX="0"
+             shadowOffsetY="4"
+             shadowOpacity="0.5"
+             shadowRadius="4">
         <modifier pressed="true">
-          <style shadowOffsetY="1" shadowRadius="1" />
+          <style shadowOffsetY="1"
+                 shadowRadius="1" />
         </modifier>
       </style>
     </styles>
@@ -82,16 +82,19 @@
       <view scroll="1"
             style="Main">
         <text style="Description">Regular</text>
-        <view style="Button" action="reload" href="styling/button.xml">
+        <view action="reload"
+              href="styling/button.xml"
+              style="Button">
           <text style="Button__Label">Hello</text>
         </view>
         <text style="Description">Disabled</text>
         <view style="Button Button--Disabled">
           <text style="Button__Label">Disabled</text>
         </view>
-
         <text style="Description">Shadow</text>
-        <view style="Button Button--Shadow" action="reload" href="styling/button.xml">
+        <view action="reload"
+              href="styling/button.xml"
+              style="Button Button--Shadow">
           <text style="Button__Label">Shadow</text>
         </view>
       </view>

--- a/examples/styling/index.xml
+++ b/examples/styling/index.xml
@@ -79,6 +79,13 @@
           <text style="Item__Label">Button Styling</text>
           <text style="Item__Chevron">&gt;</text>
         </item>
+        <item href="/styling/shadows.xml"
+              key="shadow"
+              show-during-load="loadingScreen"
+              style="Item">
+          <text style="Item__Label">Shadow Styling</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
       </list>
     </body>
   </screen>

--- a/examples/styling/shadows.xml
+++ b/examples/styling/shadows.xml
@@ -1,0 +1,116 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style alignItems="center"
+             backgroundColor="white"
+             borderBottomColor="#eee"
+             borderBottomWidth="1"
+             flexDirection="row"
+             height="72"
+             id="Header"
+             paddingLeft="24"
+             paddingRight="24"
+             paddingTop="24" />
+      <style color="blue"
+             fontWeight="600"
+             fontSize="16"
+             id="Header__Back"
+             paddingRight="16" />
+      <style color="black"
+             fontWeight="600"
+             fontSize="24"
+             id="Header__Title" />
+      <style backgroundColor="white"
+             flex="1"
+             id="Body" />
+      <style fontWeight="600"
+             fontSize="16"
+             id="Description"
+             margin="24"
+             marginBottom="0" />
+      <style alignItems="center"
+             borderBottomColor="#eee"
+             borderBottomWidth="1"
+             flex="1"
+             flexDirection="row"
+             height="48"
+             id="Item"
+             justifyContent="space-between"
+             paddingLeft="24"
+             paddingRight="24" />
+      <style fontWeight="normal"
+             fontSize="18"
+             id="Item__Label" />
+      <style fontWeight="bold"
+             fontSize="18"
+             id="Item__Chevron" />
+      <style flex="1"
+             id="Main" />
+      <style backgroundColor="#63CB76"
+             borderRadius="16"
+             flex="1"
+             flexDirection="row"
+             id="Button"
+             justifyContent="center"
+             margin="24"
+             padding="24" />
+      <style color="white"
+             fontWeight="bold"
+             fontSize="24"
+             id="Button__Label" />
+      <style id="Button--Disabled" opacity="0.5" />
+
+      <style id="Button--Shadow"
+        shadowColor="black"
+        shadowOffsetX="0"
+        shadowOffsetY="4"
+        shadowOpacity="0.5"
+        shadowRadius="4"
+      />
+
+      <style id="Button--BlueShadow"
+        shadowColor="blue"
+      />
+
+      <style id="Button--BigRadius"
+        shadowRadius="10"
+      />
+
+      <style id="Button--Offset"
+        shadowOffsetX="5"
+        shadowOffsetY="-5"
+      />
+
+    </styles>
+    <body style="Body">
+      <header style="Header">
+        <text action="back"
+              href="#"
+              style="Header__Back">Back</text>
+        <text style="Header__Title">Shadow Styling</text>
+      </header>
+      <view scroll="1"
+            style="Main">
+        <text style="Description">Regular</text>
+        <view style="Button Button--Shadow">
+          <text style="Button__Label">Hello</text>
+        </view>
+
+        <text style="Description">Shadow color</text>
+        <view style="Button Button--Shadow Button--BlueShadow">
+          <text style="Button__Label">Hello</text>
+        </view>
+
+        <text style="Description">Radius</text>
+        <view style="Button Button--Shadow Button--BigRadius">
+          <text style="Button__Label">Hello</text>
+        </view>
+
+        <text style="Description">Offset</text>
+        <view style="Button Button--Shadow Button--Offset">
+          <text style="Button__Label">Hello</text>
+        </view>
+      </view>
+    </body>
+  </screen>
+</doc>

--- a/examples/styling/shadows.xml
+++ b/examples/styling/shadows.xml
@@ -1,86 +1,78 @@
 <doc xmlns="https://hyperview.org/hyperview">
   <screen>
     <styles>
-      <style alignItems="center"
+      <style id="Header"
+             alignItems="center"
              backgroundColor="white"
              borderBottomColor="#eee"
              borderBottomWidth="1"
              flexDirection="row"
              height="72"
-             id="Header"
              paddingLeft="24"
              paddingRight="24"
              paddingTop="24" />
-      <style color="blue"
-             fontWeight="600"
+      <style id="Header__Back"
+             color="blue"
              fontSize="16"
-             id="Header__Back"
+             fontWeight="600"
              paddingRight="16" />
-      <style color="black"
-             fontWeight="600"
+      <style id="Header__Title"
+             color="black"
              fontSize="24"
-             id="Header__Title" />
-      <style backgroundColor="white"
-             flex="1"
-             id="Body" />
-      <style fontWeight="600"
+             fontWeight="600" />
+      <style id="Body"
+             backgroundColor="white"
+             flex="1" />
+      <style id="Description"
              fontSize="16"
-             id="Description"
+             fontWeight="600"
              margin="24"
              marginBottom="0" />
-      <style alignItems="center"
+      <style id="Item"
+             alignItems="center"
              borderBottomColor="#eee"
              borderBottomWidth="1"
              flex="1"
              flexDirection="row"
              height="48"
-             id="Item"
              justifyContent="space-between"
              paddingLeft="24"
              paddingRight="24" />
-      <style fontWeight="normal"
+      <style id="Item__Label"
              fontSize="18"
-             id="Item__Label" />
-      <style fontWeight="bold"
+             fontWeight="normal" />
+      <style id="Item__Chevron"
              fontSize="18"
-             id="Item__Chevron" />
-      <style flex="1"
-             id="Main" />
-      <style backgroundColor="#63CB76"
+             fontWeight="bold" />
+      <style id="Main"
+             flex="1" />
+      <style id="Button"
+             backgroundColor="#63CB76"
              borderRadius="16"
              flex="1"
              flexDirection="row"
-             id="Button"
              justifyContent="center"
              margin="24"
              padding="24" />
-      <style color="white"
-             fontWeight="bold"
+      <style id="Button__Label"
+             color="white"
              fontSize="24"
-             id="Button__Label" />
-      <style id="Button--Disabled" opacity="0.5" />
-
+             fontWeight="bold" />
+      <style id="Button--Disabled"
+             opacity="0.5" />
       <style id="Button--Shadow"
-        shadowColor="black"
-        shadowOffsetX="0"
-        shadowOffsetY="4"
-        shadowOpacity="0.5"
-        shadowRadius="4"
-      />
-
+             shadowColor="black"
+             shadowOffsetX="0"
+             shadowOffsetY="4"
+             shadowOpacity="0.5"
+             shadowRadius="4" />
       <style id="Button--BlueShadow"
-        shadowColor="blue"
-      />
-
+             shadowColor="blue" />
       <style id="Button--BigRadius"
-        shadowRadius="10"
-      />
-
+             shadowRadius="10" />
       <style id="Button--Offset"
-        shadowOffsetX="5"
-        shadowOffsetY="-5"
-      />
-
+             shadowOffsetX="5"
+             shadowOffsetY="-5" />
     </styles>
     <body style="Body">
       <header style="Header">
@@ -95,17 +87,14 @@
         <view style="Button Button--Shadow">
           <text style="Button__Label">Hello</text>
         </view>
-
         <text style="Description">Shadow color</text>
         <view style="Button Button--Shadow Button--BlueShadow">
           <text style="Button__Label">Hello</text>
         </view>
-
         <text style="Description">Radius</text>
         <view style="Button Button--Shadow Button--BigRadius">
           <text style="Button__Label">Hello</text>
         </view>
-
         <text style="Description">Offset</text>
         <view style="Button Button--Shadow Button--Offset">
           <text style="Button__Label">Hello</text>

--- a/src/services/stylesheets/index.js
+++ b/src/services/stylesheets/index.js
@@ -115,6 +115,11 @@ const STYLE_ATTRIBUTE_CONVERTERS = {
   borderTopLeftRadius: number,
   borderTopRightRadius: number,
   opacity: floatNumber,
+  shadowColor: string,
+  shadowOffsetX: number,
+  shadowOffsetY: number,
+  shadowOpacity: floatNumber,
+  shadowRadius: number,
 
   // text attributes
   color: string,
@@ -189,6 +194,19 @@ function createStylesheet(
           rules[attr.name] = converter(attr.value);
         }
       }
+
+      if (
+        rules['shadowOffsetX'] !== undefined ||
+        rules['shadowOffsetY'] !== undefined
+      ) {
+        rules.shadowOffset = {
+          width: rules.shadowOffsetX,
+          height: rules.shadowOffsetY,
+        };
+        delete rules.shadowOffsetX;
+        delete rules.shadowOffsetY;
+      }
+
       stylesheet[styleId] = rules;
     }
   }

--- a/src/services/stylesheets/index.js
+++ b/src/services/stylesheets/index.js
@@ -195,9 +195,11 @@ function createStylesheet(
         }
       }
 
+      // Shadow offset numbers needs to be be converted into a single object
+      // on the style sheet.
       if (
-        rules['shadowOffsetX'] !== undefined ||
-        rules['shadowOffsetY'] !== undefined
+        rules.shadowOffsetX !== undefined ||
+        rules.shadowOffsetY !== undefined
       ) {
         rules.shadowOffset = {
           width: rules.shadowOffsetX,


### PR DESCRIPTION
Add support for shadow attributes to the `<style>` element. It works with modifiers so that shadow can change on pushed buttons:
```
<style id="Button--Shadow"
  shadowColor="black"
  shadowOffsetX="0"
  shadowOffsetY="4"
  shadowOpacity="0.5"
  shadowRadius="4"
>
  <modifier pressed="true">
    <style shadowOffsetY="1" shadowRadius="1" />
  </modifier>
</style>
```
Screenshot:
![2019-05-19 09 25 18](https://user-images.githubusercontent.com/1034502/57989443-842c1f80-7a4f-11e9-8ecc-056f49d1388a.gif)

All available style attributes:
<img width="487" alt="Screen Shot 2019-05-19 at 9 23 54 AM" src="https://user-images.githubusercontent.com/1034502/57989445-8a220080-7a4f-11e9-8a96-264e137eb39e.png">
