### PR TITLE
Implement "show" and "hide" actions

### DIFF
--- a/examples/behaviors/hide.xml
+++ b/examples/behaviors/hide.xml
@@ -91,7 +91,7 @@
         </view>
         <text id="hide2-content" style="Hide">Content to be hidden</text>
 
-        <text style="Description">When toggling with delay, you can use indicators.</text>
+        <text style="Description">When hiding with delay, you can use indicators.</text>
         <view action="hide"
               target="hide3-content"
               delay="1000"

--- a/examples/behaviors/hide.xml
+++ b/examples/behaviors/hide.xml
@@ -1,0 +1,120 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style id="Header"
+             alignItems="center"
+             backgroundColor="white"
+             borderBottomColor="#eee"
+             borderBottomWidth="1"
+             flexDirection="row"
+             height="72"
+             paddingLeft="24"
+             paddingRight="24"
+             paddingTop="24" />
+      <style id="Header__Back"
+             color="blue"
+             fontSize="16"
+             fontWeight="600"
+             paddingRight="16" />
+      <style id="Header__Title"
+             color="black"
+             fontSize="24"
+             fontWeight="600" />
+      <style id="Body"
+             backgroundColor="white"
+             flex="1" />
+      <style id="Description"
+             fontSize="16"
+             fontWeight="normal"
+             margin="24"
+             marginBottom="0" />
+      <style id="Item"
+             alignItems="center"
+             borderBottomColor="#eee"
+             borderBottomWidth="1"
+             flex="1"
+             flexDirection="row"
+             height="48"
+             justifyContent="space-between"
+             paddingLeft="24"
+             paddingRight="24" />
+      <style id="Item__Label"
+             fontSize="18"
+             fontWeight="normal" />
+      <style id="Item__Chevron"
+             fontSize="18"
+             fontWeight="bold" />
+      <style id="Button"
+             alignItems="center"
+             backgroundColor="#63CB76"
+             borderRadius="16"
+             flex="1"
+             flexDirection="column"
+             margin="24"
+             padding="24" />
+      <style id="Button__Label"
+             color="white"
+             fontSize="24"
+             fontWeight="bold" />
+      <style id="Hide"
+             color="red"
+             fontSize="18"
+             textAlign="center"
+             fontWeight="bold" />
+      <style id="Main"
+             flex="1" />
+      <style id="Spacer" height="40" />
+    </styles>
+    <body style="Body">
+      <header style="Header">
+        <text action="back"
+              href="#"
+              style="Header__Back">Back</text>
+        <text style="Header__Title">Hide</text>
+      </header>
+      <view scroll="true"
+            style="Main">
+        <text style="Description">Tapping the button below will hide the element below.</text>
+        <view action="hide"
+              target="hide1-content"
+              style="Button">
+          <text style="Button__Label">Hide</text>
+        </view>
+        <text id="hide1-content" style="Hide">Content to be hidden</text>
+
+        <text style="Description">Hide can work with the delay attribute. In this example, the hide will be delayed 1 second.</text>
+        <view action="hide"
+              target="hide2-content"
+              delay="1000"
+              style="Button">
+          <text style="Button__Label">Hide with Delay</text>
+        </view>
+        <text id="hide2-content" style="Hide">Content to be hidden</text>
+
+        <text style="Description">When toggling with delay, you can use indicators.</text>
+        <view action="hide"
+              target="hide3-content"
+              delay="1000"
+              show-during-load="hide3-spinner"
+              style="Button">
+          <text style="Button__Label">Hide with Spinner</text>
+          <view id="hide3-spinner" hide="true">
+            <spinner color="white" />
+          </view>
+        </view>
+        <text id="hide3-content" style="Hide">Content to be hidden</text>
+
+        <text style="Description">You can hide multiple elements at once. The button below will hide content A and B with one press</text>
+        <view style="Button">
+          <behavior action="hide" target="hide4-content" />
+          <behavior action="hide" target="hide5-content" />
+          <text style="Button__Label">Hide Multiple</text>
+        </view>
+        <text id="hide4-content" style="Hide">Content A</text>
+        <text id="hide5-content" style="Hide">Content B</text>
+
+        <view style="Spacer" />
+      </view>
+    </body>
+  </screen>
+</doc>

--- a/examples/behaviors/index.xml
+++ b/examples/behaviors/index.xml
@@ -99,6 +99,20 @@
             <text style="Item__Label">Prepend</text>
             <text style="Item__Chevron">&gt;</text>
           </item>
+          <item href="/behaviors/hide.xml"
+                key="hide"
+                show-during-load="loadingScreen"
+                style="Item">
+            <text style="Item__Label">Hide</text>
+            <text style="Item__Chevron">&gt;</text>
+          </item>
+          <item href="/behaviors/show.xml"
+                key="show"
+                show-during-load="loadingScreen"
+                style="Item">
+            <text style="Item__Label">Show</text>
+            <text style="Item__Chevron">&gt;</text>
+          </item>
           <item href="/behaviors/toggle.xml"
                 key="toggle"
                 show-during-load="loadingScreen"

--- a/examples/behaviors/show.xml
+++ b/examples/behaviors/show.xml
@@ -1,0 +1,120 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style id="Header"
+             alignItems="center"
+             backgroundColor="white"
+             borderBottomColor="#eee"
+             borderBottomWidth="1"
+             flexDirection="row"
+             height="72"
+             paddingLeft="24"
+             paddingRight="24"
+             paddingTop="24" />
+      <style id="Header__Back"
+             color="blue"
+             fontSize="16"
+             fontWeight="600"
+             paddingRight="16" />
+      <style id="Header__Title"
+             color="black"
+             fontSize="24"
+             fontWeight="600" />
+      <style id="Body"
+             backgroundColor="white"
+             flex="1" />
+      <style id="Description"
+             fontSize="16"
+             fontWeight="normal"
+             margin="24"
+             marginBottom="0" />
+      <style id="Item"
+             alignItems="center"
+             borderBottomColor="#eee"
+             borderBottomWidth="1"
+             flex="1"
+             flexDirection="row"
+             height="48"
+             justifyContent="space-between"
+             paddingLeft="24"
+             paddingRight="24" />
+      <style id="Item__Label"
+             fontSize="18"
+             fontWeight="normal" />
+      <style id="Item__Chevron"
+             fontSize="18"
+             fontWeight="bold" />
+      <style id="Button"
+             alignItems="center"
+             backgroundColor="#63CB76"
+             borderRadius="16"
+             flex="1"
+             flexDirection="column"
+             margin="24"
+             padding="24" />
+      <style id="Button__Label"
+             color="white"
+             fontSize="24"
+             fontWeight="bold" />
+      <style id="Show"
+             color="red"
+             fontSize="18"
+             textAlign="center"
+             fontWeight="bold" />
+      <style id="Main"
+             flex="1" />
+      <style id="Spacer" height="40" />
+    </styles>
+    <body style="Body">
+      <header style="Header">
+        <text action="back"
+              href="#"
+              style="Header__Back">Back</text>
+        <text style="Header__Title">Show</text>
+      </header>
+      <view scroll="true"
+            style="Main">
+        <text style="Description">Tapping the button below will show the visibility of the element below.</text>
+        <view action="show"
+              target="show1-content"
+              style="Button">
+          <text style="Button__Label">Show</text>
+        </view>
+        <text id="show1-content" style="Show" hide="true">Content to be shown</text>
+
+        <text style="Description">Show can work with the delay attribute. In this example, the show will be delayed 1 second.</text>
+        <view action="show"
+              target="show2-content"
+              delay="1000"
+              style="Button">
+          <text style="Button__Label">Show with Delay</text>
+        </view>
+        <text id="show2-content" style="Show" hide="true">Content to be shown</text>
+
+        <text style="Description">When showing with delay, you can use indicators.</text>
+        <view action="show"
+              target="show3-content"
+              delay="1000"
+              show-during-load="show3-spinner"
+              style="Button">
+          <text style="Button__Label">Show with Spinner</text>
+          <view id="show3-spinner" hide="true">
+            <spinner color="white" />
+          </view>
+        </view>
+        <text id="show3-content" style="Show" hide="true">Content to be shown</text>
+
+        <text style="Description">You can show multiple elements at once. The button below will show content A and B with one press</text>
+        <view style="Button">
+          <behavior action="show" target="show4-content" />
+          <behavior action="show" target="show5-content" />
+          <text style="Button__Label">Show Multiple</text>
+        </view>
+        <text id="show4-content" style="Show" hide="true">Content A</text>
+        <text id="show5-content" style="Show" hide="true">Content B</text>
+
+        <view style="Spacer" />
+      </view>
+    </body>
+  </screen>
+</doc>

--- a/src/behaviors/hv-hide/index.js
+++ b/src/behaviors/hv-hide/index.js
@@ -1,0 +1,83 @@
+// @flow
+
+import type {
+  DOMString,
+  Document,
+  Element,
+  HvComponentOnUpdate,
+  HvGetRoot,
+  HvUpdateRoot,
+} from 'hyperview/src/types';
+import { later, shallowCloneToRoot } from 'hyperview/src/services';
+import {
+  setIndicatorsAfterLoad,
+  setIndicatorsBeforeLoad,
+} from 'hyperview/src/services/behaviors';
+
+export default {
+  action: 'hide',
+  callback: (
+    element: Element,
+    onUpdate: HvComponentOnUpdate,
+    getRoot: HvGetRoot,
+    updateRoot: HvUpdateRoot,
+  ) => {
+    const targetId: ?DOMString = element.getAttribute('target');
+    if (!targetId) {
+      return;
+    }
+
+    const delayAttr: string = element.getAttribute('delay') || '0';
+    const parsedDelay: number = parseInt(delayAttr, 10);
+    const delay: number = isNaN(parsedDelay) ? 0 : parsedDelay;
+
+    const showIndicatorIds: Array<string> = (
+      element.getAttribute('show-during-load') || ''
+    ).split(' ');
+    const hideIndicatorIds: Array<string> = (
+      element.getAttribute('hide-during-load') || ''
+    ).split(' ');
+
+    const hideElement = () => {
+      const doc: Document = getRoot();
+      const targetElement: ?Element = doc.getElementById(targetId);
+      if (!targetElement) {
+        return;
+      }
+
+      // Hide the target
+      targetElement.setAttribute('hide', 'true');
+      let newRoot: Document = shallowCloneToRoot(targetElement);
+
+      // If using delay, we need to undo the indicators shown earlier.
+      if (delay > 0) {
+        newRoot = setIndicatorsAfterLoad(
+          showIndicatorIds,
+          hideIndicatorIds,
+          newRoot,
+        );
+      }
+      // Update the DOM with the new hidden state and finished indicators.
+      updateRoot(newRoot);
+    };
+
+    if (delay === 0) {
+      // If there's no delay, hide target immediately without showing/hiding
+      // any indicators.
+      hideElement();
+    } else {
+      // If there's a delay, first trigger the indicators before the hide
+      const newRoot = setIndicatorsBeforeLoad(
+        showIndicatorIds,
+        hideIndicatorIds,
+        getRoot(),
+      );
+      // Update the DOM to reflect the new state of the indicators.
+      updateRoot(newRoot);
+      // Wait for the delay then hide the target.
+      later(delay)
+        .then(hideElement)
+        .catch(hideElement);
+    }
+  },
+};

--- a/src/behaviors/hv-show/index.js
+++ b/src/behaviors/hv-show/index.js
@@ -1,0 +1,83 @@
+// @flow
+
+import type {
+  DOMString,
+  Document,
+  Element,
+  HvComponentOnUpdate,
+  HvGetRoot,
+  HvUpdateRoot,
+} from 'hyperview/src/types';
+import { later, shallowCloneToRoot } from 'hyperview/src/services';
+import {
+  setIndicatorsAfterLoad,
+  setIndicatorsBeforeLoad,
+} from 'hyperview/src/services/behaviors';
+
+export default {
+  action: 'show',
+  callback: (
+    element: Element,
+    onUpdate: HvComponentOnUpdate,
+    getRoot: HvGetRoot,
+    updateRoot: HvUpdateRoot,
+  ) => {
+    const targetId: ?DOMString = element.getAttribute('target');
+    if (!targetId) {
+      return;
+    }
+
+    const delayAttr: string = element.getAttribute('delay') || '0';
+    const parsedDelay: number = parseInt(delayAttr, 10);
+    const delay: number = isNaN(parsedDelay) ? 0 : parsedDelay;
+
+    const showIndicatorIds: Array<string> = (
+      element.getAttribute('show-during-load') || ''
+    ).split(' ');
+    const hideIndicatorIds: Array<string> = (
+      element.getAttribute('hide-during-load') || ''
+    ).split(' ');
+
+    const showElement = () => {
+      const doc: Document = getRoot();
+      const targetElement: ?Element = doc.getElementById(targetId);
+      if (!targetElement) {
+        return;
+      }
+
+      // Show the target
+      targetElement.setAttribute('hide', 'false');
+      let newRoot: Document = shallowCloneToRoot(targetElement);
+
+      // If using delay, we need to undo the indicators shown earlier.
+      if (delay > 0) {
+        newRoot = setIndicatorsAfterLoad(
+          showIndicatorIds,
+          hideIndicatorIds,
+          newRoot,
+        );
+      }
+      // Update the DOM with the new shown state and finished indicators.
+      updateRoot(newRoot);
+    };
+
+    if (delay === 0) {
+      // If there's no delay, show target immediately without showing/hiding
+      // any indicators.
+      showElement();
+    } else {
+      // If there's a delay, first trigger the indicators before the show.
+      const newRoot = setIndicatorsBeforeLoad(
+        showIndicatorIds,
+        hideIndicatorIds,
+        getRoot(),
+      );
+      // Update the DOM to reflect the new state of the indicators.
+      updateRoot(newRoot);
+      // Wait for the delay then show the target.
+      later(delay)
+        .then(showElement)
+        .catch(showElement);
+    }
+  },
+};

--- a/src/services/behaviors/index.js
+++ b/src/services/behaviors/index.js
@@ -15,11 +15,13 @@ import type {
   HvBehavior,
 } from 'hyperview/src/types';
 import HvAlert from 'hyperview/src/behaviors/hv-alert';
+import HvHide from 'hyperview/src/behaviors/hv-hide';
 import HvShare from 'hyperview/src/behaviors/hv-share';
+import HvShow from 'hyperview/src/behaviors/hv-show';
 import HvToggle from 'hyperview/src/behaviors/hv-toggle';
 import { shallowCloneToRoot } from 'hyperview/src/services';
 
-const HYPERVIEW_BEHAVIORS = [HvAlert, HvShare, HvToggle];
+const HYPERVIEW_BEHAVIORS = [HvAlert, HvHide, HvShare, HvShow, HvToggle];
 
 export const getRegistry = (behaviors: HvBehavior[] = []): BehaviorRegistry =>
   [...HYPERVIEW_BEHAVIORS, ...behaviors].reduce(


### PR DESCRIPTION
Similar to #90 , this PR adds `hide` and `show` actions that will hide or show elements on a screen. Unlike `toggle`, it will only perform one or the other.

The new actions also works with conventional behavior attributes like delay, show-during-load, hide-during-load. Note that showing/hiding indicators will only work if delay is non-zero.