### PR TITLE
Fix: Nested lists

### DIFF
--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -69,10 +69,22 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
     const showScrollIndicator =
       element.getAttribute('shows-scroll-indicator') !== 'false';
 
+    // $FlowFixMe: call of method `getElementsByTagNameNS`. Method cannot be called on any member of intersection type
+    const itemElements = element.getElementsByTagNameNS(
+      Namespaces.HYPERVIEW,
+      'item',
+    );
+    const items = [];
+    for (let j = 0; j < itemElements.length; j += 1) {
+      const itemElement = itemElements.item(j);
+      if (itemElement.parentNode === element) {
+        items.push(itemElement);
+      }
+    }
+
     const listProps = {
       style,
-      // $FlowFixMe: see node_modules/react-native/Libraries/Lists/FlatList.js:73
-      data: element.getElementsByTagNameNS(Namespaces.HYPERVIEW, 'item'),
+      data: items,
       horizontal,
       keyExtractor: item => item.getAttribute('key'),
       // $FlowFixMe: return value should be of ?React.Element<any>

--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -77,7 +77,9 @@ export default class HvSectionList extends PureComponent<
         const items = [];
         for (let j = 0; j < itemElements.length; j += 1) {
           const itemElement = itemElements.item(j);
-          items.push(itemElement);
+          if (itemElement && itemElement.parentNode === sectionElement) {
+            items.push(itemElement);
+          }
         }
         const titleElement = sectionElement
           .getElementsByTagNameNS(Namespaces.HYPERVIEW, 'section-title')


### PR DESCRIPTION
Prevent list from rendering duplicated items by filtering item that match parent list/section

Given following markup:
```xml
<section-list>
    <section>
        <section-title>
            <text style="h6">Section 1</text>
        </section-title>
        <item>
            <text style="b3">Item 1-1</text>
            <list>
                <item style="mx-24"><text style="b3">Item 1-1-1</text></item>
                <item style="mx-24"><text style="b3">Item 1-1-2</text></item>
                <item style="mx-24"><text style="b3">Item 1-1-3</text></item>
            </list>
        </item>
        <item><text style="b3">Item 1-2</text></item>
        <item><text style="b3">Item 1-3</text></item>
    </section>
    <section>
        <section-title>
            <text style="h6">Section 2</text>
        </section-title>
        <item><text style="b3">Item 2-1</text></item>
    </section>
</section-list>
```

| Before | After |
|--------|------|
| <img width="117" alt="Screen Shot 2020-03-06 at 2 31 12 PM" src="https://user-images.githubusercontent.com/309515/76127682-286b5c80-5fb7-11ea-9631-7abe51d649bd.png"> | <img width="130" alt="Screen Shot 2020-03-06 at 2 06 32 PM" src="https://user-images.githubusercontent.com/309515/76127248-0f15e080-5fb6-11ea-8b70-c58effe83d25.png"> |

