### PR TITLE
Revert "Fix: Nested lists"

### DIFF
--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -69,22 +69,10 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
     const showScrollIndicator =
       element.getAttribute('shows-scroll-indicator') !== 'false';
 
-    // $FlowFixMe: call of method `getElementsByTagNameNS`. Method cannot be called on any member of intersection type
-    const itemElements = element.getElementsByTagNameNS(
-      Namespaces.HYPERVIEW,
-      'item',
-    );
-    const items = [];
-    for (let j = 0; j < itemElements.length; j += 1) {
-      const itemElement = itemElements.item(j);
-      if (itemElement.parentNode === element) {
-        items.push(itemElement);
-      }
-    }
-
     const listProps = {
       style,
-      data: items,
+      // $FlowFixMe: see node_modules/react-native/Libraries/Lists/FlatList.js:73
+      data: element.getElementsByTagNameNS(Namespaces.HYPERVIEW, 'item'),
       horizontal,
       keyExtractor: item => item.getAttribute('key'),
       // $FlowFixMe: return value should be of ?React.Element<any>

--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -77,9 +77,7 @@ export default class HvSectionList extends PureComponent<
         const items = [];
         for (let j = 0; j < itemElements.length; j += 1) {
           const itemElement = itemElements.item(j);
-          if (itemElement && itemElement.parentNode === sectionElement) {
-            items.push(itemElement);
-          }
+          items.push(itemElement);
         }
         const titleElement = sectionElement
           .getElementsByTagNameNS(Namespaces.HYPERVIEW, 'section-title')


### PR DESCRIPTION
Reverts Instawork/hyperview#131

This seemed to cause issues in a couple of places where a view wraps items, i.e.

```xml
<list>
  <view>
    <item>foo</item>
    <item>bar</item>
  </view>
</list>
```

[the spec](https://hyperview.org/docs/reference_list) doesn't mention anything on this topic, and it's unclear whether wrapping view should be a supported feature - if so we might need to find a different way to fix the original issue.

cc @adamstep for input