### PR TITLE
Feature: Add spinner mode in date-field

### DIFF
--- a/examples/ui_elements/forms/date_field.xml
+++ b/examples/ui_elements/forms/date_field.xml
@@ -152,6 +152,17 @@
                       placeholderTextColor="#8D9494" />
         </view>
         <view style="FormGroup">
+          <text style="label">Date field in spinner mode</text>
+          <date-field field-style="Input"
+                      field-text-style="Input__Text"
+                      label-format="MMMM D, YYYY"
+                      modal-style="PickerModal"
+                      modal-text-style="PickerModal__text"
+                      mode="spinner"
+                      placeholder="Select date"
+                      placeholderTextColor="#8D9494" />
+        </view>
+        <view style="FormGroup">
           <text style="label">Filled date field</text>
           <date-field field-style="Input"
                       field-text-style="Input__Text"

--- a/src/components/hv-date-field/index.js
+++ b/src/components/hv-date-field/index.js
@@ -178,6 +178,7 @@ export default class HvDateField extends PureComponent<Props, State> {
   showPickerAndroid = async () => {
     const maxValue: ?DOMString = this.props.element.getAttribute('max');
     const minValue: ?DOMString = this.props.element.getAttribute('min');
+    const mode: ?string = this.props.element.getAttribute('mode');
     const minDate: ?Date = HvDateField.createDateFromString(minValue);
     const maxDate: ?Date = HvDateField.createDateFromString(maxValue);
     const options: Object = {
@@ -189,6 +190,7 @@ export default class HvDateField extends PureComponent<Props, State> {
     if (maxDate) {
       options.maxDate = maxDate;
     }
+    options.mode = mode || 'default';
     const openAction = await DatePickerAndroid.open(options);
     const { action, year, month, day } = openAction;
     if (action === DatePickerAndroid.dateSetAction) {


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/406825428187110/1153389465437105/f)

Expose a `mode` attribute for `date-field` element which passes on the options to `DatePickerAndroid.open` method.

## UI States

| Default (calendar) mode | Spinner mode |
| - | - |
| ![Screenshot_1576577574](https://user-images.githubusercontent.com/6682655/70987181-66a65d80-20e5-11ea-8bea-824776f7c21f.png) | ![Screenshot_1576577577](https://user-images.githubusercontent.com/6682655/70987204-6efe9880-20e5-11ea-87d7-970d65923162.png) |

