### PR TITLE
Proof of concept: cached Hyperview requests Part 2

### DIFF
--- a/examples/index.xml
+++ b/examples/index.xml
@@ -56,7 +56,7 @@
         <text style="Header__Title">Hyperview Examples</text>
       </header>
       <list>
-        <item href="/ui_elements/index.xml"
+        <item href="/ui_elements/index.xml?max-age=30"
               key="layout"
               show-during-load="loadingScreen"
               style="Item">

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test": "yarn generate test && yarn test:flow && yarn test:lint && yarn test:render && yarn test:unit"
   },
   "dependencies": {
+    "http-cache-semantics": "^4.0.3",
     "lru-cache": "^5.1.1",
     "react-native-webview": "5.12.0",
     "tiny-emitter": "2.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -281,7 +281,7 @@ export default class HyperScreen extends React.Component {
     }
 
     if (!prevState.warningHeader && this.state.warningHeader) {
-      this.screenEventEmitter.emit(ON_RESPONSE_REVALIDATED);
+      this.screenEventEmitter.emit(ON_RESPONSE_STALE_REVALIDATING);
     }
   }
 

--- a/src/services/cache/index.js
+++ b/src/services/cache/index.js
@@ -15,7 +15,12 @@ import type {
   RequestOptions,
   Response,
 } from 'hyperview/src/services/cache/types';
+import CachePolicy from 'http-cache-semantics';
 import LRU from 'lru-cache';
+
+const cachePolicyOptions = {
+  shared: false,
+};
 
 const cachedFetch = (
   url: string,
@@ -25,23 +30,43 @@ const cachedFetch = (
 ): Promise<Response> => {
   console.log(`HV cache size: ${cache.length}`);
   const cacheKey = url;
-  const cached = cache.get(cacheKey);
-  if (cached !== undefined) {
-    console.log('HV found in cache!');
-    const response = cached.response.clone();
 
-    // TODO: remove!
-    response.headers.set('warning', '110 hyperview "Response is stale"');
-    if (options.onRevalidate) {
-      setTimeout(options.onRevalidate, 2000);
+  const cacheValue: HttpCacheValue = cache.get(cacheKey);
+  if (cacheValue !== undefined) {
+    console.log('HV found in cache!');
+    const oldResponse = cacheValue.response.clone();
+    const oldPolicy = cacheValue.policy;
+
+    if (!oldPolicy.satisfiesWithoutRevalidation(options)) {
+      // The value in the cache needs to be revalidated before we use it.
+      const newHeaders = oldPolicy.revalidationHeaders(options);
+      const newOptions = {
+        ...options,
+        headers: newHeaders,
+      };
+      baseFetch(url, newOptions).then(newResponse => {
+        const { policy, modified } = oldPolicy.revalidatedPolicy(
+          options,
+          newResponse,
+        );
+        const response = modified ? newResponse : oldResponse;
+        const newCacheValue: HttpCacheValue = {
+          response,
+        };
+        cache.set(cacheKey, newCacheValue, policy.timeToLive());
+      });
     }
 
-    return Promise.resolve(response);
+    // We can use the old response to respond to the request
+    oldResponse.headers = oldPolicy.responseHeaders();
+    return Promise.resolve(oldResponse);
   }
 
   console.log('HV not in cache, fetching...');
   return baseFetch(url, options).then(response => {
-    if (!response.ok) {
+    const cachePolicy = new CachePolicy(options, response, cachePolicyOptions);
+    if (!cachePolicy.storable()) {
+      console.log('response not cacheable');
       return response;
     }
 
@@ -50,10 +75,11 @@ const cachedFetch = (
       const cacheValue: HttpCacheValue = {
         response: clonedResponse,
         size: blob.size,
+        policy: cachePolicy,
       };
 
-      const expiry = 1 * 60 * 1000; // 5 min default
-      console.log('caching...');
+      const expiry = cachePolicy.timeToLive();
+      console.log(`caching for ${expiry}ms...`);
       cache.set(cacheKey, cacheValue, expiry);
     });
 

--- a/src/services/cache/types.js
+++ b/src/services/cache/types.js
@@ -15,6 +15,7 @@ export type { Fetch, Request, Response };
 export type RequestOptions = {
   method?: string,
   onRevalidate?: () => void,
+  headers?: { [key: string]: any },
 };
 
 type Cache<K, V> = {
@@ -39,6 +40,7 @@ type CacheOptions<K, V> = {
 export type HttpCacheValue = {
   size: number,
   response: Response,
+  policy: any,
 };
 
 export type HttpCache = Cache<string, HttpCacheValue>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4408,6 +4408,10 @@ htmlparser2@~3.3.0:
     domutils "1.1"
     readable-stream "1.0"
 
+http-cache-semantics@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz#495704773277eeef6e43f9ab2c2c7d259dda25c5"
+
 http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
   version "1.6.3"
   resolved "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"


### PR DESCRIPTION
This PR extends #139 and adds the `http-cache-semantics` library. In theory, it analyzes the requests and responses to adhere to the HTTP spec for when requests need to be revalidated. However, I haven't been able to get it to work, so there's either something wrong in the library or the implementation.

Possible extensions:
- `http-cache-semantics` does not support `stale-if-error` and `stale-while-revalidating`. I opened an issue on the library here, it looks like it's been addressed: https://github.com/kornelski/http-cache-semantics/issues/27