### PR TITLE
Proposal: cumulative mode for select-single

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -14,7 +14,7 @@
     "@expo/samples": "2.1.1",
     "expo": "^35.0.0",
     "expo-cli": "^3.2.2",
-    "hyperview": "0.16.3",
+    "hyperview": "0.22.0",
     "moment": "^2.24.0",
     "react": "16.8.3",
     "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -5754,9 +5754,9 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-hyperview@0.16.3:
-  version "0.16.3"
-  resolved "https://registry.yarnpkg.com/hyperview/-/hyperview-0.16.3.tgz#1dfedda516437a78833623bf5bb19b1b561d10d2"
+hyperview@0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/hyperview/-/hyperview-0.22.0.tgz#7d648e11be8904dc74aa892ba52df5df0f8134b7"
   dependencies:
     react-native-webview "5.12.0"
     tiny-emitter "2.1.0"

--- a/docs/reference_selectsingle.md
+++ b/docs/reference_selectsingle.md
@@ -33,6 +33,7 @@ A `<select-single>` element most often appears within a `<form>` element. Howeve
 ## Attributes
 
 - [`name`](#name)
+- [`cumulative`](#cumulative)
 - [`style`](#style)
 - [`id`](#id)
 - [`hide`](#hide)
@@ -44,6 +45,26 @@ A `<select-single>` element most often appears within a `<form>` element. Howeve
 | string | **Yes**  |
 
 The name of the selection input within a `<form>` element. This name will be used when serializing a form to form data that gets sent in a server request.
+
+#### `cumulative`
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
+
+Use `cumulative="true"` to render all preceding `<option>`s as selected and all subsequent `<options>` as unselected. The most frequent application is for rating UIs, like a 1-5 star rating. For example:
+
+```xml
+<select-single style="Stars" cumulative="true">
+  <option style="Star" value="1" />
+  <option style="Star" value="2" />
+  <option style="Star" value="3" />
+  <option style="Star" value="4" />
+  <option style="Star" value="5" />
+</select-single>
+```
+
+When the user presses the star option with value 3, stars 1 and 2 will also render as selected. However, the `<select-single>` input will only have a value of 3.
 
 #### `style`
 

--- a/examples/case_studies/rating_modal.xml
+++ b/examples/case_studies/rating_modal.xml
@@ -76,11 +76,16 @@
              flexDirection="row"
              margin="0"
              marginTop="24" />
-      <style id="Rating__Star"
-             height="40"
-             marginRight="10"
-             width="40" />
-      <style id="Rating__Star--Filled" />
+      <style id="Rating__Star" height="40" width="40" marginRight="10">
+        <modifier selected="true">
+          <style height="0" width="0" />
+        </modifier>
+      </style>
+      <style id="Rating__Star--Filled" height="0" width="0" marginRight="10">
+        <modifier selected="true">
+          <style height="40" width="40" />
+        </modifier>
+      </style>
       <style id="BottomSheet"
              borderTopColor="#e1e1e1"
              borderTopWidth="1"
@@ -188,34 +193,46 @@
           <text style="WorkerInfo__Time">Fri Aug 3, 7:00 PM - 1:00 AM</text>
           <view id="rating"
                 style="RatingContainer">
-            <view id="star0"
-                  style="Rating">
-              <image action="replace-inner"
-                     href="#star1"
-                     source="/case_studies/star_empty@2x.png"
-                     style="Rating__Star"
-                     target="rating" />
-              <image action="replace-inner"
-                     href="#star2"
-                     source="/case_studies/star_empty@2x.png"
-                     style="Rating__Star"
-                     target="rating" />
-              <image action="replace-inner"
-                     href="#star3"
-                     source="/case_studies/star_empty@2x.png"
-                     style="Rating__Star"
-                     target="rating" />
-              <image action="replace-inner"
-                     href="#star4"
-                     source="/case_studies/star_empty@2x.png"
-                     style="Rating__Star"
-                     target="rating" />
-              <image action="replace-inner"
-                     href="#star5"
-                     source="/case_studies/star_empty@2x.png"
-                     style="Rating__Star"
-                     target="rating" />
-            </view>
+
+            <select-single cumulative="true" style="Rating">
+
+              <option value="1">
+                <image source="/case_studies/star_empty@2x.png"
+                       style="Rating__Star" />
+                <image source="/case_studies/star_filled@2x.png"
+                       style="Rating__Star--Filled" />
+              </option>
+
+              <option value="2">
+                <image source="/case_studies/star_empty@2x.png"
+                       style="Rating__Star" />
+                <image source="/case_studies/star_filled@2x.png"
+                       style="Rating__Star--Filled" />
+              </option>
+
+              <option value="3">
+                <image source="/case_studies/star_empty@2x.png"
+                       style="Rating__Star" />
+                <image source="/case_studies/star_filled@2x.png"
+                       style="Rating__Star--Filled" />
+              </option>
+
+              <option value="4">
+                <image source="/case_studies/star_empty@2x.png"
+                       style="Rating__Star" />
+                <image source="/case_studies/star_filled@2x.png"
+                       style="Rating__Star--Filled" />
+              </option>
+
+              <option value="5">
+                <image source="/case_studies/star_empty@2x.png"
+                       style="Rating__Star" />
+                <image source="/case_studies/star_filled@2x.png"
+                       style="Rating__Star--Filled" />
+              </option>
+
+            </select-single>
+
           </view>
         </view>
         <view style="FormGroup">
@@ -248,147 +265,5 @@
         </view>
       </view>
     </body>
-    <view hide="true">
-      <view id="star1"
-            style="Rating">
-        <image action="replace-inner"
-               href="#star1"
-               source="star_filled@2x.png"
-               style="Rating__Star Rating__Star--Filled"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star2"
-               source="/case_studies/star_empty@2x.png"
-               style="Rating__Star"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star3"
-               source="/case_studies/star_empty@2x.png"
-               style="Rating__Star"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star4"
-               source="/case_studies/star_empty@2x.png"
-               style="Rating__Star"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star5"
-               source="/case_studies/star_empty@2x.png"
-               style="Rating__Star"
-               target="rating" />
-      </view>
-      <view id="star2"
-            style="Rating">
-        <image action="replace-inner"
-               href="#star1"
-               source="/case_studies/star_filled@2x.png"
-               style="Rating__Star Rating__Star--Filled"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star2"
-               source="/case_studies/star_filled@2x.png"
-               style="Rating__Star Rating__Star--Filled"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star3"
-               source="/case_studies/star_empty@2x.png"
-               style="Rating__Star"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star4"
-               source="/case_studies/star_empty@2x.png"
-               style="Rating__Star"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star5"
-               source="/case_studies/star_empty@2x.png"
-               style="Rating__Star"
-               target="rating" />
-      </view>
-      <view id="star3"
-            style="Rating">
-        <image action="replace-inner"
-               href="#star1"
-               source="/case_studies/star_filled@2x.png"
-               style="Rating__Star Rating__Star--Filled"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star2"
-               source="/case_studies/star_filled@2x.png"
-               style="Rating__Star Rating__Star--Filled"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star3"
-               source="/case_studies/star_filled@2x.png"
-               style="Rating__Star Rating__Star--Filled"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star4"
-               source="/case_studies/star_empty@2x.png"
-               style="Rating__Star"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star5"
-               source="/case_studies/star_empty@2x.png"
-               style="Rating__Star"
-               target="rating" />
-      </view>
-      <view id="star4"
-            style="Rating">
-        <image action="replace-inner"
-               href="#star1"
-               source="/case_studies/star_filled@2x.png"
-               style="Rating__Star Rating__Star--Filled"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star2"
-               source="/case_studies/star_filled@2x.png"
-               style="Rating__Star Rating__Star--Filled"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star3"
-               source="/case_studies/star_filled@2x.png"
-               style="Rating__Star Rating__Star--Filled"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star4"
-               source="/case_studies/star_filled@2x.png"
-               style="Rating__Star Rating__Star--Filled"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star5"
-               source="/case_studies/star_empty@2x.png"
-               style="Rating__Star"
-               target="rating" />
-      </view>
-      <view id="star5"
-            style="Rating">
-        <image action="replace-inner"
-               href="#star1"
-               source="/case_studies/star_filled@2x.png"
-               style="Rating__Star Rating__Star--Filled"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star2"
-               source="/case_studies/star_filled@2x.png"
-               style="Rating__Star Rating__Star--Filled"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star3"
-               source="/case_studies/star_filled@2x.png"
-               style="Rating__Star Rating__Star--Filled"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star4"
-               source="/case_studies/star_filled@2x.png"
-               style="Rating__Star Rating__Star--Filled"
-               target="rating" />
-        <image action="replace-inner"
-               href="#star5"
-               source="/case_studies/star_filled@2x.png"
-               style="Rating__Star Rating__Star--Filled"
-               target="rating" />
-      </view>
-    </view>
   </screen>
 </doc>

--- a/examples/case_studies/rating_modal.xml
+++ b/examples/case_studies/rating_modal.xml
@@ -201,6 +201,7 @@
                        style="Rating__Star" />
                 <image source="/case_studies/star_filled@2x.png"
                        style="Rating__Star--Filled" />
+                <behavior trigger="select" action="dispatch-event" event-name="select1" />
               </option>
 
               <option value="2">
@@ -208,6 +209,7 @@
                        style="Rating__Star" />
                 <image source="/case_studies/star_filled@2x.png"
                        style="Rating__Star--Filled" />
+                <behavior trigger="select" action="dispatch-event" event-name="select2" />
               </option>
 
               <option value="3">
@@ -215,6 +217,7 @@
                        style="Rating__Star" />
                 <image source="/case_studies/star_filled@2x.png"
                        style="Rating__Star--Filled" />
+                <behavior trigger="select" action="dispatch-event" event-name="select3" />
               </option>
 
               <option value="4">
@@ -222,6 +225,7 @@
                        style="Rating__Star" />
                 <image source="/case_studies/star_filled@2x.png"
                        style="Rating__Star--Filled" />
+                <behavior trigger="select" action="dispatch-event" event-name="select4" />
               </option>
 
               <option value="5">
@@ -229,19 +233,46 @@
                        style="Rating__Star" />
                 <image source="/case_studies/star_filled@2x.png"
                        style="Rating__Star--Filled" />
+                <behavior trigger="select" action="dispatch-event" event-name="select5" />
               </option>
 
             </select-single>
 
           </view>
         </view>
-        <view style="FormGroup">
+
+        <view>
+          <view style="FormGroup" id="heading">
+          </view>
+
+          <behavior trigger="on-event" event-name="select1" action="replace-inner" href="#heading-1" target="heading" />
+          <behavior trigger="on-event" event-name="select2" action="replace-inner" href="#heading-2" target="heading" />
+          <behavior trigger="on-event" event-name="select3" action="replace-inner" href="#heading-3" target="heading" />
+          <behavior trigger="on-event" event-name="select4" action="replace-inner" href="#heading-4" target="heading" />
+          <behavior trigger="on-event" event-name="select5" action="replace-inner" href="#heading-5" target="heading" />
+
+          <view hide="true">
+            <text id="heading-1">Too bad, can you tell us more?</text>
+            <text id="heading-2">Too bad, can you tell us more?</text>
+            <text id="heading-3">What could be better?</text>
+            <text id="heading-4">That's good</text>
+            <text id="heading-5">Great!</text>
+          </view>
+        </view>
+
+        <behavior trigger="on-event" event-name="select1" action="show" target="other-feedback" />
+        <behavior trigger="on-event" event-name="select2" action="show" target="other-feedback" />
+        <behavior trigger="on-event" event-name="select3" action="show" target="other-feedback" />
+        <behavior trigger="on-event" event-name="select4" action="show" target="other-feedback" />
+        <behavior trigger="on-event" event-name="select5" action="show" target="other-feedback" />
+        <view style="FormGroup" hide="true" id="other-feedback">
           <text-area focusStyles="input input--focused"
                      outerStyles="outerInput"
                      placeholder="Any other feedback?"
                      placeholderTextColor="#8D9494"
                      style="input" />
         </view>
+
       </view>
       <view style="BottomSheet">
         <view id="saveButtonContainer"

--- a/examples/ui_elements/forms/select_single.xml
+++ b/examples/ui_elements/forms/select_single.xml
@@ -139,6 +139,25 @@
                  width="32" />
         </modifier>
       </style>
+
+
+      <style id="SelectBars"
+        flexDirection="row"
+        justifyContent="center"
+        marginTop="24"
+        marginBottom="40"
+        paddingBottom="24"
+      >
+      <style id="SelectBar"
+        width="32"
+        height="40"
+        backgroundColor="#ddd"
+        marginRight="16"
+      >
+        <modifier selected="true">
+          <style backgroundColor="#4778ff" />
+        </modifier>
+      </style>
     </styles>
     <body style="Body">
       <header style="Header">
@@ -149,6 +168,8 @@
       </header>
       <view scroll="true"
             style="Main">
+
+
         <text style="Description">Simple Select</text>
         <select-single name="choice"
                        style="Select">
@@ -243,6 +264,17 @@
             <text style="SelectCustom__Label">Unknown</text>
           </option>
         </select-single>
+
+
+        <text style="Description">Cumulative</text>
+        <select-single style="SelectBars" cumulative="true">
+          <option style="SelectBar" value="1" />
+          <option style="SelectBar" value="2" />
+          <option style="SelectBar" value="3" />
+          <option style="SelectBar" value="4" />
+          <option style="SelectBar" value="5" />
+        </select-single>
+
       </view>
     </body>
   </screen>

--- a/examples/ui_elements/forms/select_single.xml
+++ b/examples/ui_elements/forms/select_single.xml
@@ -275,6 +275,15 @@
           <option style="SelectBar" value="5" />
         </select-single>
 
+        <text style="Description">Cumulative and selected</text>
+        <select-single style="SelectBars" cumulative="true">
+          <option style="SelectBar" value="1" />
+          <option style="SelectBar" value="2" />
+          <option style="SelectBar" value="3" selected="true" />
+          <option style="SelectBar" value="4" />
+          <option style="SelectBar" value="5" />
+        </select-single>
+
       </view>
     </body>
   </screen>

--- a/src/components/hv-option/index.js
+++ b/src/components/hv-option/index.js
@@ -105,14 +105,18 @@ export default class HvOption extends PureComponent<HvComponentProps, State> {
 
     const value = element.getAttribute('value');
     const selected = element.getAttribute('selected') === 'true';
+    const selectedAsCumulative =
+      element.getAttribute('selected-as-cumulative') === 'true';
+
+    const renderAsSelected = selected || selectedAsCumulative;
 
     // Updates options with pressed/selected state, so that child element can render
     // using the appropriate modifier styles.
     const newOptions = {
       ...options,
-      selected,
       pressed,
-      pressedSelected: pressed && selected,
+      selected: renderAsSelected,
+      pressedSelected: pressed && renderAsSelected,
     };
     const props = createProps(element, stylesheets, newOptions);
 

--- a/src/components/hv-select-single/index.js
+++ b/src/components/hv-select-single/index.js
@@ -46,16 +46,51 @@ export default class HvSelectSingle extends PureComponent<HvComponentProps> {
     const newElement = element.cloneNode(true);
     const options = newElement.getElementsByTagNameNS(
       Namespaces.HYPERVIEW,
-      'option',
+      LOCAL_NAME.OPTION,
     );
+
+    const isCumulative: boolean =
+      newElement.getAttribute('cumulative') === 'true';
+
+    // Calculate the index of the selected index. This is
+    // used in the cumulative mode, to render the preceding
+    // options as selected.
+    let selectedIndex: ?number = null;
     for (let i = 0; i < options.length; i += 1) {
       const opt = options.item(i);
       if (opt) {
         const value = opt.getAttribute('value');
+        if (value === selectedValue) {
+          selectedIndex = i;
+        }
+      }
+    }
+
+    for (let i = 0; i < options.length; i += 1) {
+      const opt = options.item(i);
+      if (opt) {
+        const value = opt.getAttribute('value');
+        // Only the option with the selected value
+        // should be rendered as selected.
         opt.setAttribute(
           'selected',
           value === selectedValue ? 'true' : 'false',
         );
+        // If using the cumulative mode, all options
+        // should be updated with a flag indicating if
+        // they should render as selected. Options
+        // preceding the selected one should be selected,
+        // the later options should be unselected.
+        if (
+          isCumulative &&
+          selectedIndex !== null &&
+          selectedIndex !== undefined
+        ) {
+          opt.setAttribute(
+            'selected-as-cumulative',
+            i < selectedIndex ? 'true' : 'false',
+          );
+        }
       }
     }
     onUpdate('#', 'swap', element, { newElement });

--- a/src/components/hv-select-single/index.js
+++ b/src/components/hv-select-single/index.js
@@ -56,12 +56,14 @@ export default class HvSelectSingle extends PureComponent<HvComponentProps> {
     // used in the cumulative mode, to render the preceding
     // options as selected.
     let selectedIndex: ?number = null;
-    for (let i = 0; i < options.length; i += 1) {
-      const opt = options.item(i);
-      if (opt) {
-        const value = opt.getAttribute('value');
-        if (value === selectedValue) {
-          selectedIndex = i;
+    if (isCumulative) {
+      for (let i = 0; i < options.length; i += 1) {
+        const opt = options.item(i);
+        if (opt) {
+          const value = opt.getAttribute('value');
+          if (value === selectedValue) {
+            selectedIndex = i;
+          }
         }
       }
     }

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -79,13 +79,15 @@ export default class HyperRef extends PureComponent<Props, State> {
       }
       return false;
     });
+    let time = 0;
     onEventBehaviors.forEach(behaviorElement => {
       const handler = this.createActionHandler(
         this.props.element,
         behaviorElement,
         this.props.onUpdate,
       );
-      handler();
+      setTimeout(handler, time);
+      time += 1;
       if (__DEV__) {
         const listenerElement: Element = behaviorElement.cloneNode(false);
         const caughtEvent: string = behaviorElement.getAttribute('event-name');

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -79,15 +79,13 @@ export default class HyperRef extends PureComponent<Props, State> {
       }
       return false;
     });
-    let time = 0;
     onEventBehaviors.forEach(behaviorElement => {
       const handler = this.createActionHandler(
         this.props.element,
         behaviorElement,
         this.props.onUpdate,
       );
-      setTimeout(handler, time);
-      time += 1;
+      setTimeout(handler, 0);
       if (__DEV__) {
         const listenerElement: Element = behaviorElement.cloneNode(false);
         const caughtEvent: string = behaviorElement.getAttribute('event-name');


### PR DESCRIPTION
Recently, we realized it's a bit cumbersome to implement star-ratings in Hyperview since we need to use hidden elements and swap out the star widget with different ones.

I realized that the rating widget is basically a `<select-single>`, except that it renders all `<option>` elements as selected if they precede the pressed one. So, we could implement ratings widgets if we added a `cumulative` mode to `<select-single>`:

```xml
<select-single name="rating" cumulative="true">
  <option value="1" style="bar" />
  <option value="2" style="bar" />
  <option value="3" style="bar" />
</select-single>
```
With this syntax, selecting "2" will render both "1" and "2" as selected. The form's data will only include `rating=2`.

I re-wrote the business rating case study example to mimic the UI recently implemented by @flochtililoch , with much less markup:

![rating](https://user-images.githubusercontent.com/1034502/73515466-3b808080-43aa-11ea-95f3-e345b3adede7.gif)