### PR TITLE
mark deprecated method as UNSAFE_

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -141,7 +141,7 @@ export default class HyperScreen extends React.Component {
    * If the navigation params have a different URL than the screen's URL, Update the
    * preload screen and URL to load.
    */
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const oldNavigationState = this.getNavigationState(this.props);
     const newNavigationState = this.getNavigationState(nextProps);
 


### PR DESCRIPTION
required for React Native Upgrade to 0.61.x