### PR TITLE
Fix: keyboard avoiding view prop

### DIFF
--- a/docs/reference_view.md
+++ b/docs/reference_view.md
@@ -49,6 +49,7 @@ A `<view>` element can only appear anywhere within a `<screen>` element.
 - [`style`](#style)
 - [`scroll`](#scroll)
 - [`scroll-orientation`](#scroll-orientation)
+- [`scroll-to-input-offset`](#scroll-to-input-offset)
 - [`id`](#id)
 - [`hide`](#hide)
 
@@ -79,6 +80,14 @@ An attribute indicating whether the content in the can be scrollable. The style 
 | **vertical** (default), horizontal | No       |
 
 An attribute indicating the direction in which the view will scroll.
+
+#### `scroll-to-input-offset`
+
+| Type   | Required                |
+| ------ | ----------------------- |
+| number | No (defauls to **120**) |
+
+An attribute defining an additional scroll offset to be applied to the view, when a `<text-field>` or `<text-area>` is focused. Only work in combination with attribute `scroll` set to `"true"`.
 
 #### `id`
 

--- a/docs/reference_view.md
+++ b/docs/reference_view.md
@@ -87,7 +87,7 @@ An attribute indicating the direction in which the view will scroll.
 | ------ | ----------------------- |
 | number | No (defauls to **120**) |
 
-An attribute defining an additional scroll offset to be applied to the view, when a `<text-field>` or `<text-area>` is focused. Only work in combination with attribute `scroll` set to `"true"`.
+An attribute defining an additional scroll offset to be applied to the view, when a `<text-field>` or `<text-area>` is focused. Only valid in combination with attribute `scroll` set to `"true"`.
 
 #### `id`
 

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -53,9 +53,15 @@ export default class HvView extends PureComponent<HvComponentProps> {
         const scrollToInputAdditionalOffset = element.getAttribute(
           'scroll-to-input-offset',
         );
-        props.scrollToInputAdditionalOffset = scrollToInputAdditionalOffset
-          ? parseInt(scrollToInputAdditionalOffset, 10)
-          : 120;
+        const defaultScrollToInputAdditionalOffset = 120;
+        if (scrollToInputAdditionalOffset) {
+          const parsedOffset = parseInt(scrollToInputAdditionalOffset, 10);
+          props.scrollToInputAdditionalOffset = isNaN(parsedOffset)
+            ? 0
+            : defaultScrollToInputAdditionalOffset;
+        } else {
+          props.scrollToInputAdditionalOffset = defaultScrollToInputAdditionalOffset;
+        }
 
         props.keyboardOpeningTime = 0;
         props.keyboardShouldPersistTaps = 'handled';

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -50,7 +50,13 @@ export default class HvView extends PureComponent<HvComponentProps> {
       const hasFields = textFields.length > 0 || textAreas.length > 0;
       c = hasFields ? KeyboardAwareScrollView : ScrollView;
       if (hasFields) {
-        props.extraScrollHeight = 32;
+        const scrollToInputAdditionalOffset = element.getAttribute(
+          'scroll-to-input-offset',
+        );
+        props.scrollToInputAdditionalOffset = scrollToInputAdditionalOffset
+          ? parseInt(scrollToInputAdditionalOffset, 10)
+          : 120;
+
         props.keyboardOpeningTime = 0;
         props.keyboardShouldPersistTaps = 'handled';
         props.scrollEventThrottle = 16;

--- a/src/components/hv-view/types.js
+++ b/src/components/hv-view/types.js
@@ -16,6 +16,7 @@ export type InternalProps = {|
   keyboardOpeningTime?: ?number,
   keyboardShouldPersistTaps?: ?string,
   scrollEventThrottle?: ?number,
+  scrollToInputAdditionalOffset?: ?number,
   getTextInputRefs?: ?() => [],
   horizontal?: ?boolean,
   style?: ?Array<StyleSheet<*>>,


### PR DESCRIPTION
Set `scrollToInputAdditionalOffset` prop of [`react-native-keyboard-aware-scrollview`](https://github.com/wix/react-native-keyboard-aware-scrollview). We were previously setting the prop `extraScrollHeight`, which is a prop of the module [`react-native-keyboard-aware-scroll-view`](https://github.com/APSL/react-native-keyboard-aware-scroll-view#readme)

Also allow overriding the default value of `120` with the prop `scroll-to-input-offset`
https://app.asana.com/0/987416201877098/1158164359079221/f