### PR TITLE
Proof of concept: cached Hyperview requests Part 1

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -15,6 +15,7 @@
     "expo": "^35.0.0",
     "expo-cli": "^3.2.2",
     "hyperview": "0.20.0",
+    "lru-cache": "^5.1.1",
     "moment": "^2.24.0",
     "react": "16.8.3",
     "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",

--- a/demo/package.json
+++ b/demo/package.json
@@ -15,7 +15,6 @@
     "expo": "^35.0.0",
     "expo-cli": "^3.2.2",
     "hyperview": "0.20.0",
-    "lru-cache": "^5.1.1",
     "moment": "^2.24.0",
     "react": "16.8.3",
     "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",

--- a/demo/package.json
+++ b/demo/package.json
@@ -14,7 +14,7 @@
     "@expo/samples": "2.1.1",
     "expo": "^35.0.0",
     "expo-cli": "^3.2.2",
-    "hyperview": "0.16.3",
+    "hyperview": "0.20.0",
     "moment": "^2.24.0",
     "react": "16.8.3",
     "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",

--- a/demo/screens/HyperviewScreen.js
+++ b/demo/screens/HyperviewScreen.js
@@ -10,6 +10,10 @@ import React, { PureComponent } from 'react';
 import Hyperview from 'hyperview';
 import moment from 'moment';
 
+
+const fetchCache = {};
+
+
 export default class HyperviewScreen extends React.PureComponent {
   goBack = (params, key) => {
     const navigation = this.props.navigation;
@@ -48,12 +52,54 @@ export default class HyperviewScreen extends React.PureComponent {
 
   formatDate = (date, format) => moment(date).format(format);
 
+  cachedFetch = (url, options) => {
+    let expiry = 1 * 60; // 5 min default
+    if (typeof options === 'number') {
+      expiry = options;
+      options = undefined;
+    } else if (typeof options === 'object') {
+      // I hope you didn't set it to 0 seconds
+      expiry = options.seconds || expiry;
+    }
+    // Use the URL as the cache key to sessionStorage
+    let cacheKey = url;
+    let cached = fetchCache[cacheKey];
+    let whenCached = fetchCache[cacheKey + ':ts'];
+    if (cached !== null && whenCached !== null) {
+      console.log('found in cache!');
+
+      let age = (Date.now() - whenCached) / 1000;
+      if (age < expiry) {
+        console.log('not expired, using!');
+        let response = cached.clone();
+        return Promise.resolve(response)
+      } else {
+        console.log('expired, deleting');
+        // We need to clean up this old key
+        delete fetchCache[cacheKey];
+        delete fetchCache[cacheKey + ':ts'];
+      }
+    }
+
+    console.log('not in cache, fetching...');
+    return fetch(url, options).then(response => {
+      // let's only store in cache if the content-type is
+      // JSON or something non-binary
+      if (response.status === 200) {
+        console.log('caching...');
+        fetchCache[cacheKey] = response.clone();
+        fetchCache[cacheKey+':ts'] = Date.now();
+      }
+      return response;
+    });
+  };
+
   /**
    * fetch function used by Hyperview screens. By default, it adds
    * header to prevent caching requests.
    */
   fetchWrapper = (input, init = { headers: {} }) => {
-    return fetch(input, {
+    return this.cachedFetch(input, {
       ...init,
       headers: {
         // Don't cache requests for the demo

--- a/demo/screens/HyperviewScreen.js
+++ b/demo/screens/HyperviewScreen.js
@@ -7,8 +7,7 @@
  */
 
 import React, { PureComponent } from 'react';
-import Hyperview from 'hyperview';
-import * as Cache from 'hyperview/src/services/cache';
+import Hyperview, { Cache } from 'hyperview';
 import moment from 'moment';
 
 const hyperviewCache = Cache.createCache(5e7); // 50 MB

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -5754,9 +5754,9 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-hyperview@0.16.3:
-  version "0.16.3"
-  resolved "https://registry.yarnpkg.com/hyperview/-/hyperview-0.16.3.tgz#1dfedda516437a78833623bf5bb19b1b561d10d2"
+hyperview@0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/hyperview/-/hyperview-0.20.0.tgz#e8b604dc048e3a0f4ed1abefd8e62ffa912cc9f3"
   dependencies:
     react-native-webview "5.12.0"
     tiny-emitter "2.1.0"

--- a/examples/ui_elements/index.xml
+++ b/examples/ui_elements/index.xml
@@ -55,6 +55,19 @@
               style="Header__Back">Back</text>
         <text style="Header__Title">UI Elements</text>
       </header>
+      <view id="status-stale" hide="true">
+        <spinner />
+        <text>Stale response</text>
+      </view>
+      <view id="status-revalidated" hide="true">
+        <text>Revalidated</text>
+      </view>
+
+      <behavior trigger="response-stale" action="show" target="status-stale" />
+      <behavior trigger="response-revalidated" action="hide" target="status-stale" />
+      <behavior trigger="response-revalidated" action="show" target="status-revalidated" />
+      <behavior trigger="response-revalidated" action="hide" target="status-revalidated" delay="1000" />
+
       <list>
         <item href="/ui_elements/view.xml"
               key="view"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-native-webview": "5.12.0",
     "tiny-emitter": "2.1.0",
     "url-parse": "1.4.3",
+    "whatwg-fetch": "^3.0.0",
     "xmldom-instawork": "0.0.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:lint": "eslint src",
     "test:render": "jest test/render.test.js --forceExit",
     "test:unit": "jest --testPathPattern src",
-    "test:xmlserver": "node server.js 8085",
+    "test:xmlserver": "node xml-server.js 8085",
     "test": "yarn generate test && yarn test:flow && yarn test:lint && yarn test:render && yarn test:unit"
   },
   "dependencies": {
@@ -69,6 +69,7 @@
     "husky": "1.2.1",
     "jest": "23.1.0",
     "mkdirp": "0.5.1",
+    "morgan": "^1.9.1",
     "prettier": "1.15.3",
     "pretty-quick": "1.8.0",
     "react": "16.6.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test": "yarn generate test && yarn test:flow && yarn test:lint && yarn test:render && yarn test:unit"
   },
   "dependencies": {
+    "lru-cache": "^5.1.1",
     "react-native-webview": "5.12.0",
     "tiny-emitter": "2.1.0",
     "url-parse": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:lint": "eslint src",
     "test:render": "jest test/render.test.js --forceExit",
     "test:unit": "jest --testPathPattern src",
-    "test:xmlserver": "http-server -c-1 -p 8085 ./examples",
+    "test:xmlserver": "node server.js 8085",
     "test": "yarn generate test && yarn test:flow && yarn test:lint && yarn test:render && yarn test:unit"
   },
   "dependencies": {
@@ -62,9 +62,9 @@
     "eslint-config-prettier": "3.3.0",
     "eslint-plugin-instawork": "0.0.2",
     "eslint-plugin-prettier": "3.0.0",
+    "express": "^4.17.1",
     "flow-bin": "0.61.0",
     "glob": "7.1.2",
-    "http-server": "0.11.1",
     "humps": "2.0.1",
     "husky": "1.2.1",
     "jest": "23.1.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const app = express();
+const port = process.argv[2];
+
+app.get('/', (req, res) => res.send('Hello World!'));
+
+const cacheControlDirectives = [
+  'max-age',
+  'stale-while-revalidate',
+  'stale-if-error',
+];
+
+var cacheHeaders = function(req, res, next) {
+  const cacheControl = cacheControlDirectives.reduce((s, directive) => {
+    const param = req.query[directive];
+    return s + (param ? ` ${directive}=${param}` : '');
+  }, '');
+  res.set('Cache-Control', cacheControl);
+  next();
+};
+
+app.use(cacheHeaders);
+
+const options = {
+  dotfiles: 'ignore',
+  etag: false,
+  extensions: ['xml'],
+  index: false,
+  redirect: false,
+};
+app.use(express.static('examples', options));
+
+app.listen(port, () => console.log(`XML Server listening on port ${port}!`));

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -33,8 +33,8 @@ import React, { PureComponent } from 'react';
 import { RefreshControl, ScrollView, TouchableOpacity } from 'react-native';
 import VisibilityDetectingView from 'hyperview/src/VisibilityDetectingView';
 import { XMLSerializer } from 'xmldom-instawork';
-// eslint-disable-next-line import/no-internal-modules
 import { getBehaviorElements } from 'hyperview/src/services';
+// eslint-disable-next-line import/no-internal-modules
 import globalEventEmitter from 'tiny-emitter/instance';
 
 /**

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -149,20 +149,6 @@ export default class HyperRef extends PureComponent<Props, State> {
     });
   };
 
-  onResponseStaleRevalidating = this.createScreenEventHandler(
-    'response-stale-revalidating',
-  );
-
-  onResponseRevalidated = this.createScreenEventHandler('response-evalidated');
-
-  onResponseStaleServerError = this.createScreenEventHandler(
-    'response-stale-server-error',
-  );
-
-  onResponseStaleNetworkError = this.createScreenEventHandler(
-    'response-stale-network-error',
-  );
-
   createScreenEventHandler = (triggerName: string) => () =>
     getBehaviorElements(this.props.element)
       .filter(e => e.getAttribute(ATTRIBUTES.TRIGGER) === triggerName)
@@ -181,6 +167,20 @@ export default class HyperRef extends PureComponent<Props, State> {
           );
         }
       });
+
+  onResponseStaleRevalidating = this.createScreenEventHandler(
+    'response-stale-revalidating',
+  );
+
+  onResponseRevalidated = this.createScreenEventHandler('response-evalidated');
+
+  onResponseStaleServerError = this.createScreenEventHandler(
+    'response-stale-server-error',
+  );
+
+  onResponseStaleNetworkError = this.createScreenEventHandler(
+    'response-stale-network-error',
+  );
 
   createActionHandler = (
     element: Element,

--- a/src/index.js
+++ b/src/index.js
@@ -272,13 +272,15 @@ export default class HyperScreen extends React.Component {
     const url = this.state.url;
 
     const fetchPromise = () => this.props.fetch(url, { headers: getHyperviewHeaders() })
-      .then((response) => {
+      .then(async (response) => {
         if (!response.ok) {
           throw Error(response.statusText);
         }
-        return response.text();
+        const warningHeader = response.headers.get('warning');
+        const responseText = await response.text();
+        return { warningHeader, responseText };
       })
-      .then((responseText) => {
+      .then(({ responseText, warningHeader }) => {
         if (typeof this.props.onParseBefore === 'function') {
           this.props.onParseBefore(url);
         }

--- a/src/index.js
+++ b/src/index.js
@@ -281,7 +281,7 @@ export default class HyperScreen extends React.Component {
     }
 
     if (!prevState.warningHeader && this.state.warningHeader) {
-      this.screenEventEmitter.emit(ON_RESPONSE_STALE_REVALIDATED);
+      this.screenEventEmitter.emit(ON_RESPONSE_REVALIDATED);
     }
   }
 

--- a/src/services/cache/index.js
+++ b/src/services/cache/index.js
@@ -41,7 +41,6 @@ const cachedFetch = (
 
   console.log('HV not in cache, fetching...');
   return baseFetch(url, options).then(response => {
-    // todo: check here if cacheable
     if (!response.ok) {
       return response;
     }

--- a/src/services/cache/index.js
+++ b/src/services/cache/index.js
@@ -1,3 +1,5 @@
+// @flow
+
 import LRU from 'lru-cache';
 
 const cachedFetch = (url, options, cache, baseFetch) => {
@@ -40,7 +42,7 @@ const cachedFetch = (url, options, cache, baseFetch) => {
   });
 };
 
-export const createCache = size =>
+export const createCache = (size: number) =>
   new LRU({
     length: (n, key) => {
       return n.size;

--- a/src/services/cache/index.js
+++ b/src/services/cache/index.js
@@ -1,0 +1,53 @@
+import LRU from 'lru-cache';
+
+const cachedFetch = (url, options, cache, baseFetch) => {
+  console.log(`HV cache size: ${cache.length}`);
+  const cacheKey = url;
+  const cached = cache.get(cacheKey);
+  if (cached !== undefined) {
+    console.log('HV found in cache!');
+    const response = cached.response.clone();
+
+    // TODO: remove!
+    response.headers.set('warning', '110 hyperview "Response is stale"');
+    if (options.onRevalidate) {
+      setTimeout(options.onRevalidate, 2000);
+    }
+
+    return Promise.resolve(response);
+  }
+
+  console.log('HV not in cache, fetching...');
+  return baseFetch(url, options).then(response => {
+    // todo: check here if cacheable
+    if (!response.ok) {
+      return response;
+    }
+
+    const clonedResponse = response.clone();
+    response.blob().then(blob => {
+      const cacheValue = {
+        response: clonedResponse,
+        size: blob.size,
+      };
+
+      const expiry = 1 * 60 * 1000; // 5 min default
+      console.log('caching...');
+      cache.set(cacheKey, cacheValue, expiry);
+    });
+
+    return clonedResponse;
+  });
+};
+
+export const createCache = size =>
+  new LRU({
+    length: (n, key) => {
+      return n.size;
+    },
+    max: size,
+    updateAgeOnGet: false,
+  });
+
+export const wrapFetch = (cache, baseFetch) => (url, options) =>
+  cachedFetch(url, options, cache, baseFetch);

--- a/src/services/cache/types.js
+++ b/src/services/cache/types.js
@@ -1,0 +1,45 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type { fetch as Fetch, Request, Response } from 'whatwg-fetch';
+
+export type { Fetch, Request, Response };
+
+export type RequestOptions = {
+  method?: string,
+  onRevalidate?: () => void,
+};
+
+type Cache<K, V> = {
+  set: (key: K, value: V, maxAge?: number) => void,
+  get: (key: K) => V,
+  peek: (key: K) => V,
+  del: (key: K) => void,
+  reset: () => void,
+  has: (key: K) => boolean,
+  prune: () => void,
+  length: number,
+};
+
+type CacheOptions<K, V> = {
+  max?: number,
+  maxAge?: number,
+  length?: (value: V, key: K) => number,
+  dispose?: (key: K, value: V) => void,
+  stale?: boolean,
+};
+
+export type HttpCacheValue = {
+  size: number,
+  response: Response,
+};
+
+export type HttpCache = Cache<string, HttpCacheValue>;
+export type HttpCacheOptions = CacheOptions<string, HttpCacheValue>;

--- a/src/types.js
+++ b/src/types.js
@@ -265,6 +265,7 @@ export type ComponentRegistry = {
 export type HvComponentOptions = {
   behaviorElement?: ?Element,
   componentRegistry?: ComponentRegistry,
+  screenEventEmitter?: Object,
   delay?: ?DOMString,
   focused?: ?boolean,
   hideIndicatorIds?: ?DOMString,

--- a/src/types.js
+++ b/src/types.js
@@ -262,10 +262,17 @@ export type ComponentRegistry = {
   },
 };
 
+export type EventEmitter = {
+  on: (event: string, callback: () => void, ctx?: any) => any,
+  once: (event: string, callback: () => void, ctx?: any) => any,
+  emit: (event: string, ...args: Array<any>) => any,
+  off: (event: string, callback: () => void, ctx?: any) => any,
+};
+
 export type HvComponentOptions = {
   behaviorElement?: ?Element,
   componentRegistry?: ComponentRegistry,
-  screenEventEmitter?: Object,
+  screenEventEmitter?: EventEmitter,
   delay?: ?DOMString,
   focused?: ?boolean,
   hideIndicatorIds?: ?DOMString,
@@ -406,3 +413,14 @@ export type NavigationProps = {|
 |};
 
 export const ON_EVENT_DISPATCH = 'hyperview:on-event';
+
+export const ON_RESPONSE_STALE_REVALIDATING =
+  'hyperview:on-response-stale-revalidating';
+
+export const ON_RESPONSE_REVALIDATED = 'hyperview:on-response-revalidated';
+
+export const ON_RESPONSE_STALE_SERVER_ERROR =
+  'hyperview:on-response-stale-server-error';
+
+export const ON_RESPONSE_STALE_NETWORK_ERROR =
+  'hyperview:on-response-stale-network-error';

--- a/xml-server.js
+++ b/xml-server.js
@@ -1,8 +1,9 @@
 const express = require('express');
+const morgan = require('morgan');
 const app = express();
 const port = process.argv[2];
 
-app.get('/', (req, res) => res.send('Hello World!'));
+app.use(morgan(':method :url :status\nCache-Control: :res[cache-control]'));
 
 const cacheControlDirectives = [
   'max-age',
@@ -15,7 +16,7 @@ var cacheHeaders = function(req, res, next) {
     const param = req.query[directive];
     return s + (param ? ` ${directive}=${param}` : '');
   }, '');
-  res.set('Cache-Control', cacheControl);
+  res.set('Cache-Control', 'private' + cacheControl);
   next();
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -281,6 +281,13 @@ accepts@~1.3.0, accepts@~1.3.5:
     mime-types "~2.1.18"
     negotiator "0.6.1"
 
+accepts@~1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
+  dependencies:
+    mime-types "~2.1.24"
+    negotiator "0.6.2"
+
 acorn-dynamic-import@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz#c752bd210bef679501b6c6cb7fc84f8f47158cc4"
@@ -596,10 +603,6 @@ async-each@^1.0.0, async-each@^1.0.1:
 async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
-
-async@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
 async@^2.1.2, async@^2.1.4, async@^2.4.0, async@^2.5.0:
   version "2.6.1"
@@ -1839,6 +1842,21 @@ body-parser@1.18.3:
     raw-body "2.3.3"
     type-is "~1.6.16"
 
+body-parser@1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
+  dependencies:
+    bytes "3.1.0"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.2"
+    http-errors "1.7.2"
+    iconv-lite "0.4.24"
+    on-finished "~2.3.0"
+    qs "6.7.0"
+    raw-body "2.4.0"
+    type-is "~1.6.17"
+
 body-parser@~1.13.3:
   version "1.13.3"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.13.3.tgz#c08cf330c3358e151016a05746f13f029c97fa97"
@@ -2037,6 +2055,10 @@ bytes@2.4.0:
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
+
+bytes@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
 
 cacache@^10.0.4:
   version "10.0.4"
@@ -2377,10 +2399,6 @@ colormin@^1.0.5:
     css-color-names "0.0.4"
     has "^1.0.1"
 
-colors@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
-
 colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
@@ -2517,6 +2535,12 @@ content-disposition@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
+content-disposition@0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.3.tgz#e130caf7e7279087c5616c2007d0485698984fbd"
+  dependencies:
+    safe-buffer "5.1.2"
+
 content-type@~1.0.1, content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
@@ -2546,6 +2570,10 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
+cookie@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
+
 copy-concurrently@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"
@@ -2572,10 +2600,6 @@ core-js@^2.2.2, core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0:
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-
-corser@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/corser/-/corser-2.0.1.tgz#8eda252ecaab5840dcd975ceb90d9370c819ff87"
 
 cosmiconfig@^4.0.0:
   version "4.0.0"
@@ -3065,15 +3089,6 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
-
-ecstatic@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ecstatic/-/ecstatic-3.2.0.tgz#1b1aee1ca7c6b99cfb5cf6c9b26b481b90c4409f"
-  dependencies:
-    he "^1.1.1"
-    mime "^1.4.1"
-    minimist "^1.1.0"
-    url-join "^2.0.2"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -3643,6 +3658,41 @@ express@^4.16.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+express@^4.17.1:
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
+  dependencies:
+    accepts "~1.3.7"
+    array-flatten "1.1.1"
+    body-parser "1.19.0"
+    content-disposition "0.5.3"
+    content-type "~1.0.4"
+    cookie "0.4.0"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "~1.1.2"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "~1.1.2"
+    fresh "0.5.2"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "~2.3.0"
+    parseurl "~1.3.3"
+    path-to-regexp "0.1.7"
+    proxy-addr "~2.0.5"
+    qs "6.7.0"
+    range-parser "~1.2.1"
+    safe-buffer "5.1.2"
+    send "0.17.1"
+    serve-static "1.14.1"
+    setprototypeof "1.1.1"
+    statuses "~1.5.0"
+    type-is "~1.6.18"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
+
 extend-shallow@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-1.1.4.tgz#19d6bf94dfc09d76ba711f39b872d21ff4dd9071"
@@ -3853,6 +3903,18 @@ finalhandler@1.1.1:
     statuses "~1.4.0"
     unpipe "~1.0.0"
 
+finalhandler@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.3"
+    statuses "~1.5.0"
+    unpipe "~1.0.0"
+
 find-babel-config@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.1.0.tgz#acc01043a6749fec34429be6b64f542ebb5d6355"
@@ -3910,12 +3972,6 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
-
-follow-redirects@^1.0.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.0.tgz#234f49cf770b7f35b40e790f636ceba0c3a0ab77"
-  dependencies:
-    debug "^3.1.0"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -4269,10 +4325,6 @@ he@1.2.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
 
-he@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
-
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -4359,6 +4411,16 @@ http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
 
+http-errors@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.2.tgz#4f5029cf13239f31036e5b2e55292bcfbcc85c8f"
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.1"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.0"
+
 http-errors@~1.3.1:
   version "1.3.1"
   resolved "http://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz#197e22cdebd4198585e8694ef6786197b91ed942"
@@ -4366,26 +4428,15 @@ http-errors@~1.3.1:
     inherits "~2.0.1"
     statuses "1"
 
-http-proxy@^1.8.1:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.17.0.tgz#7ad38494658f84605e2f6db4436df410f4e5be9a"
+http-errors@~1.7.2:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
   dependencies:
-    eventemitter3 "^3.0.0"
-    follow-redirects "^1.0.0"
-    requires-port "^1.0.0"
-
-http-server@0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/http-server/-/http-server-0.11.1.tgz#2302a56a6ffef7f9abea0147d838a5e9b6b6a79b"
-  dependencies:
-    colors "1.0.3"
-    corser "~2.0.0"
-    ecstatic "^3.0.0"
-    http-proxy "^1.8.1"
-    opener "~1.4.0"
-    optimist "0.6.x"
-    portfinder "^1.0.13"
-    union "~0.4.3"
+    depd "~1.1.2"
+    inherits "2.0.4"
+    setprototypeof "1.1.1"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.0"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -4531,6 +4582,10 @@ inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
+inherits@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+
 ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
@@ -4585,6 +4640,10 @@ invert-kv@^1.0.0:
 ipaddr.js@1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.0.tgz#eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e"
+
+ipaddr.js@1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.0.tgz#37df74e430a0e47550fe54a2defe30d8acd95f65"
 
 is-absolute-url@^2.0.0:
   version "2.1.0"
@@ -5823,6 +5882,10 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
+mime-db@1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
+
 "mime-db@>= 1.36.0 < 2", mime-db@~1.37.0:
   version "1.37.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
@@ -5843,6 +5906,12 @@ mime-types@^2.1.12, mime-types@~2.1.18, mime-types@~2.1.19, mime-types@~2.1.6, m
   dependencies:
     mime-db "~1.37.0"
 
+mime-types@~2.1.24:
+  version "2.1.26"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
+  dependencies:
+    mime-db "1.43.0"
+
 mime@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
@@ -5851,7 +5920,7 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
-mime@^1.3.4, mime@^1.4.1, mime@^1.5.0:
+mime@1.6.0, mime@^1.3.4, mime@^1.4.1, mime@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
@@ -5883,7 +5952,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -5926,7 +5995,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -5969,7 +6038,7 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-ms@^2.1.1:
+ms@2.1.1, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
@@ -6023,6 +6092,10 @@ negotiator@0.5.3:
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+negotiator@0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
 
 neo-async@^2.5.0:
   version "2.6.0"
@@ -6273,17 +6346,13 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-opener@~1.4.0:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
-
 opn@^3.0.2:
   version "3.0.3"
   resolved "http://registry.npmjs.org/opn/-/opn-3.0.3.tgz#b6d99e7399f78d65c3baaffef1fb288e9b85243a"
   dependencies:
     object-assign "^4.0.1"
 
-optimist@0.6.x, optimist@^0.6.1:
+optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
   dependencies:
@@ -6440,6 +6509,10 @@ parse5@4.0.0:
 parseurl@~1.3.0, parseurl@~1.3.1, parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
+
+parseurl@~1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -6619,14 +6692,6 @@ pluralize@^7.0.0:
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
-
-portfinder@^1.0.13:
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.13.tgz#bb32ecd87c27104ae6ee44b5a3ccbf0ebb1aede9"
-  dependencies:
-    async "^1.5.2"
-    debug "^2.2.0"
-    mkdirp "0.5.x"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -7002,6 +7067,13 @@ proxy-addr@~2.0.4:
     forwarded "~0.1.2"
     ipaddr.js "1.8.0"
 
+proxy-addr@~2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.5.tgz#34cbd64a2d81f4b1fd21e76f9f06c8a45299ee34"
+  dependencies:
+    forwarded "~0.1.2"
+    ipaddr.js "1.9.0"
+
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -7071,9 +7143,9 @@ qs@6.5.2, qs@^6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
-qs@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-2.3.3.tgz#e9e85adbe75da0bbe4c8e0476a086290f863b404"
+qs@6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
 
 query-string@^4.1.0:
   version "4.3.4"
@@ -7136,6 +7208,10 @@ range-parser@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.0.3.tgz#6872823535c692e2c2a0103826afd82c2e0ff175"
 
+range-parser@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
+
 raw-body@2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"
@@ -7143,6 +7219,15 @@ raw-body@2.3.3:
     bytes "3.0.0"
     http-errors "1.6.3"
     iconv-lite "0.4.23"
+    unpipe "1.0.0"
+
+raw-body@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.0.tgz#a1ce6fb9c9bc356ca52e89256ab59059e13d0332"
+  dependencies:
+    bytes "3.1.0"
+    http-errors "1.7.2"
+    iconv-lite "0.4.24"
     unpipe "1.0.0"
 
 raw-body@~2.1.2:
@@ -7907,6 +7992,24 @@ send@0.16.2:
     range-parser "~1.2.0"
     statuses "~1.4.0"
 
+send@0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"
+  dependencies:
+    debug "2.6.9"
+    depd "~1.1.2"
+    destroy "~1.0.4"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "~1.7.2"
+    mime "1.6.0"
+    ms "2.1.1"
+    on-finished "~2.3.0"
+    range-parser "~1.2.1"
+    statuses "~1.5.0"
+
 serialize-error@^2.1.0:
   version "2.1.0"
   resolved "http://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a"
@@ -7945,6 +8048,15 @@ serve-static@1.13.2:
     parseurl "~1.3.2"
     send "0.16.2"
 
+serve-static@1.14.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.14.1.tgz#666e636dc4f010f7ef29970a88a674320898b2f9"
+  dependencies:
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    parseurl "~1.3.3"
+    send "0.17.1"
+
 serve-static@~1.10.0:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.10.3.tgz#ce5a6ecd3101fed5ec09827dac22a9c29bfb0535"
@@ -7982,6 +8094,10 @@ setimmediate@^1.0.4, setimmediate@^1.0.5:
 setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
+
+setprototypeof@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
 
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.11"
@@ -8204,7 +8320,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-statuses@1, "statuses@>= 1.4.0 < 2":
+statuses@1, "statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
 
@@ -8512,6 +8628,10 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+toidentifier@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
+
 toposort@^1.0.0:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
@@ -8563,6 +8683,13 @@ type-is@~1.6.16, type-is@~1.6.6:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.18"
+
+type-is@~1.6.17, type-is@~1.6.18:
+  version "1.6.18"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.24"
 
 typedarray@^0.0.6:
   version "0.0.6"
@@ -8649,12 +8776,6 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^0.4.3"
 
-union@~0.4.3:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/union/-/union-0.4.6.tgz#198fbdaeba254e788b0efcb630bc11f24a2959e0"
-  dependencies:
-    qs "~2.3.3"
-
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
@@ -8703,10 +8824,6 @@ uri-js@^4.2.2:
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
-
-url-join@^2.0.2:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/url-join/-/url-join-2.0.5.tgz#5af22f18c052a000a48d7b82c5e9c2e2feeda728"
 
 url-loader@^0.6.2:
   version "0.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5693,6 +5693,12 @@ lru-cache@^4.0.1, lru-cache@^4.1.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  dependencies:
+    yallist "^3.0.2"
+
 macos-release@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-1.1.0.tgz#831945e29365b470aa8724b0ab36c8f8959d10fb"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1797,6 +1797,12 @@ basic-auth@~1.0.3:
   version "1.0.4"
   resolved "http://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz#030935b01de7c9b94a824b29f3fccb750d3a5290"
 
+basic-auth@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  dependencies:
+    safe-buffer "5.1.2"
+
 batch@0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.5.3.tgz#3f3414f380321743bfc1042f9a83ff1d5824d464"
@@ -6000,6 +6006,16 @@ mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+morgan@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
+  dependencies:
+    basic-auth "~2.0.0"
+    debug "2.6.9"
+    depd "~1.1.2"
+    on-finished "~2.3.0"
+    on-headers "~1.0.1"
 
 morgan@~1.6.1:
   version "1.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9080,6 +9080,10 @@ whatwg-fetch@^1.0.0:
   version "1.1.1"
   resolved "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz#ac3c9d39f320c6dce5339969d054ef43dd333319"
 
+whatwg-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.2.0.tgz#a3d58ef10b76009b042d03e25591ece89b88d171"


### PR DESCRIPTION
Creating this PR as a proof-of-concept of a client-side HTTP cache for Hyperview. Opening this now for context for the offline support team. Some implementation details:

- I converted the demo server to a custom Node server so that I can control the response cache headers. Appending params like `?max-age= 600` to requests will add the appropriate header to the response.
- There are now two types of event emitters:
    - the global emitter is used for the existing event dispatch system. It works across screens.
    - each screen has its own emitter. This is used for the cache events (revalidating, revalidated, server error, network error)
- All of the caching functionality is implemented in the cache module. It exposes a function that wraps the standard `fetch()` function with a version that uses an in-memory cache.

Possible extensions:
- [ ] Analyze cache semantics for full support of HTTP caching
- [ ] Cache should not just be in-memory, but write to storage so that it works if app is closed and re-opened 
