### PR TITLE
Fixed share content on android

### DIFF
--- a/src/behaviors/hv-share/index.js
+++ b/src/behaviors/hv-share/index.js
@@ -42,12 +42,20 @@ const getOptions = (dialogTitle: ?DOMString, subject: ?DOMString): Options => {
 };
 
 // `url` is not supported on android. See https://facebook.github.io/react-native/docs/share
-const platformSpecificContent = content => {
-  if (Platform.OS === 'android' && content.url) {
-    const msg = content.message + ' ' + content.url;
-    return { ...content, message: msg };
+const platformSpecificContent = (
+  message: ?DOMString,
+  title: ?DOMString,
+  url: ?DOMString,
+): ?Content => {
+  const content = getContent(message, title, url);
+  if (content) {
+    if (Platform.OS === 'android' && content.url) {
+      const msg = `${content.message} ${content.url}`;
+      return { ...content, message: msg };
+    }
+    return content;
   }
-  return content;
+  return null;
 };
 
 export default {
@@ -69,10 +77,10 @@ export default {
     const title: ?DOMString = element.getAttributeNS(Namespaces.SHARE, 'title');
     const url: ?DOMString = element.getAttributeNS(Namespaces.SHARE, 'url');
 
-    const content = getContent(message, title, url);
+    const content = platformSpecificContent(message, title, url);
     if (content) {
       const options = getOptions(dialogTitle, subject);
-      Share.share(platformSpecificContent(content), options);
+      Share.share(content, options);
     }
   },
 };

--- a/src/behaviors/hv-share/index.js
+++ b/src/behaviors/hv-share/index.js
@@ -11,7 +11,7 @@
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import type { Content, Options } from './types';
 import type { DOMString, Element } from 'hyperview/src/types';
-import { Share } from 'react-native';
+import { Platform, Share } from 'react-native';
 
 const getContent = (
   message: ?DOMString,
@@ -41,6 +41,15 @@ const getOptions = (dialogTitle: ?DOMString, subject: ?DOMString): Options => {
   return {};
 };
 
+// `url` is not supported on android. See https://facebook.github.io/react-native/docs/share
+const platformSpecificContent = content => {
+  if (Platform.OS === 'android' && content.url) {
+    const msg = content.message + ' ' + content.url;
+    return { ...content, message: msg };
+  }
+  return content;
+};
+
 export default {
   action: 'share',
   callback: (element: Element) => {
@@ -63,7 +72,7 @@ export default {
     const content = getContent(message, title, url);
     if (content) {
       const options = getOptions(dialogTitle, subject);
-      Share.share(content, options);
+      Share.share(platformSpecificContent(content), options);
     }
   },
 };


### PR DESCRIPTION
[Bug](https://app.asana.com/0/378088913887644/1132648377334187/f)

### Description
`url` is not supported on Android. Thus, we concatenate the url portion to the message on android. 
See: https://facebook.github.io/react-native/docs/share

### Test
Android9
![android_share_referral](https://user-images.githubusercontent.com/2883006/62202428-e76af400-b3a6-11e9-95a2-d862a29bf304.gif)

iPhone
https://drive.google.com/file/d/1bnN49DJHtxv_boNW-r80mzhPHRXDu0XM/view?usp=sharing
