### PR TITLE
Fix: action="close" / action="back" behavior causing incorrect reload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -462,7 +462,7 @@ export default class HyperScreen extends React.Component {
     } else if (Object.values(NAV_ACTIONS).includes(action)) {
       this.navigation.setUrl(this.state.url);
       this.navigation.setDocument(this.state.doc);
-      this.navigation.navigate(href, action, currentElement, opts);
+      this.navigation.navigate(href || Navigation.ANCHOR_ID_SEPARATOR, action, currentElement, opts);
     } else if (Object.values(UPDATE_ACTIONS).includes(action)) {
       this.onUpdateFragment(href, action, currentElement, opts);
     } else if (action === ACTIONS.SWAP) {

--- a/src/services/navigation/index.js
+++ b/src/services/navigation/index.js
@@ -13,7 +13,7 @@ import type {
 import { NAV_ACTIONS } from 'hyperview/src/types';
 import { getFormData } from 'hyperview/src/services';
 
-const ANCHOR_ID_SEPARATOR = '#';
+export const ANCHOR_ID_SEPARATOR = '#';
 const QUERY_SEPARATOR = '?';
 
 const getHrefKey = (href: string): string => href.split(QUERY_SEPARATOR)[0];


### PR DESCRIPTION
Default `href` to `#` when attribute not set, so that navigation service does not try to load a different URL.

https://app.asana.com/0/244065166232575/1153051694506464/f