### PR TITLE
Implement set-value behavior for form inputs

### DIFF
--- a/examples/advanced_behaviors/index.xml
+++ b/examples/advanced_behaviors/index.xml
@@ -93,6 +93,13 @@
           <text style="Item__Label">Dispatch Event</text>
           <text style="Item__Chevron">&gt;</text>
         </item>
+        <item href="/advanced_behaviors/set_value/index.xml"
+              key="set_value"
+              show-during-load="loadingScreen"
+              style="Item">
+          <text style="Item__Label">Set Value</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
       </list>
     </body>
   </screen>

--- a/examples/advanced_behaviors/set_value/index.xml
+++ b/examples/advanced_behaviors/set_value/index.xml
@@ -1,0 +1,346 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style id="Header"
+             alignItems="center"
+             backgroundColor="white"
+             borderBottomColor="#eee"
+             borderBottomWidth="1"
+             flexDirection="row"
+             height="72"
+             paddingLeft="24"
+             paddingRight="24"
+             paddingTop="24" />
+      <style id="Header__Back"
+             color="blue"
+             fontSize="16"
+             fontWeight="600"
+             paddingRight="16" />
+      <style id="Header__Title"
+             color="black"
+             fontSize="24"
+             fontWeight="600" />
+      <style id="Body"
+             backgroundColor="white"
+             flex="1" />
+      <style id="Description"
+             fontSize="16"
+             fontWeight="500"
+             margin="24"
+             marginTop="16"
+             marginBottom="0" />
+      <style id="Item"
+             alignItems="center"
+             borderBottomColor="#eee"
+             borderBottomWidth="1"
+             flex="1"
+             flexDirection="row"
+             height="48"
+             justifyContent="space-between"
+             paddingLeft="24"
+             paddingRight="24" />
+      <style id="Item__Label"
+             fontSize="18"
+             fontWeight="normal" />
+      <style id="Item__Chevron"
+             fontSize="18"
+             fontWeight="bold" />
+      <style id="Button"
+             backgroundColor="#63CB76"
+             borderRadius="16"
+             flexDirection="row"
+             justifyContent="center"
+             margin="24"
+             padding="24" />
+      <style id="Button__Label"
+             color="white"
+             fontSize="24"
+             fontWeight="bold" />
+      <style id="Main"
+             flex="1" />
+      <style id="Containers"
+             flex="1"
+             flexDirection="row"
+             marginLeft="24"
+             marginRight="24" />
+      <style id="Container"
+             flex="1" />
+      <style id="FormGroup"
+             flex="1"
+             marginLeft="24"
+             marginRight="24"
+             marginBottom="16"
+             marginTop="8" />
+      <style id="input"
+             borderBottomColor="#E1E1E1"
+             borderBottomWidth="1"
+             borderColor="#4E4D4D"
+             flex="1"
+             fontSize="16"
+             fontWeight="normal"
+             paddingBottom="8"
+             paddingTop="8">
+      <style id="input__text"
+             fontSize="16"
+             fontWeight="normal"></style>
+        <modifier pressed="true">
+          <style borderBottomColor="green" />
+        </modifier>
+        <modifier focused="true">
+          <style borderBottomColor="#4778FF" />
+        </modifier>
+      </style>
+      <style id="section" marginLeft="24" fontSize="18" fontWeight="bold" marginTop="8" />
+      <style id="PickerModal"
+             backgroundColor="white"
+             borderTopColor="#E1E1E1"
+             borderTopWidth="1"
+             shadowOffsetX="0"
+             shadowOffsetY="-5"
+             shadowOpacity="0.2"
+             shadowRadius="5" />
+      <style id="PickerModal__text"
+             color="blue"
+             fontSize="16"
+             fontWeight="600"
+             marginBottom="16"
+             padding="24">
+        <modifier pressed="true">
+          <style opacity="0.5" />
+        </modifier>
+      </style>
+      <style id="Tags"
+             flex="1"
+             flexDirection="row"
+             flexWrap="wrap"
+             justifyContent="flex-start"
+             marginTop="8" />
+      <style id="Tag"
+             borderColor="#bdc4c4"
+             borderRadius="32"
+             borderWidth="1"
+             marginBottom="8"
+             marginRight="8"
+             paddingBottom="8"
+             paddingLeft="16"
+             paddingRight="16"
+             paddingTop="8">
+        <modifier selected="true">
+          <style backgroundColor="#4778ff"
+                 borderColor="white" />
+        </modifier>
+      </style>
+      <style id="Tag__Label"
+             color="#4e4d4d"
+             fontSize="16"
+             fontWeight="bold"
+             lineHeight="18">
+        <modifier selected="true">
+          <style color="white" />
+        </modifier>
+      </style>
+      <style id="links"
+        flexDirection="row" />
+      <style id="link" color="#4778FF" fontWeight="bold" marginTop="8" marginRight="16" />
+
+    </styles>
+    <body style="Body">
+      <header style="Header">
+        <text action="back"
+              href="#"
+              style="Header__Back">Back</text>
+        <text style="Header__Title">Set Value</text>
+      </header>
+      <view style="Main" scroll="true">
+        <view style="FormGroup">
+          <view style="links">
+            <text style="link">
+              <behavior action="set-value" value="Multi" target="id_tf" />
+              <behavior action="set-value" value="Multi" target="id_ta" />
+              <behavior action="set-value" value="Ramen" target="id_ss" />
+              <behavior action="set-value" value="2" target="id_pf" />
+              <behavior action="set-value" value="2019-04-02" target="id_df" />
+              <behavior action="set-value" value="on" target="id_s" />
+              Set all
+            </text>
+            <text style="link">
+              <behavior action="set-value" value="" target="id_tf" />
+              <behavior action="set-value" value="" target="id_ta" />
+              <behavior action="set-value" value="" target="id_pf" />
+              <behavior action="set-value" value="" target="id_ss" />
+              <behavior action="set-value" value="" target="id_df" />
+              <behavior action="set-value" value="off" target="id_s" />
+              Clear all
+            </text>
+          </view>
+          <view style="links">
+            <text style="link">
+              <behavior action="set-value" value="Multi" target="id_tf" delay="500" />
+              <behavior action="set-value" value="Multi" target="id_ta" delay="1000" />
+              <behavior action="set-value" value="Ramen" target="id_ss" delay="1500" />
+              <behavior action="set-value" value="2" target="id_pf" delay="2000" />
+              <behavior action="set-value" value="2019-04-02" target="id_df" delay="2500" />
+              <behavior action="set-value" value="on" target="id_s" delay="3000" />
+              Set all with delay
+            </text>
+            <text style="link">
+              <behavior action="set-value" value="" target="id_tf" delay="500" />
+              <behavior action="set-value" value="" target="id_ta" delay="1000" />
+              <behavior action="set-value" value="" target="id_ss" delay="1500" />
+              <behavior action="set-value" value="" target="id_pf" delay="2000" />
+              <behavior action="set-value" value="" target="id_df" delay="2500" />
+              <behavior action="set-value" value="off" target="id_s" delay="3000" />
+              Clear all with delay
+            </text>
+          </view>
+
+          <view style="links">
+            <text style="link">
+              <behavior action="set-value" value="Multi" target="id_tf" delay="500" show-during-load="id_tf_loading" />
+              <behavior action="set-value" value="Multi" target="id_ta" delay="1000" show-during-load="id_ta_loading" />
+              <behavior action="set-value" value="Ramen" target="id_ss" delay="1500" show-during-load="id_ss_loading" />
+              <behavior action="set-value" value="2" target="id_pf" delay="2000" show-during-load="id_pf_loading" />
+              <behavior action="set-value" value="2019-04-02" target="id_df" delay="2500" show-during-load="id_df_loading" />
+              <behavior action="set-value" value="on" target="id_s" delay="3000" show-during-load="id_s_loading" />
+              Set all with indicator
+            </text>
+            <text style="link">
+              <behavior action="set-value" value="" target="id_tf" delay="500" show-during-load="id_tf_loading" />
+              <behavior action="set-value" value="" target="id_ta" delay="1000" show-during-load="id_ta_loading" />
+              <behavior action="set-value" value="" target="id_ss" delay="1500" show-during-load="id_ss_loading" />
+              <behavior action="set-value" value="" target="id_pf" delay="2000" show-during-load="id_pf_loading" />
+              <behavior action="set-value" value="" target="id_df" delay="2500" show-during-load="id_df_loading" />
+              <behavior action="set-value" value="off" target="id_s" delay="3000" show-during-load="id_s_loading" />
+              Clear all with indicator
+            </text>
+          </view>
+        </view>
+
+        <text style="section">Text fields</text>
+        <view style="FormGroup">
+          <text style="label" hide="true" id="id_tf_loading">Loading...</text>
+          <text-field id="id_tf"
+                      name="tf"
+                      placeholder="Text field"
+                      placeholderTextColor="#8D9494"
+                      style="input" />
+          <text style="link" action="set-value" value="Test" target="id_tf">
+            Set value to "Test"
+          </text>
+          <text style="link" action="set-value" value="" target="id_tf">
+            Clear value
+          </text>
+        </view>
+
+        <text style="section">Text areas</text>
+        <view style="FormGroup">
+          <text style="label" hide="true" id="id_ta_loading">Loading...</text>
+          <text-area id="id_ta"
+                      name="ta"
+                      placeholder="Text area"
+                      placeholderTextColor="#8D9494"
+                      style="input" />
+          <text style="link" action="set-value" value="Test&#10;Multi&#10;Line" target="id_ta">
+            Set multi-line value
+          </text>
+          <text style="link" action="set-value" value="" target="id_ta">
+            Clear value
+          </text>
+        </view>
+
+        <text style="section">Select Single</text>
+        <view style="FormGroup">
+          <text style="label" hide="true" id="id_ss_loading">Loading...</text>
+          <select-single id="id_ss" name="ss" style="Tags">
+            <option style="Tag"
+                    value="Ramen">
+              <text style="Tag__Label">Ramen</text>
+            </option>
+            <option style="Tag"
+                    value="Sushi">
+              <text style="Tag__Label">Sushi</text>
+            </option>
+            <option style="Tag"
+                    value="Pizza">
+              <text style="Tag__Label">Pizza</text>
+            </option>
+            <option style="Tag"
+                    value="Chinese">
+              <text style="Tag__Label">Chinese</text>
+            </option>
+          </select-single>
+          <text style="link" action="set-value" value="Sushi" target="id_ss">
+            Select "Sushi"
+          </text>
+          <text style="link" action="set-value" value="bogus" target="id_ss">
+            Clear
+          </text>
+        </view>
+
+        <text style="section">Picker fields</text>
+        <view style="FormGroup">
+          <text style="label" hide="true" id="id_pf_loading">Loading...</text>
+          <picker-field field-style="input"
+                        field-text-style="input__text"
+                        name="pf"
+                        id="id_pf"
+                        modal-style="PickerModal"
+                        modal-text-style="PickerModal__text"
+                        placeholder="Select choice"
+                        placeholderTextColor="#8D9494">
+            <picker-item label="No choice"
+                         value="" />
+            <picker-item label="Choice 0"
+                         value="0" />
+            <picker-item label="Choice 1"
+                         value="1" />
+            <picker-item label="Choice 2"
+                         value="2" />
+            <picker-item label="Choice 3"
+                         value="3" />
+            <picker-item label="Choice 4"
+                         value="4" />
+          </picker-field>
+          <text style="link" action="set-value" value="4" target="id_pf">
+            Select 4
+          </text>
+          <text style="link" action="set-value" value="" target="id_pf">
+            Clear
+          </text>
+        </view>
+
+        <text style="section">Date field</text>
+        <view style="FormGroup">
+          <text style="label" hide="true" id="id_df_loading">Loading...</text>
+          <date-field field-style="input"
+                      field-text-style="input__text"
+                      id="id_df"
+                      label-format="MMMM D, YYYY"
+                      modal-style="PickerModal"
+                      modal-text-style="PickerModal__text"
+                      placeholder="Select date"
+                      placeholderTextColor="#8D9494" />
+          <text style="link" action="set-value" value="2019-10-06" target="id_df">
+            Select "2019-10-06"
+          </text>
+          <text style="link" action="set-value" value="" target="id_df">
+            Clear
+          </text>
+        </view>
+
+        <text style="section">Switch</text>
+        <view style="FormGroup">
+          <text style="label" hide="true" id="id_s_loading">Loading...</text>
+          <switch id="id_s" name="s" value="off" />
+          <text style="link" action="set-value" value="on" target="id_s">
+            Turn on
+          </text>
+          <text style="link" action="set-value" value="off" target="id_s">
+            Turn off
+          </text>
+        </view>
+
+      </view>
+    </body>
+  </screen>
+</doc>

--- a/src/behaviors/hv-hide/index.js
+++ b/src/behaviors/hv-hide/index.js
@@ -1,5 +1,6 @@
 // @flow
 
+import * as Behaviors from 'hyperview/src/services/behaviors';
 import type {
   DOMString,
   Document,
@@ -9,10 +10,6 @@ import type {
   HvUpdateRoot,
 } from 'hyperview/src/types';
 import { later, shallowCloneToRoot } from 'hyperview/src/services';
-import {
-  setIndicatorsAfterLoad,
-  setIndicatorsBeforeLoad,
-} from 'hyperview/src/services/behaviors';
 
 export default {
   action: 'hide',
@@ -51,7 +48,7 @@ export default {
 
       // If using delay, we need to undo the indicators shown earlier.
       if (delay > 0) {
-        newRoot = setIndicatorsAfterLoad(
+        newRoot = Behaviors.setIndicatorsAfterLoad(
           showIndicatorIds,
           hideIndicatorIds,
           newRoot,
@@ -67,7 +64,7 @@ export default {
       hideElement();
     } else {
       // If there's a delay, first trigger the indicators before the hide
-      const newRoot = setIndicatorsBeforeLoad(
+      const newRoot = Behaviors.setIndicatorsBeforeLoad(
         showIndicatorIds,
         hideIndicatorIds,
         getRoot(),

--- a/src/behaviors/hv-set-value/index.js
+++ b/src/behaviors/hv-set-value/index.js
@@ -1,5 +1,6 @@
 // @flow
 
+import * as Behaviors from 'hyperview/src/services/behaviors';
 import type {
   DOMString,
   Document,
@@ -9,10 +10,8 @@ import type {
   HvUpdateRoot,
 } from 'hyperview/src/types';
 import { later, shallowCloneToRoot } from 'hyperview/src/services';
-import {
-  setIndicatorsAfterLoad,
-  setIndicatorsBeforeLoad,
-} from 'hyperview/src/services/behaviors';
+
+const ID_SEPARATOR = ' ';
 
 export default {
   action: 'set-value',
@@ -24,6 +23,7 @@ export default {
   ) => {
     const targetId: ?DOMString = element.getAttribute('target');
     if (!targetId) {
+      console.warn('[behaviors/set-value]: missing "target" attribute');
       return;
     }
 
@@ -35,10 +35,10 @@ export default {
 
     const showIndicatorIds: Array<string> = (
       element.getAttribute('show-during-load') || ''
-    ).split(' ');
+    ).split(ID_SEPARATOR);
     const hideIndicatorIds: Array<string> = (
       element.getAttribute('hide-during-load') || ''
-    ).split(' ');
+    ).split(ID_SEPARATOR);
 
     const setValue = () => {
       const doc: Document = getRoot();
@@ -53,7 +53,7 @@ export default {
 
       // If using delay, we need to undo the indicators shown earlier.
       if (delay > 0) {
-        newRoot = setIndicatorsAfterLoad(
+        newRoot = Behaviors.setIndicatorsAfterLoad(
           showIndicatorIds,
           hideIndicatorIds,
           newRoot,
@@ -69,7 +69,7 @@ export default {
       setValue();
     } else {
       // If there's a delay, first trigger the indicators before the show.
-      const newRoot = setIndicatorsBeforeLoad(
+      const newRoot = Behaviors.setIndicatorsBeforeLoad(
         showIndicatorIds,
         hideIndicatorIds,
         getRoot(),

--- a/src/behaviors/hv-set-value/index.js
+++ b/src/behaviors/hv-set-value/index.js
@@ -1,0 +1,85 @@
+// @flow
+
+import type {
+  DOMString,
+  Document,
+  Element,
+  HvComponentOnUpdate,
+  HvGetRoot,
+  HvUpdateRoot,
+} from 'hyperview/src/types';
+import { later, shallowCloneToRoot } from 'hyperview/src/services';
+import {
+  setIndicatorsAfterLoad,
+  setIndicatorsBeforeLoad,
+} from 'hyperview/src/services/behaviors';
+
+export default {
+  action: 'set-value',
+  callback: (
+    element: Element,
+    onUpdate: HvComponentOnUpdate,
+    getRoot: HvGetRoot,
+    updateRoot: HvUpdateRoot,
+  ) => {
+    const targetId: ?DOMString = element.getAttribute('target');
+    if (!targetId) {
+      return;
+    }
+
+    const newValue: string = element.getAttribute('value') || '';
+
+    const delayAttr: string = element.getAttribute('delay') || '0';
+    const parsedDelay: number = parseInt(delayAttr, 10);
+    const delay: number = isNaN(parsedDelay) ? 0 : parsedDelay;
+
+    const showIndicatorIds: Array<string> = (
+      element.getAttribute('show-during-load') || ''
+    ).split(' ');
+    const hideIndicatorIds: Array<string> = (
+      element.getAttribute('hide-during-load') || ''
+    ).split(' ');
+
+    const setValue = () => {
+      const doc: Document = getRoot();
+      const targetElement: ?Element = doc.getElementById(targetId);
+      if (!targetElement) {
+        return;
+      }
+
+      // Show the target
+      targetElement.setAttribute('value', newValue);
+      let newRoot: Document = shallowCloneToRoot(targetElement);
+
+      // If using delay, we need to undo the indicators shown earlier.
+      if (delay > 0) {
+        newRoot = setIndicatorsAfterLoad(
+          showIndicatorIds,
+          hideIndicatorIds,
+          newRoot,
+        );
+      }
+      // Update the DOM with the new shown state and finished indicators.
+      updateRoot(newRoot);
+    };
+
+    if (delay === 0) {
+      // If there's no delay, show target immediately without showing/hiding
+      // any indicators.
+      setValue();
+    } else {
+      // If there's a delay, first trigger the indicators before the show.
+      const newRoot = setIndicatorsBeforeLoad(
+        showIndicatorIds,
+        hideIndicatorIds,
+        getRoot(),
+      );
+      // Update the DOM to reflect the new state of the indicators.
+      updateRoot(newRoot);
+      // Wait for the delay then show the target.
+      later(delay)
+        .then(setValue)
+        .catch(setValue);
+    }
+  },
+};

--- a/src/behaviors/hv-show/index.js
+++ b/src/behaviors/hv-show/index.js
@@ -1,5 +1,6 @@
 // @flow
 
+import * as Behaviors from 'hyperview/src/services/behaviors';
 import type {
   DOMString,
   Document,
@@ -9,10 +10,6 @@ import type {
   HvUpdateRoot,
 } from 'hyperview/src/types';
 import { later, shallowCloneToRoot } from 'hyperview/src/services';
-import {
-  setIndicatorsAfterLoad,
-  setIndicatorsBeforeLoad,
-} from 'hyperview/src/services/behaviors';
 
 export default {
   action: 'show',
@@ -51,7 +48,7 @@ export default {
 
       // If using delay, we need to undo the indicators shown earlier.
       if (delay > 0) {
-        newRoot = setIndicatorsAfterLoad(
+        newRoot = Behaviors.setIndicatorsAfterLoad(
           showIndicatorIds,
           hideIndicatorIds,
           newRoot,
@@ -67,7 +64,7 @@ export default {
       showElement();
     } else {
       // If there's a delay, first trigger the indicators before the show.
-      const newRoot = setIndicatorsBeforeLoad(
+      const newRoot = Behaviors.setIndicatorsBeforeLoad(
         showIndicatorIds,
         hideIndicatorIds,
         getRoot(),

--- a/src/behaviors/hv-toggle/index.js
+++ b/src/behaviors/hv-toggle/index.js
@@ -1,5 +1,6 @@
 // @flow
 
+import * as Behaviors from 'hyperview/src/services/behaviors';
 import type {
   DOMString,
   Document,
@@ -9,10 +10,6 @@ import type {
   HvUpdateRoot,
 } from 'hyperview/src/types';
 import { later, shallowCloneToRoot } from 'hyperview/src/services';
-import {
-  setIndicatorsAfterLoad,
-  setIndicatorsBeforeLoad,
-} from 'hyperview/src/services/behaviors';
 
 export default {
   action: 'toggle',
@@ -54,7 +51,7 @@ export default {
 
       // If using the delay, we need to undo the indicators shown earlier.
       if (delay > 0) {
-        newRoot = setIndicatorsAfterLoad(
+        newRoot = Behaviors.setIndicatorsAfterLoad(
           showIndicatorIds,
           hideIndicatorIds,
           newRoot,
@@ -70,7 +67,7 @@ export default {
       toggleElement();
     } else {
       // If there's a delay, first trigger the indicators before the toggle.
-      const newRoot = setIndicatorsBeforeLoad(
+      const newRoot = Behaviors.setIndicatorsBeforeLoad(
         showIndicatorIds,
         hideIndicatorIds,
         getRoot(),

--- a/src/components/hv-date-field/index.js
+++ b/src/components/hv-date-field/index.js
@@ -286,14 +286,18 @@ export default class HvDateField extends PureComponent<Props, State> {
                 onPressOut={this.toggleCancelPress}
                 onPress={this.onModalCancel}
               >
-                <Text style={cancelTextStyle}>{cancelLabel}</Text>
+                <View>
+                  <Text style={cancelTextStyle}>{cancelLabel}</Text>
+                </View>
               </TouchableWithoutFeedback>
               <TouchableWithoutFeedback
                 onPressIn={this.toggleSavePress}
                 onPressOut={this.toggleSavePress}
                 onPress={this.onModalDone}
               >
-                <Text style={doneTextStyle}>{doneLabel}</Text>
+                <View>
+                  <Text style={doneTextStyle}>{doneLabel}</Text>
+                </View>
               </TouchableWithoutFeedback>
             </View>
             {this.renderPickeriOS()}

--- a/src/components/hv-date-field/index.js
+++ b/src/components/hv-date-field/index.js
@@ -49,7 +49,7 @@ export default class HvDateField extends PureComponent<Props, State> {
     super(props);
     const element: Element = props.element;
     const stringValue: ?DOMString = element.getAttribute('value');
-    const value: ?Date = this.createDateFromString(stringValue);
+    const value: ?Date = HvDateField.createDateFromString(stringValue);
     const pickerValue: Date = value || new Date();
     this.state = {
       // Date that's selected in the field. Can be null.
@@ -63,45 +63,11 @@ export default class HvDateField extends PureComponent<Props, State> {
     };
   }
 
-  componentDidUpdate = (prevProps: Props, prevState: State) => {
-    // TODO: move to React hooks once we adopt them across the codebase.
-    if (Platform.OS === 'android') {
-      if (!prevState.fieldPressed && this.state.fieldPressed) {
-        this.showPickerAndroid();
-      }
-    }
-
-    const { element } = this.props;
-    if (element.hasAttribute('value')) {
-      const newValue = element.getAttribute('value') || '';
-      const newDate = this.createDateFromString(newValue);
-      // NOTE(adam): We convert from date to strings for the comparison to normalize the representation.
-      if (
-        this.createStringFromDate(newDate) !==
-        this.createStringFromDate(this.state.value)
-      ) {
-        this.setState({ value: newDate, pickerValue: newDate || new Date() });
-      }
-    }
-  };
-
-  /**
-   * Given a ISO date string (YYYY-MM-DD), returns a Date object. If the string
-   * cannot be parsed or is falsey, returns null.
-   */
-  createDateFromString = (value: ?string): ?Date => {
-    if (!value) {
-      return null;
-    }
-    const [year, month, day] = value.split('-').map(p => parseInt(p, 10));
-    return new Date(year, month - 1, day);
-  };
-
   /**
    * Given a Date object, returns an ISO date string (YYYY-MM-DD). If the Date
    * object is null, returns an empty string.
    */
-  createStringFromDate = (date: ?Date): string => {
+  static createStringFromDate = (date: ?Date): string => {
     if (!date) {
       return '';
     }
@@ -109,6 +75,44 @@ export default class HvDateField extends PureComponent<Props, State> {
     const month = date.getUTCMonth() + 1;
     const day = date.getUTCDate();
     return `${year}-${month}-${day}`;
+  };
+
+  /**
+   * Given a ISO date string (YYYY-MM-DD), returns a Date object. If the string
+   * cannot be parsed or is falsey, returns null.
+   */
+  static createDateFromString = (value: ?string): ?Date => {
+    if (!value) {
+      return null;
+    }
+    const [year, month, day] = value.split('-').map(p => parseInt(p, 10));
+    return new Date(year, month - 1, day);
+  };
+
+  static getDerivedStateFromProps(nextProps: Props, prevState: State): State {
+    const { element } = nextProps;
+    if (element.hasAttribute('value')) {
+      const newValue = element.getAttribute('value') || '';
+      const newDate = HvDateField.createDateFromString(newValue);
+
+      // NOTE(adam): We convert from date to strings for the comparison to normalize the representation.
+      if (
+        HvDateField.createStringFromDate(newDate) !==
+        HvDateField.createStringFromDate(prevState.value)
+      ) {
+        return { value: newDate, pickerValue: newDate || new Date() };
+      }
+    }
+    return {};
+  }
+
+  componentDidUpdate = (prevProps: Props, prevState: State) => {
+    // TODO: move to React hooks once we adopt them across the codebase.
+    if (Platform.OS === 'android') {
+      if (!prevState.fieldPressed && this.state.fieldPressed) {
+        this.showPickerAndroid();
+      }
+    }
   };
 
   toggleFieldPress = () => {
@@ -154,7 +158,7 @@ export default class HvDateField extends PureComponent<Props, State> {
     // selected value gets serialized in the parent form.
     element.setAttribute(
       'value',
-      this.createStringFromDate(this.state.pickerValue),
+      HvDateField.createStringFromDate(this.state.pickerValue),
     );
   };
 
@@ -166,8 +170,8 @@ export default class HvDateField extends PureComponent<Props, State> {
   showPickerAndroid = async () => {
     const maxValue: ?DOMString = this.props.element.getAttribute('max');
     const minValue: ?DOMString = this.props.element.getAttribute('min');
-    const minDate: ?Date = this.createDateFromString(minValue);
-    const maxDate: ?Date = this.createDateFromString(maxValue);
+    const minDate: ?Date = HvDateField.createDateFromString(minValue);
+    const maxDate: ?Date = HvDateField.createDateFromString(maxValue);
     const options: Object = {
       date: this.state.pickerValue,
     };
@@ -195,8 +199,8 @@ export default class HvDateField extends PureComponent<Props, State> {
   renderPickeriOS = (): ReactNode => {
     const minValue: ?DOMString = this.props.element.getAttribute('min');
     const maxValue: ?DOMString = this.props.element.getAttribute('max');
-    const minDate: ?Date = this.createDateFromString(minValue);
-    const maxDate: ?Date = this.createDateFromString(maxValue);
+    const minDate: ?Date = HvDateField.createDateFromString(minValue);
+    const maxDate: ?Date = HvDateField.createDateFromString(maxValue);
     const onDateChange = (value: Date) => {
       this.setState({ pickerValue: value });
     };

--- a/src/components/hv-date-field/index.js
+++ b/src/components/hv-date-field/index.js
@@ -100,10 +100,18 @@ export default class HvDateField extends PureComponent<Props, State> {
         HvDateField.createStringFromDate(newDate) !==
         HvDateField.createStringFromDate(prevState.value)
       ) {
-        return { value: newDate, pickerValue: newDate || new Date() };
+        const { focused, fieldPressed, donePressed, cancelPressed } = prevState;
+        return {
+          cancelPressed,
+          donePressed,
+          fieldPressed,
+          focused,
+          pickerValue: newDate || new Date(),
+          value: newDate,
+        };
       }
     }
-    return {};
+    return prevState;
   }
 
   componentDidUpdate = (prevProps: Props, prevState: State) => {

--- a/src/components/hv-date-field/index.js
+++ b/src/components/hv-date-field/index.js
@@ -70,6 +70,19 @@ export default class HvDateField extends PureComponent<Props, State> {
         this.showPickerAndroid();
       }
     }
+
+    const { element } = this.props;
+    if (element.hasAttribute('value')) {
+      const newValue = element.getAttribute('value') || '';
+      const newDate = this.createDateFromString(newValue);
+      // NOTE(adam): We convert from date to strings for the comparison to normalize the representation.
+      if (
+        this.createStringFromDate(newDate) !==
+        this.createStringFromDate(this.state.value)
+      ) {
+        this.setState({ value: newDate, pickerValue: newDate || new Date() });
+      }
+    }
   };
 
   /**

--- a/src/components/hv-date-field/stories/basic.xml
+++ b/src/components/hv-date-field/stories/basic.xml
@@ -1,0 +1,65 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style
+        id="Body"
+        backgroundColor="white"
+        flex="1"
+      />
+      <style
+        id="Input"
+        borderBottomColor="#E1E1E1"
+        borderBottomWidth="1"
+        borderColor="#4E4D4D"
+        flex="1"
+        paddingBottom="8"
+        paddingTop="8"
+      >
+        <modifier pressed="true">
+          <style borderBottomColor="#4778FF" />
+        </modifier>
+        <modifier focused="true">
+          <style borderBottomColor="#4778FF" />
+        </modifier>
+      </style>
+      <style
+        id="Input__Text"
+        fontSize="16"
+        fontWeight="normal"
+      />
+      <style
+        id="PickerModal"
+        backgroundColor="white"
+        borderTopColor="#E1E1E1"
+        borderTopWidth="1"
+        shadowOffsetX="0"
+        shadowOffsetY="-5"
+        shadowOpacity="0.2"
+        shadowRadius="5"
+      />
+      <style
+        id="PickerModal__text"
+        color="blue"
+        fontSize="16"
+        fontWeight="600"
+        marginBottom="16"
+        padding="24"
+      >
+        <modifier pressed="true">
+          <style opacity="0.5" />
+        </modifier>
+      </style>
+    </styles>
+    <body style="Body">
+      <date-field
+        field-style="Input"
+        field-text-style="Input__Text"
+        label-format="MMMM D, YYYY"
+        modal-style="PickerModal"
+        modal-text-style="PickerModal__text"
+        placeholder="Select date"
+        placeholderTextColor="#8D9494"
+      />
+    </body>
+  </screen>
+</doc>

--- a/src/components/hv-date-field/stories/index.js
+++ b/src/components/hv-date-field/stories/index.js
@@ -1,0 +1,22 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import * as Helpers from 'hyperview/storybook/helpers';
+import HvDateField from 'hyperview/src/components/hv-date-field';
+import React from 'react';
+
+const createStory = Helpers.stories(HvDateField);
+createStory('basic', ({ element, stylesheets }) => (
+  <HvDateField
+    element={element}
+    options={Helpers.getOptions()}
+    stylesheets={stylesheets}
+  />
+));

--- a/src/components/hv-picker-field/index.js
+++ b/src/components/hv-picker-field/index.js
@@ -67,6 +67,7 @@ export default class HvPickerField extends PureComponent<Props, State> {
     const { element } = this.props;
     const newValue = element.getAttribute('value') || '';
     if (newValue !== this.state.value) {
+      // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ value: newValue });
     }
   }

--- a/src/components/hv-picker-field/index.js
+++ b/src/components/hv-picker-field/index.js
@@ -63,13 +63,9 @@ export default class HvPickerField extends PureComponent<Props, State> {
     };
   }
 
-  componentDidUpdate() {
-    const { element } = this.props;
-    const newValue = element.getAttribute('value') || '';
-    if (newValue !== this.state.value) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({ value: newValue });
-    }
+  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
+    const value = nextProps.element.getAttribute('value') || '';
+    return value !== prevState.value ? { value } : {};
   }
 
   toggleFieldPress = () => {

--- a/src/components/hv-picker-field/index.js
+++ b/src/components/hv-picker-field/index.js
@@ -224,14 +224,18 @@ export default class HvPickerField extends PureComponent<Props, State> {
                 onPressOut={this.toggleCancelPress}
                 onPress={this.onModalCancel}
               >
-                <Text style={cancelTextStyle}>{cancelLabel}</Text>
+                <View>
+                  <Text style={cancelTextStyle}>{cancelLabel}</Text>
+                </View>
               </TouchableWithoutFeedback>
               <TouchableWithoutFeedback
                 onPressIn={this.toggleSavePress}
                 onPressOut={this.toggleSavePress}
                 onPress={this.onModalDone}
               >
-                <Text style={doneTextStyle}>{doneLabel}</Text>
+                <View>
+                  <Text style={doneTextStyle}>{doneLabel}</Text>
+                </View>
               </TouchableWithoutFeedback>
             </View>
             {this.renderPicker()}

--- a/src/components/hv-picker-field/index.js
+++ b/src/components/hv-picker-field/index.js
@@ -63,6 +63,14 @@ export default class HvPickerField extends PureComponent<Props, State> {
     };
   }
 
+  componentDidUpdate() {
+    const { element } = this.props;
+    const newValue = element.getAttribute('value') || '';
+    if (newValue !== this.state.value) {
+      this.setState({ value: newValue });
+    }
+  }
+
   toggleFieldPress = () => {
     this.setState({ fieldPressed: !this.state.fieldPressed });
   };

--- a/src/components/hv-select-single/index.js
+++ b/src/components/hv-select-single/index.js
@@ -25,6 +25,17 @@ export default class HvSelectSingle extends PureComponent<Props> {
     this.onSelect = this.onSelect.bind(this);
   }
 
+  componentDidUpdate() {
+    const { element } = this.props;
+    if (element.hasAttribute('value')) {
+      // NOTE(adam): we need to remove the attribute before
+      // selection, since selection will update the component.
+      const newValue = element.getAttribute('value');
+      element.removeAttribute('value');
+      this.onSelect(newValue);
+    }
+  }
+
   /**
    * Callback passed to children. Option components invoke this callback when selected.
    * SingleSelect will update the XML DOM so that only the selected option is has a

--- a/src/components/hv-switch/index.js
+++ b/src/components/hv-switch/index.js
@@ -29,6 +29,14 @@ export default class HvSwitch extends PureComponent<Props, State> {
     };
   }
 
+  componentDidUpdate() {
+    const { element } = this.props;
+    const newValue = element.getAttribute('value') === 'on';
+    if (newValue !== this.state.value) {
+      this.setState({ value: newValue });
+    }
+  }
+
   render() {
     if (this.props.element.getAttribute('hide') === 'true') {
       return null;

--- a/src/components/hv-switch/index.js
+++ b/src/components/hv-switch/index.js
@@ -30,8 +30,7 @@ export default class HvSwitch extends PureComponent<Props, State> {
   }
 
   componentDidUpdate() {
-    const { element } = this.props;
-    const newValue = element.getAttribute('value') === 'on';
+    const newValue = this.props.element.getAttribute('value') === 'on';
     if (newValue !== this.state.value) {
       this.setState({ value: newValue });
     }

--- a/src/components/hv-switch/index.js
+++ b/src/components/hv-switch/index.js
@@ -22,9 +22,8 @@ export default class HvSwitch extends PureComponent<Props, State> {
   state: State;
 
   constructor(props: Props) {
-    const { element } = props;
     super(props);
-    const initialValue = element.getAttribute('value') === 'on';
+    const initialValue = props.element.getAttribute('value') === 'on';
     this.state = {
       value: initialValue,
     };

--- a/src/components/hv-switch/index.js
+++ b/src/components/hv-switch/index.js
@@ -32,6 +32,7 @@ export default class HvSwitch extends PureComponent<Props, State> {
   componentDidUpdate() {
     const newValue = this.props.element.getAttribute('value') === 'on';
     if (newValue !== this.state.value) {
+      // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ value: newValue });
     }
   }

--- a/src/components/hv-switch/index.js
+++ b/src/components/hv-switch/index.js
@@ -29,12 +29,9 @@ export default class HvSwitch extends PureComponent<Props, State> {
     };
   }
 
-  componentDidUpdate() {
-    const newValue = this.props.element.getAttribute('value') === 'on';
-    if (newValue !== this.state.value) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({ value: newValue });
-    }
+  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
+    const value = nextProps.element.getAttribute('value') === 'on';
+    return value !== prevState.value ? { value } : {};
   }
 
   render() {

--- a/src/components/hv-switch/stories/basic.xml
+++ b/src/components/hv-switch/stories/basic.xml
@@ -1,0 +1,22 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style
+        id="Body"
+        backgroundColor="white"
+        flex="1"
+      />
+      <style
+        id="switch"
+        backgroundColor="#E1E1E1"
+      >
+        <modifier selected="true">
+          <style backgroundColor="#4778FF" />
+        </modifier>
+      </style>
+    </styles>
+    <body style="Body">
+      <switch style="switch" name="switch1" value="on" />
+    </body>
+  </screen>
+</doc>

--- a/src/components/hv-switch/stories/index.js
+++ b/src/components/hv-switch/stories/index.js
@@ -1,0 +1,24 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import * as Helpers from 'hyperview/storybook/helpers';
+import HvSwitch from 'hyperview/src/components/hv-switch';
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+
+const createStory = Helpers.stories(HvSwitch);
+createStory('basic', ({ element, stylesheets }) => (
+  <HvSwitch
+    element={element}
+    onUpdate={action('onUpdate')}
+    options={Helpers.getOptions()}
+    stylesheets={stylesheets}
+  />
+));

--- a/src/components/hv-text-area/index.js
+++ b/src/components/hv-text-area/index.js
@@ -27,6 +27,14 @@ export default class HvTextArea extends PureComponent<Props, State> {
     };
   }
 
+  componentDidUpdate() {
+    const { element } = this.props;
+    const newValue = element.getAttribute('value') || '';
+    if (newValue !== this.state.value) {
+      this.setState({ value: newValue });
+    }
+  }
+
   render() {
     const { element, stylesheets, options } = this.props;
 

--- a/src/components/hv-text-area/index.js
+++ b/src/components/hv-text-area/index.js
@@ -27,13 +27,9 @@ export default class HvTextArea extends PureComponent<Props, State> {
     };
   }
 
-  componentDidUpdate() {
-    const { element } = this.props;
-    const newValue = element.getAttribute('value') || '';
-    if (newValue !== this.state.value) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({ value: newValue });
-    }
+  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
+    const value = nextProps.element.getAttribute('value') || '';
+    return value !== prevState.value ? { value } : {};
   }
 
   render() {

--- a/src/components/hv-text-area/index.js
+++ b/src/components/hv-text-area/index.js
@@ -31,6 +31,7 @@ export default class HvTextArea extends PureComponent<Props, State> {
     const { element } = this.props;
     const newValue = element.getAttribute('value') || '';
     if (newValue !== this.state.value) {
+      // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ value: newValue });
     }
   }

--- a/src/components/hv-text-field/index.js
+++ b/src/components/hv-text-field/index.js
@@ -11,6 +11,7 @@
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import type { Props, State } from './types';
 import React, { PureComponent } from 'react';
+import type { Element } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import { TextInput } from 'react-native';
 import TinyMask from 'hyperview/src/mask.js';
@@ -46,11 +47,13 @@ export default class HvTextField extends PureComponent<Props, State> {
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {
     const { element } = nextProps;
-    const value = HvTextField.getFormattedValue(
+    const newValue = HvTextField.getFormattedValue(
       element,
       element.getAttribute('value') || '',
     );
-    return value !== prevState.value ? { value } : {};
+    return newValue !== prevState.value
+      ? { focused: prevState.focused, value: newValue }
+      : prevState;
   }
 
   render() {

--- a/src/components/hv-text-field/index.js
+++ b/src/components/hv-text-field/index.js
@@ -33,9 +33,7 @@ export default class HvTextField extends PureComponent<Props, State> {
    * Currently supports the "mask" attribute, which will be applied
    * to format the provided value.
    */
-  getFormattedValue = (value: string) => {
-    const { element } = this.props;
-
+  static getFormattedValue = (element: Element, value: string) => {
     if (!element.hasAttribute('mask')) {
       return value;
     }
@@ -46,15 +44,13 @@ export default class HvTextField extends PureComponent<Props, State> {
     return mask.mask(value) || '';
   };
 
-  componentDidUpdate() {
-    const { element } = this.props;
-    const newValue = this.getFormattedValue(
+  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
+    const { element } = nextProps;
+    const value = HvTextField.getFormattedValue(
+      element,
       element.getAttribute('value') || '',
     );
-    if (newValue !== this.state.value) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({ value: newValue });
-    }
+    return value !== prevState.value ? { value } : {};
   }
 
   render() {
@@ -78,7 +74,7 @@ export default class HvTextField extends PureComponent<Props, State> {
       onChangeText: value => {
         // Render the formatted value and store the formatted value
         // in state (on the XML element).
-        const formattedValue = this.getFormattedValue(value);
+        const formattedValue = HvTextField.getFormattedValue(element, value);
         this.setState({ value: formattedValue });
         element.setAttribute('value', formattedValue);
       },

--- a/src/components/hv-text-field/index.js
+++ b/src/components/hv-text-field/index.js
@@ -52,6 +52,7 @@ export default class HvTextField extends PureComponent<Props, State> {
       element.getAttribute('value') || '',
     );
     if (newValue !== this.state.value) {
+      // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ value: newValue });
     }
   }

--- a/src/components/hv-text-field/index.js
+++ b/src/components/hv-text-field/index.js
@@ -46,6 +46,16 @@ export default class HvTextField extends PureComponent<Props, State> {
     return mask.mask(value) || '';
   };
 
+  componentDidUpdate() {
+    const { element } = this.props;
+    const newValue = this.getFormattedValue(
+      element.getAttribute('value') || '',
+    );
+    if (newValue !== this.state.value) {
+      this.setState({ value: newValue });
+    }
+  }
+
   render() {
     const { element, stylesheets, options } = this.props;
 

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -28,7 +28,7 @@ import type { PressHandlers, Props, State } from './types';
 import React, { PureComponent } from 'react';
 import { RefreshControl, ScrollView, TouchableOpacity } from 'react-native';
 import VisibilityDetectingView from 'hyperview/src/VisibilityDetectingView';
-import { XMLSerializer } from 'xmldom';
+import { XMLSerializer } from 'xmldom-instawork';
 // eslint-disable-next-line import/no-internal-modules
 import eventEmitter from 'tiny-emitter/instance';
 import { getBehaviorElements } from 'hyperview/src/services';

--- a/src/services/behaviors/index.js
+++ b/src/services/behaviors/index.js
@@ -16,12 +16,20 @@ import type {
 } from 'hyperview/src/types';
 import HvAlert from 'hyperview/src/behaviors/hv-alert';
 import HvHide from 'hyperview/src/behaviors/hv-hide';
+import HvSetValue from 'hyperview/src/behaviors/hv-set-value';
 import HvShare from 'hyperview/src/behaviors/hv-share';
 import HvShow from 'hyperview/src/behaviors/hv-show';
 import HvToggle from 'hyperview/src/behaviors/hv-toggle';
 import { shallowCloneToRoot } from 'hyperview/src/services';
 
-const HYPERVIEW_BEHAVIORS = [HvAlert, HvHide, HvShare, HvShow, HvToggle];
+const HYPERVIEW_BEHAVIORS = [
+  HvAlert,
+  HvHide,
+  HvSetValue,
+  HvShare,
+  HvShow,
+  HvToggle,
+];
 
 export const getRegistry = (behaviors: HvBehavior[] = []): BehaviorRegistry =>
   [...HYPERVIEW_BEHAVIORS, ...behaviors].reduce(

--- a/storybook/stories.gen.js
+++ b/storybook/stories.gen.js
@@ -1,4 +1,5 @@
 // DO NOT EDIT: Auto-generate this file by running `yarn generate`
+import '../src/components/hv-date-field/stories/index.js';
 import '../src/components/hv-image/stories/index.js';
 import '../src/components/hv-list/stories/index.js';
 import '../src/components/hv-option/stories/index.js';
@@ -7,6 +8,7 @@ import '../src/components/hv-section-list/stories/index.js';
 import '../src/components/hv-select-multiple/stories/index.js';
 import '../src/components/hv-select-single/stories/index.js';
 import '../src/components/hv-spinner/stories/index.js';
+import '../src/components/hv-switch/stories/index.js';
 import '../src/components/hv-text-area/stories/index.js';
 import '../src/components/hv-text-field/stories/index.js';
 import '../src/components/hv-web-view/stories/index.js';

--- a/storybook/templates.gen.js
+++ b/storybook/templates.gen.js
@@ -1,5 +1,72 @@
 // DO NOT EDIT: Auto-generate this file by running `yarn generate`
 export default {
+  'hyperview/src/components/hv-date-field/stories/basic.xml':
+  `<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style
+        id="Body"
+        backgroundColor="white"
+        flex="1"
+      />
+      <style
+        id="Input"
+        borderBottomColor="#E1E1E1"
+        borderBottomWidth="1"
+        borderColor="#4E4D4D"
+        flex="1"
+        paddingBottom="8"
+        paddingTop="8"
+      >
+        <modifier pressed="true">
+          <style borderBottomColor="#4778FF" />
+        </modifier>
+        <modifier focused="true">
+          <style borderBottomColor="#4778FF" />
+        </modifier>
+      </style>
+      <style
+        id="Input__Text"
+        fontSize="16"
+        fontWeight="normal"
+      />
+      <style
+        id="PickerModal"
+        backgroundColor="white"
+        borderTopColor="#E1E1E1"
+        borderTopWidth="1"
+        shadowOffsetX="0"
+        shadowOffsetY="-5"
+        shadowOpacity="0.2"
+        shadowRadius="5"
+      />
+      <style
+        id="PickerModal__text"
+        color="blue"
+        fontSize="16"
+        fontWeight="600"
+        marginBottom="16"
+        padding="24"
+      >
+        <modifier pressed="true">
+          <style opacity="0.5" />
+        </modifier>
+      </style>
+    </styles>
+    <body style="Body">
+      <date-field
+        field-style="Input"
+        field-text-style="Input__Text"
+        label-format="MMMM D, YYYY"
+        modal-style="PickerModal"
+        modal-text-style="PickerModal__text"
+        placeholder="Select date"
+        placeholderTextColor="#8D9494"
+      />
+    </body>
+  </screen>
+</doc>
+`,
   'hyperview/src/components/hv-image/stories/basic.xml':
   `<doc xmlns="https://hyperview.org/hyperview">
   <screen>
@@ -1675,6 +1742,30 @@ export default {
     </styles>
     <body style="Body">
       <spinner color="red" />
+    </body>
+  </screen>
+</doc>
+`,
+  'hyperview/src/components/hv-switch/stories/basic.xml':
+  `<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style
+        id="Body"
+        backgroundColor="white"
+        flex="1"
+      />
+      <style
+        id="switch"
+        backgroundColor="#E1E1E1"
+      >
+        <modifier selected="true">
+          <style backgroundColor="#4778FF" />
+        </modifier>
+      </style>
+    </styles>
+    <body style="Body">
+      <switch style="switch" name="switch1" value="on" />
     </body>
   </screen>
 </doc>


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/923014529014430/1143376661956577/f)

Proof of concept of a new `set-value` action that allows settings form input values via a behavior. Example syntax:
`<behavior action="set-value" target="myDateField" value="new value" />`

When this behavior triggers, it will set the text field with id `myDateField` to `new value`.

I've implemented support for this behavior in `<text-field>`, `<text-area>`, `<picker-field>`, `<date-field>`, and `<select-single>`. Need to add `<select-multiple>` and `<switch>`.

**NOTE**: In order to get this feature working, I needed to update the component state in `componentDidUpdate` by reading the attributes in the `element` prop. This is against our eslint rules which I slienced for now. To properly address this issue, the input elements would need to be re-written to not keep any local state (we could maybe keep the local state on the `element`). This is a bigger re-write that I didn't want to do now, but I added a tracking task for it [here](https://app.asana.com/0/923014529014430/1144293982403313/f).