### PR TITLE
Add elevation support to Hyperview

### DIFF
--- a/docs/reference_style.md
+++ b/docs/reference_style.md
@@ -90,6 +90,7 @@ A `<style>` element should only appear as a direct child of a `<styles>` element
   - [`borderTopColor`](#bordertopcolor)
   - [`borderTopLeftRadius`](#bordertopleftradius)
   - [`borderTopRightRadius`](#bordertoprightradius)
+  - [`elevation`](#elevation)
   - [`opacity`](#opacity)
   - [`shadowColor`](#shadowcolor)
   - [`shadowOffsetX`](#shadowoffsetx)
@@ -580,6 +581,14 @@ It works similarly to `width` in CSS, but in Hyperview you must use points or pe
 | ------ | -------- |
 | number | No       |
 
+#### `elevation`
+
+**NOTE**: Elevation only works on Android. For iOS, use [shadow style attributes](#shadowcolor).
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
 #### `opacity`
 
 | Type   | Required |
@@ -588,11 +597,15 @@ It works similarly to `width` in CSS, but in Hyperview you must use points or pe
 
 #### `shadowColor`
 
+**NOTE**: `shadowColor` only works on iOS. For Android, use [elevation](#elevation).
+
 | Type  | Required |
 | ----- | -------- |
 | color | No       |
 
 #### `shadowOffsetX`
+
+**NOTE**: `shadowColor` only works on iOS. For Android, use [elevation](#elevation).
 
 | Type   | Required |
 | ------ | -------- |
@@ -600,17 +613,23 @@ It works similarly to `width` in CSS, but in Hyperview you must use points or pe
 
 #### `shadowOffsetY`
 
+**NOTE**: `shadowColor` only works on iOS. For Android, use [elevation](#elevation).
+
 | Type   | Required |
 | ------ | -------- |
 | number | No       |
 
 #### `shadowOpacity`
 
+**NOTE**: `shadowColor` only works on iOS. For Android, use [elevation](#elevation).
+
 | Type        | Required |
 | ----------- | -------- |
 | float (0-1) | No       |
 
 #### `shadowRadius`
+
+**NOTE**: `shadowColor` only works on iOS. For Android, use [elevation](#elevation).
 
 | Type   | Required |
 | ------ | -------- |

--- a/examples/styling/button.xml
+++ b/examples/styling/button.xml
@@ -61,13 +61,15 @@
       <style id="Button--Disabled"
              opacity="0.5" />
       <style id="Button--Shadow"
+             elevation="4"
              shadowColor="black"
              shadowOffsetX="0"
              shadowOffsetY="4"
              shadowOpacity="0.5"
              shadowRadius="4">
         <modifier pressed="true">
-          <style shadowOffsetY="1"
+          <style elevation="1"
+                 shadowOffsetY="1"
                  shadowRadius="1" />
         </modifier>
       </style>

--- a/examples/styling/elevation.xml
+++ b/examples/styling/elevation.xml
@@ -58,49 +58,31 @@
              color="white"
              fontSize="24"
              fontWeight="bold" />
-      <style id="Button--Disabled"
-             opacity="0.5" />
-      <style id="Button--Shadow"
-             shadowColor="black"
-             shadowOffsetX="0"
-             shadowOffsetY="4"
-             shadowOpacity="0.5"
-             shadowRadius="4" />
-      <style id="Button--BlueShadow"
-             shadowColor="blue" />
-      <style id="Button--BigRadius"
-             shadowRadius="10" />
-      <style id="Button--Offset"
-             shadowOffsetX="5"
-             shadowOffsetY="-5" />
+      <style id="Button--Elevation3"
+             elevation="3" />
+      <style id="Button--Elevation10"
+             elevation="10" />
     </styles>
     <body style="Body">
       <header style="Header">
         <text action="back"
               href="#"
               style="Header__Back">Back</text>
-        <text style="Header__Title">Shadow Styling</text>
+        <text style="Header__Title">Elevation Styling</text>
       </header>
       <view scroll="1"
             style="Main">
-        <text style="Description">Shadow styling only works on iOS. For Android, use the elevation prop.</text>
-        <text style="Description">Regular</text>
-        <view style="Button Button--Shadow">
+        <text style="Description">Elevation styling only works on Android. For iOS, use shadow styles.</text>
+        <text style="Description">Elevation: 3</text>
+        <view style="Button Button--Elevation3">
           <text style="Button__Label">Hello</text>
         </view>
-        <text style="Description">Shadow color</text>
-        <view style="Button Button--Shadow Button--BlueShadow">
-          <text style="Button__Label">Hello</text>
-        </view>
-        <text style="Description">Radius</text>
-        <view style="Button Button--Shadow Button--BigRadius">
-          <text style="Button__Label">Hello</text>
-        </view>
-        <text style="Description">Offset</text>
-        <view style="Button Button--Shadow Button--Offset">
+        <text style="Description">Elevation: 10</text>
+        <view style="Button Button--Elevation10">
           <text style="Button__Label">Hello</text>
         </view>
       </view>
     </body>
   </screen>
 </doc>
+

--- a/examples/styling/index.xml
+++ b/examples/styling/index.xml
@@ -83,7 +83,14 @@
               key="shadow"
               show-during-load="loadingScreen"
               style="Item">
-          <text style="Item__Label">Shadow Styling</text>
+          <text style="Item__Label">Shadow Styling (iOS only)</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item href="/styling/elevation.xml"
+              key="elevation"
+              show-during-load="loadingScreen"
+              style="Item">
+          <text style="Item__Label">Elevation Styling (Android only)</text>
           <text style="Item__Chevron">&gt;</text>
         </item>
       </list>

--- a/src/services/stylesheets/index.js
+++ b/src/services/stylesheets/index.js
@@ -68,6 +68,7 @@ const STYLE_ATTRIBUTE_CONVERTERS = {
   borderWidth: number,
   bottom: numberOrPercent,
   display: string,
+  elevation: number,
   flex: number,
   flexBasis: number,
   flexDirection: string,


### PR DESCRIPTION
In a previous PR I added shadow support for iOS. This is not supported on Android, so instead I exposed the elevation style property. Also:
- updated examples to include elevation
- updated docs on website

![Screenshot_20190521-112303](https://user-images.githubusercontent.com/1034502/58122486-a42e2100-7bbe-11e9-9de8-ab42a7adb1b2.png)
