### PR TITLE
Preserve multiple query params when constructing URLs

### DIFF
--- a/src/services/url/index.js
+++ b/src/services/url/index.js
@@ -19,7 +19,7 @@ const QUERY_PARAM_SEPARATOR = '&';
  * Otherwise, pull the protocol/domain/port from base URL and append the href.
  */
 export const getUrlFromHref = (href: string, baseUrl: string): string => {
-  const rootUrl = urlParse(href, baseUrl, true);
+  const rootUrl = urlParse(href, baseUrl, false);
   return rootUrl.toString();
 };
 

--- a/src/services/url/index.test.js
+++ b/src/services/url/index.test.js
@@ -21,6 +21,11 @@ describe('getUrlFromHref', () => {
     const baseUrl = 'http://baz';
     expect(Url.getUrlFromHref(href, baseUrl)).toEqual('http://baz/bar');
   });
+  it('preserves multiple query params', () => {
+    const href = '/bar?a=1&a=2';
+    const baseUrl = 'http://baz';
+    expect(Url.getUrlFromHref(href, baseUrl)).toEqual('http://baz/bar?a=1&a=2');
+  });
 });
 
 describe('addParamsToUrl', () => {


### PR DESCRIPTION
I discovered a quirk of the `url-parse` library: the default url parser does not preserve duplicate query params: https://github.com/unshiftio/url-parse/issues/163

This breaks URL passing in our app. In this case, the fix is to tell the library not to parse the query string. Added a regression test. 