### PR TITLE
Expose events API

### DIFF
--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -8,11 +8,11 @@
  *
  */
 
+import * as Events from 'hyperview/src/services/events';
 import * as Render from 'hyperview/src/services/render';
 import {
   ACTIONS,
   NAV_ACTIONS,
-  ON_EVENT_DISPATCH,
   PRESS_TRIGGERS,
   TRIGGERS,
   UPDATE_ACTIONS,
@@ -29,8 +29,6 @@ import React, { PureComponent } from 'react';
 import { RefreshControl, ScrollView, TouchableOpacity } from 'react-native';
 import VisibilityDetectingView from 'hyperview/src/VisibilityDetectingView';
 import { XMLSerializer } from 'xmldom-instawork';
-// eslint-disable-next-line import/no-internal-modules
-import eventEmitter from 'tiny-emitter/instance';
 import { getBehaviorElements } from 'hyperview/src/services';
 
 /**
@@ -48,7 +46,7 @@ export default class HyperRef extends PureComponent<Props, State> {
     this.triggerLoadBehaviors();
 
     // Register event listener for on-event triggers
-    eventEmitter.on(ON_EVENT_DISPATCH, this.onEventDispatch);
+    Events.subscribe(this.onEventDispatch);
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -60,7 +58,7 @@ export default class HyperRef extends PureComponent<Props, State> {
 
   componentWillUnmount() {
     // Remove event listener for on-event triggers to avoid memory leaks
-    eventEmitter.off(ON_EVENT_DISPATCH, this.onEventDispatch);
+    Events.unsubscribe(this.onEventDispatch);
   }
 
   onEventDispatch = (eventName: string) => {

--- a/src/services/events/index.js
+++ b/src/services/events/index.js
@@ -1,0 +1,24 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { ON_EVENT_DISPATCH } from 'hyperview/src/types';
+import TinyEmitter from 'tiny-emitter';
+
+const tinyEmitter = new TinyEmitter();
+
+export const dispatch = (eventName: string) => {
+  tinyEmitter.emit(ON_EVENT_DISPATCH, eventName);
+};
+
+export const subscribe = (callback: (eventName: string) => void) =>
+  tinyEmitter.on(ON_EVENT_DISPATCH, callback);
+
+export const unsubscribe = (callback: (eventName: string) => void) =>
+  tinyEmitter.off(ON_EVENT_DISPATCH, callback);


### PR DESCRIPTION
Extract out event dispatcher/listener code into a dedicated service, and expose it as part of the public API.

Relates to https://app.asana.com/0/244065166232575/1158603120086761/f