### PR TITLE
Hyperview XML Schema

### DIFF
--- a/examples/advanced_behaviors/alert/behavior.xml
+++ b/examples/advanced_behaviors/alert/behavior.xml
@@ -139,8 +139,8 @@
                     alert:title="Choose an action"
                     trigger="press"
                     xmlns:alert="https://hyperview.org/hyperview-alert"
-                    xmlns:phone="https://hyperview.org/hyperview-phone"
-                    xmlns:sms="https://hyperview.org/hyperview-sms">
+                    xmlns:phone="https://instawork.com/hyperview-phone"
+                    xmlns:sms="https://instawork.com/hyperview-sms">
             <alert:option action="phone"
                           alert:label="Call phone"
                           phone:number="(555) 555-5555" />

--- a/examples/advanced_behaviors/set_value/index.xml
+++ b/examples/advanced_behaviors/set_value/index.xml
@@ -79,10 +79,10 @@
              fontSize="16"
              fontWeight="normal"
              paddingBottom="8"
-             paddingTop="8">
+             paddingTop="8"/>
       <style id="input__text"
              fontSize="16"
-             fontWeight="normal"></style>
+             fontWeight="normal">
         <modifier pressed="true">
           <style borderBottomColor="green" />
         </modifier>

--- a/examples/case_studies/_rating_save.xml
+++ b/examples/case_studies/_rating_save.xml
@@ -1,7 +1,7 @@
 <view id="savedButton"
       style="BottomSheet__Button"
       xmlns="https://hyperview.org/hyperview"
-      xmlns:ns1="https://hyperview.org/hyperview-redux">
+      xmlns:ns1="https://instawork.com/hyperview-redux">
   <behavior action="close"
             delay="300"
             href="/case_studies/business_rating.xml"

--- a/examples/case_studies/business_rating.xml
+++ b/examples/case_studies/business_rating.xml
@@ -1,5 +1,5 @@
 <doc xmlns="https://hyperview.org/hyperview"
-     xmlns:ns1="https://hyperview.org/hyperview-intercom">&gt; 
+     xmlns:ns1="https://hyperview.org/hyperview-intercom">
 <screen>
   <styles>
     <style id="Header"

--- a/examples/case_studies/business_rating.xml
+++ b/examples/case_studies/business_rating.xml
@@ -1,5 +1,5 @@
 <doc xmlns="https://hyperview.org/hyperview"
-     xmlns:ns1="https://hyperview.org/hyperview-intercom">
+     xmlns:ns1="https://instawork.com/hyperview-intercom">
 <screen>
   <styles>
     <style id="Header"

--- a/examples/case_studies/feedback_widget.xml
+++ b/examples/case_studies/feedback_widget.xml
@@ -1,5 +1,5 @@
 <doc xmlns="https://hyperview.org/hyperview"
-     xmlns:ns1="https://hyperview.org/hyperview-intercom">&gt; 
+     xmlns:ns1="https://hyperview.org/hyperview-intercom">
 <screen>
   <styles>
     <style id="Header"
@@ -182,15 +182,20 @@
     </view>
   </body>
 </screen>
-<view id="more-feedback"
-      style="FeedbackContainer__Extra">
-  <view style="Feedback">
-    <text style="Feedback__Label">Something else was added :)</text>
-  </view>
-  <view style="Feedback">
-    <text style="Feedback__Label">Something else was added :)</text>
-  </view>
-  <view style="Feedback">
-    <text style="Feedback__Label">Something else was added :)</text>
-  </view>
-</view></doc>
+<screen>
+  <body>
+    <view id="more-feedback"
+          style="FeedbackContainer__Extra">
+      <view style="Feedback">
+        <text style="Feedback__Label">Something else was added :)</text>
+      </view>
+      <view style="Feedback">
+        <text style="Feedback__Label">Something else was added :)</text>
+      </view>
+      <view style="Feedback">
+        <text style="Feedback__Label">Something else was added :)</text>
+      </view>
+    </view>
+  </body>
+</screen>
+</doc>

--- a/examples/case_studies/photos/index.xml
+++ b/examples/case_studies/photos/index.xml
@@ -168,7 +168,7 @@
         </view>
       </view>
       <section-list>
-        <section key="stories">
+        <section>
           <section-title></section-title>
           <item key="stories">
             <view scroll-orientation="horizontal"
@@ -211,7 +211,7 @@
             </view>
           </item>
         </section>
-        <section key="1">
+        <section>
           <section-title style="ImageHeader">
             <view style="ImageHeader__Left">
               <image href="/case_studies/photos/index.xml"
@@ -286,7 +286,7 @@
             </view>
           </item>
         </section>
-        <section key="2">
+        <section>
           <section-title style="ImageHeader">
             <view style="ImageHeader__Left">
               <image source="/case_studies/photos/avatars/picard.jpg"
@@ -343,7 +343,7 @@
             </view>
           </item>
         </section>
-        <section key="3">
+        <section>
           <section-title style="ImageHeader">
             <view style="ImageHeader__Left">
               <image source="/case_studies/photos/avatars/worf.jpg"
@@ -392,7 +392,7 @@
             </view>
           </item>
         </section>
-        <section key="4">
+        <section>
           <section-title style="ImageHeader">
             <view style="ImageHeader__Left">
               <image source="/case_studies/photos/avatars/deanna.png"

--- a/examples/case_studies/rating_modal.xml
+++ b/examples/case_studies/rating_modal.xml
@@ -219,10 +219,9 @@
           </view>
         </view>
         <view style="FormGroup">
-          <text-area focusStyles="input input--focused"
-                     outerStyles="outerInput"
-                     placeholder="Any other feedback?"
+          <text-area placeholder="Any other feedback?"
                      placeholderTextColor="#8D9494"
+                     name="other_feedback"
                      style="input" />
         </view>
       </view>

--- a/examples/ui_elements/forms/date_field.xml
+++ b/examples/ui_elements/forms/date_field.xml
@@ -148,6 +148,7 @@
                       label-format="MMMM D, YYYY"
                       modal-style="PickerModal"
                       modal-text-style="PickerModal__text"
+                      name="date"
                       placeholder="Select date"
                       placeholderTextColor="#8D9494" />
         </view>
@@ -159,6 +160,7 @@
                       modal-style="PickerModal"
                       modal-text-style="PickerModal__text"
                       mode="spinner"
+                      name="date"
                       placeholder="Select date"
                       placeholderTextColor="#8D9494" />
         </view>
@@ -169,6 +171,7 @@
                       label-format="MMMM D, YYYY"
                       modal-style="PickerModal"
                       modal-text-style="PickerModal__text"
+                      name="date"
                       placeholder="Select date"
                       placeholderTextColor="#8D9494"
                       value="2018-03-07" />
@@ -180,6 +183,7 @@
                       label-format="MMMM D, YYYY"
                       modal-style="PickerModal"
                       modal-text-style="PickerModal__text"
+                      name="date"
                       placeholder="Select date"
                       placeholderTextColor="#8D9494"
                       value="2018-03-07" />
@@ -188,6 +192,7 @@
                       label-format="L"
                       modal-style="PickerModal"
                       modal-text-style="PickerModal__text"
+                      name="date"
                       placeholder="Select date"
                       placeholderTextColor="#8D9494"
                       value="2018-03-07" />
@@ -196,6 +201,7 @@
                       label-format="MMMM [the] Do, [`]YY"
                       modal-style="PickerModal"
                       modal-text-style="PickerModal__text"
+                      name="date"
                       placeholder="Select date"
                       placeholderTextColor="#8D9494"
                       value="2018-03-07" />
@@ -208,6 +214,7 @@
                       min="2018-05-05"
                       modal-style="PickerModal"
                       modal-text-style="PickerModal__text"
+                      name="date"
                       placeholder="Select date"
                       placeholderTextColor="#8D9494" />
           <date-field field-style="Input"
@@ -217,6 +224,7 @@
                       modal-style="PickerModal"
                       modal-text-style="PickerModal__text"
                       mode="spinner"
+                      name="date"
                       placeholder="Select date (spinner)"
                       placeholderTextColor="#8D9494" />
         </view>
@@ -228,6 +236,7 @@
                       max="2024-05-05"
                       modal-style="PickerModal"
                       modal-text-style="PickerModal__text"
+                      name="date"
                       placeholder="Select date"
                       placeholderTextColor="#8D9494" />
           <date-field field-style="Input"
@@ -237,6 +246,7 @@
                       modal-style="PickerModal"
                       modal-text-style="PickerModal__text"
                       mode="spinner"
+                      name="date"
                       placeholder="Select date (spinner)"
                       placeholderTextColor="#8D9494" />
         </view>
@@ -249,6 +259,7 @@
                       min="2018-05-05"
                       modal-style="PickerModal"
                       modal-text-style="PickerModal__text"
+                      name="date"
                       placeholder="Select date"
                       placeholderTextColor="#8D9494" />
           <date-field field-style="Input"
@@ -259,6 +270,7 @@
                       modal-style="PickerModal"
                       modal-text-style="PickerModal__text"
                       mode="spinner"
+                      name="date"
                       placeholder="Select date (spinner)"
                       placeholderTextColor="#8D9494" />
         </view>
@@ -269,6 +281,7 @@
                       label-format="MMMM D, YYYY"
                       modal-style="PickerModal"
                       modal-text-style="PickerModal__text"
+                      name="date"
                       placeholder="Select date"
                       placeholderTextColor="#8D9494" />
           <text style="help help--error">Please select a date</text>
@@ -280,6 +293,7 @@
                       label-format="MMMM D, YYYY"
                       modal-style="PickerModal"
                       modal-text-style="PickerModal__text"
+                      name="date"
                       placeholder="Select date"
                       placeholderTextColor="#8D9494"
                       value="2018-03-07" />
@@ -292,6 +306,7 @@
                       label-format="MMMM D, YYYY"
                       modal-style="PickerModalCustom"
                       modal-text-style="PickerModalCustom__text"
+                      name="date"
                       placeholder="Select date"
                       placeholderTextColor="#8D9494"
                       value="2018-03-07" />

--- a/examples/ui_elements/forms/picker.xml
+++ b/examples/ui_elements/forms/picker.xml
@@ -146,6 +146,7 @@
                         field-text-style="Input__Text"
                         modal-style="PickerModal"
                         modal-text-style="PickerModal__text"
+                        name="picker"
                         placeholder="Select choice"
                         placeholderTextColor="#8D9494">
             <picker-item label="Choice 0"
@@ -170,6 +171,7 @@
                         field-text-style="Input__Text"
                         modal-style="PickerModal"
                         modal-text-style="PickerModal__text"
+                        name="picker"
                         placeholder="Select choice"
                         placeholderTextColor="#8D9494"
                         value="3">
@@ -195,6 +197,7 @@
                         field-text-style="Input__Text"
                         modal-style="PickerModal"
                         modal-text-style="PickerModal__text"
+                        name="picker"
                         placeholder="Select choice"
                         placeholderTextColor="#8D9494"
                         value="3">
@@ -222,6 +225,7 @@
                         field-text-style="Input__Text Input__Text--Error"
                         modal-style="PickerModal"
                         modal-text-style="PickerModal__text"
+                        name="picker"
                         placeholder="Select choice"
                         placeholderTextColor="#8D9494">
             <picker-item label="Choice 0"
@@ -247,6 +251,7 @@
                         field-text-style="Input__Text Input__Text--Error"
                         modal-style="PickerModal"
                         modal-text-style="PickerModal__text"
+                        name="picker"
                         placeholder="Select choice"
                         placeholderTextColor="#8D9494"
                         value="3">
@@ -275,6 +280,7 @@
                         field-text-style="InputCustom__Text"
                         modal-style="PickerModalCustom"
                         modal-text-style="PickerModalCustom__text"
+                        name="picker"
                         placeholder="Select choice"
                         placeholderTextColor="#8D9494">
             <picker-item label="Choice 0"

--- a/examples/ui_elements/forms/switch.xml
+++ b/examples/ui_elements/forms/switch.xml
@@ -75,7 +75,6 @@
              marginTop="16" />
       <style id="help--error"
              color="#FF4847" />
-      </style>
       <style id="switch"
         backgroundColor="#E1E1E1"
       >
@@ -123,6 +122,7 @@
             <text style="Button__Label">Serialize</text>
           </view>
         </form>
+      </view>
     </body>
   </screen>
 </doc>

--- a/examples/ui_elements/forms/text_input.xml
+++ b/examples/ui_elements/forms/text_input.xml
@@ -95,6 +95,7 @@
           <text style="label">Default input field</text>
           <text-field placeholder="First name"
                       placeholderTextColor="#8D9494"
+                      name="text"
                       style="input" />
           <text style="help">Please enter your full name</text>
         </view>
@@ -102,6 +103,7 @@
           <text style="label">Filled input field</text>
           <text-field placeholder="First name"
                       placeholderTextColor="#8D9494"
+                      name="text"
                       style="input"
                       value="Milhouse" />
           <text style="help">Please enter your full name</text>
@@ -110,6 +112,7 @@
           <text style="label">Validation error</text>
           <text-field placeholder="First name"
                       placeholderTextColor="#8D9494"
+                      name="text"
                       style="input input--error" />
           <text style="help help--error">Please enter your full name</text>
         </view>
@@ -117,6 +120,7 @@
           <text style="label">Filled validation error</text>
           <text-field placeholder="First name"
                       placeholderTextColor="#8D9494"
+                      name="text"
                       style="input input--error"
                       value="Milhouse" />
           <text style="help help--error">Name already taken</text>
@@ -126,9 +130,11 @@
           <view style="horizontalFormGroup">
             <text-field placeholder="First"
                         placeholderTextColor="#8D9494"
+                        name="text"
                         style="input" />
             <text-field placeholder="Last"
                         placeholderTextColor="#8D9494"
+                        name="text"
                         style="input" />
           </view>
         </view>
@@ -137,6 +143,7 @@
           <text-field keyboard-type="phone-pad"
                       placeholder="Phone number"
                       placeholderTextColor="#8D9494"
+                      name="text"
                       style="input"
                       value="(281) 555-2048" />
         </view>
@@ -145,6 +152,7 @@
           <text-field keyboard-type="number-pad"
                       placeholder="SSN"
                       placeholderTextColor="#8D9494"
+                      name="text"
                       style="input"
                       value="600 80 5555" />
         </view>
@@ -153,6 +161,7 @@
           <text-field keyboard-type="email-address"
                       placeholder="Email"
                       placeholderTextColor="#8D9494"
+                      name="text"
                       style="input"
                       value="gigsy@instawork.com" />
         </view>
@@ -162,6 +171,7 @@
                       mask="(999) 999-9999"
                       placeholder="Phone number"
                       placeholderTextColor="#8D9494"
+                      name="text"
                       style="input"
                       value="" />
         </view>
@@ -171,6 +181,7 @@
                       mask="9999"
                       placeholder="4-digit code"
                       placeholderTextColor="#8D9494"
+                      name="text"
                       style="input"
                       value="" />
         </view>
@@ -180,6 +191,7 @@
                       mask="999 99 9999"
                       placeholder="SSN or Tax ID"
                       placeholderTextColor="#8D9494"
+                      name="text"
                       style="input"
                       value="" />
         </view>

--- a/examples/ui_elements/forms/textarea.xml
+++ b/examples/ui_elements/forms/textarea.xml
@@ -90,14 +90,15 @@
         <view style="FormGroup">
           <text style="label">Multi-line text-area</text>
           <text-area placeholder="Instructions"
+                     name="textarea"
                      placeholderTextColor="#8D9494"
-                     style="input">
-            <text style="help">Please enter your gig instructions</text>
-          </text-area>
+                     style="input"></text-area>
+          <text style="help">Please enter your gig instructions</text>
         </view>
         <view style="FormGroup">
           <text style="label">Multi-line filled</text>
           <text-area placeholder="Instructions"
+                     name="textarea"
                      placeholderTextColor="#8D9494"
                      style="input"
                      value="One two three four"></text-area>
@@ -105,6 +106,7 @@
         <view style="FormGroup">
           <text style="label">Multi-line validation error</text>
           <text-area placeholder="Instructions"
+                     name="textarea"
                      placeholderTextColor="#8D9494"
                      style="input input--error"></text-area>
           <text style="help help--error">Please enter your gig instructions</text>
@@ -112,6 +114,7 @@
         <view style="FormGroup">
           <text style="label">Multi-line filled with validation error</text>
           <text-area placeholder="Instructions"
+                     name="textarea"
                      placeholderTextColor="#8D9494"
                      style="input input--error"
                      value="One two three four"></text-area>

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:render": "jest test/render.test.js --forceExit",
     "test:unit": "jest --testPathPattern src",
     "test:xmlserver": "http-server -c-1 -p 8085 ./examples",
+    "test:validate-xml": "find examples/ -name '*.xml' | xargs xmllint --schema schema/hyperview.xsd --noout",
     "test": "yarn generate test && yarn test:flow && yarn test:lint && yarn test:render && yarn test:unit"
   },
   "dependencies": {

--- a/schema/alert.xsd
+++ b/schema/alert.xsd
@@ -1,0 +1,23 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  attributeFormDefault="qualified"
+  elementFormDefault="qualified"
+  targetNamespace="https://hyperview.org/hyperview-alert"
+  xmlns:hv="https://hyperview.org/hyperview"
+>
+<xs:import namespace="https://hyperview.org/hyperview" schemaLocation="hyperview.xsd"/>
+
+  <xs:element name="option">
+    <xs:complexType>
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="hv:behavior" />
+      </xs:sequence>
+      <xs:attribute name="label" type="xs:string" use="required" />
+      <xs:attributeGroup ref="hv:behaviorAttributes" />
+    </xs:complexType>
+  </xs:element>
+
+  <xs:attributeGroup name="alertAttributes">
+    <xs:attribute name="message" type="xs:string" />
+    <xs:attribute name="title" type="xs:string" />
+  </xs:attributeGroup>
+</xs:schema>

--- a/schema/alert.xsd
+++ b/schema/alert.xsd
@@ -4,7 +4,7 @@
   targetNamespace="https://hyperview.org/hyperview-alert"
   xmlns:hv="https://hyperview.org/hyperview"
 >
-<xs:import namespace="https://hyperview.org/hyperview" schemaLocation="hyperview.xsd"/>
+  <xs:import namespace="https://hyperview.org/hyperview" schemaLocation="hyperview.xsd"/>
 
   <xs:element name="option">
     <xs:complexType>

--- a/schema/amplitude.xsd
+++ b/schema/amplitude.xsd
@@ -1,0 +1,10 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  attributeFormDefault="qualified"
+  elementFormDefault="qualified"
+  targetNamespace="https://instawork.com/hyperview-amplitude"
+>
+  <xs:attributeGroup name="amplitudeAttributes">
+    <xs:attribute name="event" type="xs:string" />
+    <xs:attribute name="event-props" type="xs:string" />
+  </xs:attributeGroup>
+</xs:schema>

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -21,48 +21,227 @@
   <xs:import namespace="https://instawork.com/hyperview-share" schemaLocation="share.xsd"/>
   <xs:import namespace="https://instawork.com/hyperview-sms" schemaLocation="sms.xsd"/>
 
-  <xs:simpleType name="colorType">
-    <xs:union memberTypes="xs:NMTOKEN">
-      <xs:simpleType>
-        <xs:restriction base="xs:token">
-          <xs:pattern value="#[0-9a-fA-F]{3}"/>
-        </xs:restriction>
-      </xs:simpleType>
+  <xs:simpleType name="action">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="push"/>
+      <xs:enumeration value="new"/>
+      <xs:enumeration value="back"/>
+      <xs:enumeration value="close"/>
+      <xs:enumeration value="navigate"/>
+      <xs:enumeration value="reload"/>
+      <xs:enumeration value="deep-link"/>
+      <xs:enumeration value="dispatch-event"/>
+      <xs:enumeration value="replace"/>
+      <xs:enumeration value="replace-inner"/>
+      <xs:enumeration value="append"/>
+      <xs:enumeration value="prepend"/>
+      <xs:enumeration value="show"/>
+      <xs:enumeration value="hide"/>
+      <xs:enumeration value="toggle"/>
+      <xs:enumeration value="set-value"/>
+      <xs:enumeration value="ask-rating"/>
 
-      <xs:simpleType>
-        <xs:restriction base="xs:token">
-          <xs:pattern value="#[0-9a-fA-F]{6}"/>
-        </xs:restriction>
-      </xs:simpleType>
-
-      <xs:simpleType>
-        <xs:restriction base="xs:token">
-          <xs:pattern value="#[0-9a-fA-F]{8}"/>
-        </xs:restriction>
-      </xs:simpleType>
-
-      <xs:simpleType>
-        <xs:restriction base="xs:token">
-          <xs:pattern value="rgb\(\d{1,3},\s*\d{1,3},\s*\d{1,3}\)"/>
-        </xs:restriction>
-      </xs:simpleType>
-
-      <xs:simpleType>
-        <xs:restriction base="xs:token">
-          <xs:pattern value="rgba\(\d{1,3},\s*\d{1,3},\s*\d{1,3},\s*(0?\.\d+|1|1.0+)\)"/>
-        </xs:restriction>
-      </xs:simpleType>
-    </xs:union>
+      <xs:enumeration value="alert"/>
+      <xs:enumeration value="amplitude"/>
+      <xs:enumeration value="intercom"/>
+      <xs:enumeration value="phone"/>
+      <xs:enumeration value="redux"/>
+      <xs:enumeration value="share"/>
+      <xs:enumeration value="sms"/>
+    </xs:restriction>
   </xs:simpleType>
 
-  <xs:simpleType name="dateType">
+  <xs:simpleType name="hex3">
+    <xs:restriction base="xs:token">
+      <xs:pattern value="#[0-9a-fA-F]{3}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="hex6">
+    <xs:restriction base="xs:token">
+      <xs:pattern value="#[0-9a-fA-F]{6}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="hex8">
+    <xs:restriction base="xs:token">
+      <xs:pattern value="#[0-9a-fA-F]{8}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="rgb">
+    <xs:restriction base="xs:token">
+      <xs:pattern value="rgb\(\d{1,3},\s*\d{1,3},\s*\d{1,3}\)"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="rgba">
+    <xs:restriction base="xs:token">
+      <xs:pattern value="rgba\(\d{1,3},\s*\d{1,3},\s*\d{1,3},\s*(0?\.\d+|1|1.0+)\)"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="named-color">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="aliceblue"/>
+      <xs:enumeration value="antiquewhite"/>
+      <xs:enumeration value="aqua"/>
+      <xs:enumeration value="aquamarine"/>
+      <xs:enumeration value="azure"/>
+      <xs:enumeration value="beige"/>
+      <xs:enumeration value="bisque"/>
+      <xs:enumeration value="black"/>
+      <xs:enumeration value="blanchedalmond"/>
+      <xs:enumeration value="blue"/>
+      <xs:enumeration value="blueviolet"/>
+      <xs:enumeration value="brown"/>
+      <xs:enumeration value="burlywood"/>
+      <xs:enumeration value="cadetblue"/>
+      <xs:enumeration value="chartreuse"/>
+      <xs:enumeration value="chocolate"/>
+      <xs:enumeration value="coral"/>
+      <xs:enumeration value="cornflowerblue"/>
+      <xs:enumeration value="cornsilk"/>
+      <xs:enumeration value="crimson"/>
+      <xs:enumeration value="cyan"/>
+      <xs:enumeration value="darkblue"/>
+      <xs:enumeration value="darkcyan"/>
+      <xs:enumeration value="darkgoldenrod"/>
+      <xs:enumeration value="darkgray"/>
+      <xs:enumeration value="darkgreen"/>
+      <xs:enumeration value="darkgrey"/>
+      <xs:enumeration value="darkkhaki"/>
+      <xs:enumeration value="darkmagenta"/>
+      <xs:enumeration value="darkolivegreen"/>
+      <xs:enumeration value="darkorange"/>
+      <xs:enumeration value="darkorchid"/>
+      <xs:enumeration value="darkred"/>
+      <xs:enumeration value="darksalmon"/>
+      <xs:enumeration value="darkseagreen"/>
+      <xs:enumeration value="darkslateblue"/>
+      <xs:enumeration value="darkslategrey"/>
+      <xs:enumeration value="darkturquoise"/>
+      <xs:enumeration value="darkviolet"/>
+      <xs:enumeration value="deeppink"/>
+      <xs:enumeration value="deepskyblue"/>
+      <xs:enumeration value="dimgray"/>
+      <xs:enumeration value="dimgrey"/>
+      <xs:enumeration value="dodgerblue"/>
+      <xs:enumeration value="firebrick"/>
+      <xs:enumeration value="floralwhite"/>
+      <xs:enumeration value="forestgreen"/>
+      <xs:enumeration value="fuchsia"/>
+      <xs:enumeration value="gainsboro"/>
+      <xs:enumeration value="ghostwhite"/>
+      <xs:enumeration value="gold"/>
+      <xs:enumeration value="goldenrod"/>
+      <xs:enumeration value="gray"/>
+      <xs:enumeration value="green"/>
+      <xs:enumeration value="greenyellow"/>
+      <xs:enumeration value="grey"/>
+      <xs:enumeration value="honeydew"/>
+      <xs:enumeration value="hotpink"/>
+      <xs:enumeration value="indianred"/>
+      <xs:enumeration value="indigo"/>
+      <xs:enumeration value="ivory"/>
+      <xs:enumeration value="khaki"/>
+      <xs:enumeration value="lavender"/>
+      <xs:enumeration value="lavenderblush"/>
+      <xs:enumeration value="lawngreen"/>
+      <xs:enumeration value="lemonchiffon"/>
+      <xs:enumeration value="lightblue"/>
+      <xs:enumeration value="lightcoral"/>
+      <xs:enumeration value="lightcyan"/>
+      <xs:enumeration value="lightgoldenrodyellow"/>
+      <xs:enumeration value="lightgray"/>
+      <xs:enumeration value="lightgreen"/>
+      <xs:enumeration value="lightgrey"/>
+      <xs:enumeration value="lightpink"/>
+      <xs:enumeration value="lightsalmon"/>
+      <xs:enumeration value="lightseagreen"/>
+      <xs:enumeration value="lightskyblue"/>
+      <xs:enumeration value="lightslategrey"/>
+      <xs:enumeration value="lightsteelblue"/>
+      <xs:enumeration value="lightyellow"/>
+      <xs:enumeration value="lime"/>
+      <xs:enumeration value="limegreen"/>
+      <xs:enumeration value="linen"/>
+      <xs:enumeration value="magenta"/>
+      <xs:enumeration value="maroon"/>
+      <xs:enumeration value="mediumaquamarine"/>
+      <xs:enumeration value="mediumblue"/>
+      <xs:enumeration value="mediumorchid"/>
+      <xs:enumeration value="mediumpurple"/>
+      <xs:enumeration value="mediumseagreen"/>
+      <xs:enumeration value="mediumslateblue"/>
+      <xs:enumeration value="mediumspringgreen"/>
+      <xs:enumeration value="mediumturquoise"/>
+      <xs:enumeration value="mediumvioletred"/>
+      <xs:enumeration value="midnightblue"/>
+      <xs:enumeration value="mintcream"/>
+      <xs:enumeration value="mistyrose"/>
+      <xs:enumeration value="moccasin"/>
+      <xs:enumeration value="navajowhite"/>
+      <xs:enumeration value="navy"/>
+      <xs:enumeration value="oldlace"/>
+      <xs:enumeration value="olive"/>
+      <xs:enumeration value="olivedrab"/>
+      <xs:enumeration value="orange"/>
+      <xs:enumeration value="orangered"/>
+      <xs:enumeration value="orchid"/>
+      <xs:enumeration value="palegoldenrod"/>
+      <xs:enumeration value="palegreen"/>
+      <xs:enumeration value="paleturquoise"/>
+      <xs:enumeration value="palevioletred"/>
+      <xs:enumeration value="papayawhip"/>
+      <xs:enumeration value="peachpuff"/>
+      <xs:enumeration value="peru"/>
+      <xs:enumeration value="pink"/>
+      <xs:enumeration value="plum"/>
+      <xs:enumeration value="powderblue"/>
+      <xs:enumeration value="purple"/>
+      <xs:enumeration value="rebeccapurple"/>
+      <xs:enumeration value="red"/>
+      <xs:enumeration value="rosybrown"/>
+      <xs:enumeration value="royalblue"/>
+      <xs:enumeration value="saddlebrown"/>
+      <xs:enumeration value="salmon"/>
+      <xs:enumeration value="sandybrown"/>
+      <xs:enumeration value="seagreen"/>
+      <xs:enumeration value="seashell"/>
+      <xs:enumeration value="sienna"/>
+      <xs:enumeration value="silver"/>
+      <xs:enumeration value="skyblue"/>
+      <xs:enumeration value="slateblue"/>
+      <xs:enumeration value="slategray"/>
+      <xs:enumeration value="snow"/>
+      <xs:enumeration value="springgreen"/>
+      <xs:enumeration value="steelblue"/>
+      <xs:enumeration value="tan"/>
+      <xs:enumeration value="teal"/>
+      <xs:enumeration value="thistle"/>
+      <xs:enumeration value="tomato"/>
+      <xs:enumeration value="turquoise"/>
+      <xs:enumeration value="violet"/>
+      <xs:enumeration value="wheat"/>
+      <xs:enumeration value="white"/>
+      <xs:enumeration value="whitesmoke"/>
+      <xs:enumeration value="yellow"/>
+      <xs:enumeration value="yellowgreen"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="color">
+    <xs:union memberTypes="hv:hex3 hv:hex6 hv:hex8 hv:rgb hv:rgba hv:named-color" />
+  </xs:simpleType>
+
+  <xs:simpleType name="date">
     <xs:restriction base="xs:token">
       <xs:pattern value="\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])"/>
     </xs:restriction>
   </xs:simpleType>
 
-
-  <xs:simpleType name="pointsOrPercentType">
+  <xs:simpleType name="pointsOrPercent">
     <xs:union memberTypes="xs:NMTOKEN">
       <xs:simpleType>
         <xs:restriction base="xs:token">
@@ -75,6 +254,11 @@
         </xs:restriction>
       </xs:simpleType>
     </xs:union>
+  </xs:simpleType>
+
+
+  <xs:simpleType name="styleList">
+    <xs:list itemType="xs:NCName" />
   </xs:simpleType>
 
   <xs:group name="baseChildren">
@@ -120,50 +304,12 @@
     </xs:sequence>
   </xs:group>
 
-  <xs:group name="formChildren">
-    <xs:sequence>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-
-      </xs:choice>
-    </xs:sequence>
-  </xs:group>
-
   <xs:attributeGroup name="behaviorAttributes">
-    <xs:attribute name="action">
-      <xs:simpleType>
-        <xs:restriction base="xs:string">
-          <xs:enumeration value="push"/>
-          <xs:enumeration value="new"/>
-          <xs:enumeration value="back"/>
-          <xs:enumeration value="close"/>
-          <xs:enumeration value="navigate"/>
-          <xs:enumeration value="reload"/>
-          <xs:enumeration value="deep-link"/>
-          <xs:enumeration value="dispatch-event"/>
-          <xs:enumeration value="replace"/>
-          <xs:enumeration value="replace-inner"/>
-          <xs:enumeration value="append"/>
-          <xs:enumeration value="prepend"/>
-          <xs:enumeration value="show"/>
-          <xs:enumeration value="hide"/>
-          <xs:enumeration value="toggle"/>
-          <xs:enumeration value="set-value"/>
-          <xs:enumeration value="ask-rating"/>
-
-          <xs:enumeration value="alert"/>
-          <xs:enumeration value="amplitude"/>
-          <xs:enumeration value="intercom"/>
-          <xs:enumeration value="phone"/>
-          <xs:enumeration value="redux"/>
-          <xs:enumeration value="share"/>
-          <xs:enumeration value="sms"/>
-        </xs:restriction>
-      </xs:simpleType>
-
+    <xs:attribute name="action" type="hv:action">
     </xs:attribute>
 
     <xs:attribute name="target" type="xs:NCName"/>
-    <xs:attribute name="href"/>
+    <xs:attribute name="href" type="xs:string"/>
     <xs:attribute name="once" type="xs:boolean"/>
     <xs:attribute name="trigger" type="xs:NCName"/>
     <xs:attribute name="show-during-load" type="xs:string"/>
@@ -261,13 +407,13 @@
         </xs:simpleType>
       </xs:attribute>
 
-      <xs:attribute name="backgroundColor" type="hv:colorType"/>
+      <xs:attribute name="backgroundColor" type="hv:color"/>
 
-      <xs:attribute name="borderBottomColor" type="hv:colorType"/>
+      <xs:attribute name="borderBottomColor" type="hv:color"/>
 
       <xs:attribute name="borderBottomWidth" type="xs:nonNegativeInteger"/>
 
-      <xs:attribute name="borderColor" type="hv:colorType"/>
+      <xs:attribute name="borderColor" type="hv:color"/>
 
       <xs:attribute name="borderLeftWidth" type="xs:nonNegativeInteger"/>
 
@@ -275,7 +421,7 @@
 
       <xs:attribute name="borderRightWidth" type="xs:nonNegativeInteger"/>
 
-      <xs:attribute name="borderTopColor" type="hv:colorType"/>
+      <xs:attribute name="borderTopColor" type="hv:color"/>
 
       <xs:attribute name="borderTopWidth" type="xs:nonNegativeInteger"/>
 
@@ -283,7 +429,7 @@
 
       <xs:attribute name="bottom" type="xs:integer"/>
 
-      <xs:attribute name="color" type="hv:colorType"/>
+      <xs:attribute name="color" type="hv:color"/>
       <xs:attribute name="elevation" type="xs:nonNegativeInteger"/>
 
       <xs:attribute name="flex">
@@ -318,7 +464,7 @@
         </xs:simpleType>
       </xs:attribute>
 
-      <xs:attribute name="fontFamily"/>
+      <xs:attribute name="fontFamily" type="xs:string"/>
       <xs:attribute name="fontSize" type="xs:positiveInteger"/>
       <xs:attribute name="fontStyle">
         <xs:simpleType>
@@ -347,7 +493,7 @@
         </xs:simpleType>
       </xs:attribute>
 
-      <xs:attribute name="height" type="hv:pointsOrPercentType" />
+      <xs:attribute name="height" type="hv:pointsOrPercent" />
 
       <xs:attribute name="id" type="xs:NCName"/>
 
@@ -364,7 +510,7 @@
         </xs:simpleType>
       </xs:attribute>
 
-      <xs:attribute name="left" type="hv:pointsOrPercentType"/>
+      <xs:attribute name="left" type="hv:pointsOrPercent"/>
       <xs:attribute name="lineHeight" type="xs:integer"/>
       <xs:attribute name="margin" type="xs:integer"/>
       <xs:attribute name="marginBottom" type="xs:integer"/>
@@ -373,10 +519,10 @@
       <xs:attribute name="marginRight" type="xs:integer"/>
       <xs:attribute name="marginTop" type="xs:integer"/>
       <xs:attribute name="marginVertical" type="xs:integer"/>
-      <xs:attribute name="maxHeight" type="hv:pointsOrPercentType"/>
-      <xs:attribute name="maxWidth" type="hv:pointsOrPercentType"/>
-      <xs:attribute name="minHeight" type="hv:pointsOrPercentType"/>
-      <xs:attribute name="minWidth" type="hv:pointsOrPercentType"/>
+      <xs:attribute name="maxHeight" type="hv:pointsOrPercent"/>
+      <xs:attribute name="maxWidth" type="hv:pointsOrPercent"/>
+      <xs:attribute name="minHeight" type="hv:pointsOrPercent"/>
+      <xs:attribute name="minWidth" type="hv:pointsOrPercent"/>
 
       <xs:attribute name="opacity">
         <xs:simpleType>
@@ -397,13 +543,13 @@
         </xs:simpleType>
       </xs:attribute>
 
-      <xs:attribute name="padding" type="hv:pointsOrPercentType"/>
-      <xs:attribute name="paddingBottom" type="hv:pointsOrPercentType"/>
-      <xs:attribute name="paddingHorizontal" type="hv:pointsOrPercentType"/>
-      <xs:attribute name="paddingLeft" type="hv:pointsOrPercentType"/>
-      <xs:attribute name="paddingRight" type="hv:pointsOrPercentType"/>
-      <xs:attribute name="paddingTop" type="hv:pointsOrPercentType"/>
-      <xs:attribute name="paddingVertical" type="hv:pointsOrPercentType"/>
+      <xs:attribute name="padding" type="hv:pointsOrPercent"/>
+      <xs:attribute name="paddingBottom" type="hv:pointsOrPercent"/>
+      <xs:attribute name="paddingHorizontal" type="hv:pointsOrPercent"/>
+      <xs:attribute name="paddingLeft" type="hv:pointsOrPercent"/>
+      <xs:attribute name="paddingRight" type="hv:pointsOrPercent"/>
+      <xs:attribute name="paddingTop" type="hv:pointsOrPercent"/>
+      <xs:attribute name="paddingVertical" type="hv:pointsOrPercent"/>
 
       <xs:attribute name="position">
         <xs:simpleType>
@@ -414,8 +560,8 @@
         </xs:simpleType>
       </xs:attribute>
 
-      <xs:attribute name="right" type="hv:pointsOrPercentType"/>
-      <xs:attribute name="shadowColor" type="hv:colorType"/>
+      <xs:attribute name="right" type="hv:pointsOrPercent"/>
+      <xs:attribute name="shadowColor" type="hv:color"/>
       <xs:attribute name="shadowOffsetX" type="xs:integer"/>
       <xs:attribute name="shadowOffsetY" type="xs:decimal"/>
       <xs:attribute name="shadowOpacity" type="xs:decimal"/>
@@ -434,8 +580,8 @@
       </xs:attribute>
 
       <xs:attribute name="textDecorationLine" type="xs:NCName"/>
-      <xs:attribute name="top" type="hv:pointsOrPercentType"/>
-      <xs:attribute name="width" type="hv:pointsOrPercentType"/>
+      <xs:attribute name="top" type="hv:pointsOrPercent"/>
+      <xs:attribute name="width" type="hv:pointsOrPercent"/>
 
     </xs:complexType>
   </xs:element>
@@ -452,18 +598,13 @@
   </xs:element>
 
   <xs:element name="body">
-    <xs:annotation>
-      <xs:documentation>
-        Test!
-      </xs:documentation>
-    </xs:annotation>
     <xs:complexType>
       <xs:sequence>
         <xs:element minOccurs="0" maxOccurs="1" ref="hv:header"/>
         <xs:group ref="hv:viewChildren"/>
       </xs:sequence>
       <xs:attribute name="id" type="xs:NCName"/>
-      <xs:attribute name="style" type="xs:NCName"/>
+      <xs:attribute name="style" type="hv:styleList"/>
       <xs:attributeGroup ref="hv:scrollAttributes"/>
     </xs:complexType>
   </xs:element>
@@ -471,7 +612,7 @@
   <xs:element name="header">
     <xs:complexType>
       <xs:group ref="hv:viewChildren"/>
-      <xs:attribute name="style"/>
+      <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
     </xs:complexType>
@@ -480,7 +621,7 @@
   <xs:element name="view">
     <xs:complexType>
       <xs:group ref="hv:viewChildren"/>
-      <xs:attribute name="style"/>
+      <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
@@ -491,7 +632,7 @@
   <xs:element name="image">
     <xs:complexType>
       <xs:attribute name="source" use="required" type="xs:anyURI"/>
-      <xs:attribute name="style" use="required"/>
+      <xs:attribute name="style" type="hv:styleList" use="required"/>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
@@ -505,7 +646,7 @@
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:behavior"/>
       </xs:sequence>
       <xs:attribute name="numberOfLines" type="xs:positiveInteger"/>
-      <xs:attribute name="style"/>
+      <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
@@ -528,7 +669,7 @@
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:behavior"/>
       </xs:sequence>
       <xs:attribute name="itemHeight" type="xs:positiveInteger"/>
-      <xs:attribute name="style"/>
+      <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
@@ -541,7 +682,7 @@
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:section"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:behavior"/>
       </xs:sequence>
-      <xs:attribute name="style"/>
+      <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
@@ -562,7 +703,7 @@
   <xs:element name="section-title">
     <xs:complexType>
       <xs:group ref="hv:nonListViewChildren"/>
-      <xs:attribute name="style"/>
+      <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
@@ -573,7 +714,7 @@
     <xs:complexType>
       <xs:group ref="hv:nonListViewChildren"/>
       <xs:attribute name="key" use="required" />
-      <xs:attribute name="style"/>
+      <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
@@ -582,7 +723,7 @@
 
   <xs:element name="spinner">
     <xs:complexType>
-      <xs:attribute name="color" type="hv:colorType" />
+      <xs:attribute name="color" type="hv:color" />
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
     </xs:complexType>
@@ -591,7 +732,7 @@
   <xs:element name="form">
     <xs:complexType>
       <xs:group ref="hv:viewChildren"/>
-      <xs:attribute name="style"/>
+      <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
     </xs:complexType>
@@ -612,13 +753,13 @@
       </xs:attribute>
       <xs:attribute name="value" type="xs:string"/>
       <xs:attribute name="placeholder" type="xs:string"/>
-      <xs:attribute name="placeholderTextColor" type="hv:colorType"/>
-      <xs:attribute name="min" type="hv:dateType"/>
-      <xs:attribute name="max" type="hv:dateType"/>
-      <xs:attribute name="field-style"/>
-      <xs:attribute name="field-text-style"/>
-      <xs:attribute name="modal-style"/>
-      <xs:attribute name="modal-text-style"/>
+      <xs:attribute name="placeholderTextColor" type="hv:color"/>
+      <xs:attribute name="min" type="hv:date"/>
+      <xs:attribute name="max" type="hv:date"/>
+      <xs:attribute name="field-style" type="hv:styleList"/>
+      <xs:attribute name="field-text-style" type="hv:styleList"/>
+      <xs:attribute name="modal-style" type="hv:styleList"/>
+      <xs:attribute name="modal-text-style" type="hv:styleList"/>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
     </xs:complexType>
@@ -632,13 +773,13 @@
       <xs:attribute name="name" use="required" type="xs:string"/>
       <xs:attribute name="value" type="xs:string"/>
       <xs:attribute name="placeholder" type="xs:string"/>
-      <xs:attribute name="placeholderTextColor" type="hv:colorType"/>
+      <xs:attribute name="placeholderTextColor" type="hv:color"/>
       <xs:attribute name="done-label" type="xs:string"/>
       <xs:attribute name="cancel-label" type="xs:string"/>
-      <xs:attribute name="field-style"/>
-      <xs:attribute name="field-text-style"/>
-      <xs:attribute name="modal-style"/>
-      <xs:attribute name="modal-text-style"/>
+      <xs:attribute name="field-style" type="hv:styleList"/>
+      <xs:attribute name="field-text-style" type="hv:styleList"/>
+      <xs:attribute name="modal-style" type="hv:styleList"/>
+      <xs:attribute name="modal-text-style" type="hv:styleList"/>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
     </xs:complexType>
@@ -664,7 +805,7 @@
       </xs:attribute>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
-      <xs:attribute name="style"/>
+      <xs:attribute name="style" type="hv:styleList"/>
     </xs:complexType>
   </xs:element>
 
@@ -673,7 +814,7 @@
       <xs:attribute name="name" use="required" type="xs:string"/>
       <xs:attribute name="value" type="xs:string"/>
       <xs:attribute name="placeholder" type="xs:string"/>
-      <xs:attribute name="placeholderTextColor" type="hv:colorType"/>
+      <xs:attribute name="placeholderTextColor" type="hv:color"/>
       <xs:attribute name="keyboard-type">
         <xs:simpleType>
           <xs:restriction base="xs:string">
@@ -688,7 +829,7 @@
       <xs:attribute name="mask" type="xs:string"/>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
-      <xs:attribute name="style"/>
+      <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="auto-focus" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>
@@ -698,7 +839,7 @@
       <xs:attribute name="name" use="required" type="xs:string"/>
       <xs:attribute name="value" type="xs:string"/>
       <xs:attribute name="placeholder" type="xs:string"/>
-      <xs:attribute name="placeholderTextColor" type="hv:colorType"/>
+      <xs:attribute name="placeholderTextColor" type="hv:color"/>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attribute name="style"/>
@@ -711,7 +852,7 @@
       <xs:attribute name="name" use="required" type="xs:string"/>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
-      <xs:attribute name="style"/>
+      <xs:attribute name="style" type="hv:styleList"/>
     </xs:complexType>
   </xs:element>
 
@@ -721,7 +862,7 @@
       <xs:attribute name="name" use="required" type="xs:string"/>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
-      <xs:attribute name="style"/>
+      <xs:attribute name="style" type="hv:styleList"/>
     </xs:complexType>
   </xs:element>
 
@@ -732,7 +873,7 @@
       <xs:attribute name="value" type="xs:string"/>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>
-      <xs:attribute name="style"/>
+      <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="selected" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -1,0 +1,740 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  elementFormDefault="qualified"
+  targetNamespace="https://hyperview.org/hyperview"
+  xmlns:hv="https://hyperview.org/hyperview"
+  xmlns:alert="https://hyperview.org/hyperview-alert"
+  xmlns:amp="https://instawork.com/hyperview-amplitude"
+  xmlns:intercom="https://instawork.com/hyperview-intercom"
+  xmlns:phone="https://instawork.com/hyperview-phone"
+  xmlns:redux="https://instawork.com/hyperview-redux"
+  xmlns:share="https://instawork.com/hyperview-share"
+  xmlns:sms="https://instawork.com/hyperview-sms"
+>
+
+  <xs:import namespace="https://hyperview.org/hyperview-alert" schemaLocation="alert.xsd"/>
+  <xs:import namespace="https://instawork.com/hyperview-amplitude" schemaLocation="amplitude.xsd"/>
+  <xs:import namespace="https://instawork.com/hyperview-intercom" schemaLocation="intercom.xsd"/>
+  <xs:import namespace="https://instawork.com/hyperview-phone" schemaLocation="phone.xsd"/>
+  <xs:import namespace="https://instawork.com/hyperview-redux" schemaLocation="redux.xsd"/>
+  <xs:import namespace="https://instawork.com/hyperview-share" schemaLocation="share.xsd"/>
+  <xs:import namespace="https://instawork.com/hyperview-sms" schemaLocation="sms.xsd"/>
+
+  <xs:simpleType name="colorType">
+    <xs:union memberTypes="xs:NMTOKEN">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:pattern value="#[0-9a-fA-F]{3}"/>
+        </xs:restriction>
+      </xs:simpleType>
+
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:pattern value="#[0-9a-fA-F]{6}"/>
+        </xs:restriction>
+      </xs:simpleType>
+
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:pattern value="#[0-9a-fA-F]{8}"/>
+        </xs:restriction>
+      </xs:simpleType>
+
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:pattern value="rgb\(\d{1,3},\s*\d{1,3},\s*\d{1,3}\)"/>
+        </xs:restriction>
+      </xs:simpleType>
+
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:pattern value="rgba\(\d{1,3},\s*\d{1,3},\s*\d{1,3},\s*(0?\.\d+|1|1.0+)\)"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+
+  <xs:simpleType name="dateType">
+    <xs:restriction base="xs:token">
+      <xs:pattern value="\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+  <xs:simpleType name="pointsOrPercentType">
+    <xs:union memberTypes="xs:NMTOKEN">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+        </xs:restriction>
+      </xs:simpleType>
+
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:pattern value="\d+%"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+
+  <xs:group name="baseChildren">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="hv:behavior"/>
+        <xs:element ref="hv:image"/>
+        <xs:element ref="hv:spinner"/>
+        <xs:element ref="hv:text"/>
+        <xs:element ref="hv:view"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:group name="nonListViewChildren">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="hv:behavior"/>
+        <xs:element ref="hv:date-field"/>
+        <xs:element ref="hv:form"/>
+        <xs:element ref="hv:image"/>
+        <xs:element ref="hv:option"/>
+        <xs:element ref="hv:picker-field"/>
+        <xs:element ref="hv:spinner"/>
+        <xs:element ref="hv:select-single"/>
+        <xs:element ref="hv:select-multiple"/>
+        <xs:element ref="hv:switch"/>
+        <xs:element ref="hv:text"/>
+        <xs:element ref="hv:text-area"/>
+        <xs:element ref="hv:text-field"/>
+        <xs:element ref="hv:view"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:group name="viewChildren">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:group ref="hv:nonListViewChildren"/>
+        <xs:element ref="hv:list"/>
+        <xs:element ref="hv:section-list"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:group name="formChildren">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:attributeGroup name="behaviorAttributes">
+    <xs:attribute name="action">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="push"/>
+          <xs:enumeration value="new"/>
+          <xs:enumeration value="back"/>
+          <xs:enumeration value="close"/>
+          <xs:enumeration value="navigate"/>
+          <xs:enumeration value="reload"/>
+          <xs:enumeration value="deep-link"/>
+          <xs:enumeration value="dispatch-event"/>
+          <xs:enumeration value="replace"/>
+          <xs:enumeration value="replace-inner"/>
+          <xs:enumeration value="append"/>
+          <xs:enumeration value="prepend"/>
+          <xs:enumeration value="show"/>
+          <xs:enumeration value="hide"/>
+          <xs:enumeration value="toggle"/>
+          <xs:enumeration value="set-value"/>
+          <xs:enumeration value="ask-rating"/>
+
+          <xs:enumeration value="alert"/>
+          <xs:enumeration value="amplitude"/>
+          <xs:enumeration value="intercom"/>
+          <xs:enumeration value="phone"/>
+          <xs:enumeration value="redux"/>
+          <xs:enumeration value="share"/>
+          <xs:enumeration value="sms"/>
+        </xs:restriction>
+      </xs:simpleType>
+
+    </xs:attribute>
+
+    <xs:attribute name="target" type="xs:NCName"/>
+    <xs:attribute name="href"/>
+    <xs:attribute name="once" type="xs:boolean"/>
+    <xs:attribute name="trigger" type="xs:NCName"/>
+    <xs:attribute name="show-during-load" type="xs:string"/>
+    <xs:attribute name="hide-during-load" type="xs:string"/>
+    <xs:attribute name="delay" type="xs:nonNegativeInteger"/>
+    <xs:attribute name="event-name" type="xs:string"/>
+
+    <xs:attributeGroup ref="alert:alertAttributes" />
+    <xs:attributeGroup ref="amp:amplitudeAttributes" />
+    <xs:attributeGroup ref="intercom:intercomAttributes" />
+    <xs:attributeGroup ref="phone:phoneAttributes" />
+    <xs:attributeGroup ref="redux:reduxAttributes" />
+    <xs:attributeGroup ref="share:shareAttributes" />
+    <xs:attributeGroup ref="sms:smsAttributes" />
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="scrollAttributes">
+    <xs:attribute name="scroll" type="xs:boolean"/>
+    <xs:attribute name="scroll-orientation">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="horizontal"/>
+          <xs:enumeration value="vertical"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+
+  <xs:element name="doc">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="hv:screen"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="screen">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="1" ref="hv:styles"/>
+        <xs:element minOccurs="1" maxOccurs="1" ref="hv:body"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:NCName"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="styles">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:style"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="style">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:modifier"/>
+      </xs:sequence>
+
+      <xs:attribute name="alignContent">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="flex-start"/>
+            <xs:enumeration value="flex-end"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="stretch"/>
+            <xs:enumeration value="space-between"/>
+            <xs:enumeration value="space-around"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+
+      <xs:attribute name="alignItems">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="flex-start"/>
+            <xs:enumeration value="flex-end"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="stretch"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+
+      <xs:attribute name="alignSelf">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="flex-start"/>
+            <xs:enumeration value="flex-end"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="stretch"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+
+      <xs:attribute name="backgroundColor" type="hv:colorType"/>
+
+      <xs:attribute name="borderBottomColor" type="hv:colorType"/>
+
+      <xs:attribute name="borderBottomWidth" type="xs:nonNegativeInteger"/>
+
+      <xs:attribute name="borderColor" type="hv:colorType"/>
+
+      <xs:attribute name="borderLeftWidth" type="xs:nonNegativeInteger"/>
+
+      <xs:attribute name="borderRadius" type="xs:nonNegativeInteger"/>
+
+      <xs:attribute name="borderRightWidth" type="xs:nonNegativeInteger"/>
+
+      <xs:attribute name="borderTopColor" type="hv:colorType"/>
+
+      <xs:attribute name="borderTopWidth" type="xs:nonNegativeInteger"/>
+
+      <xs:attribute name="borderWidth" type="xs:nonNegativeInteger"/>
+
+      <xs:attribute name="bottom" type="xs:integer"/>
+
+      <xs:attribute name="color" type="hv:colorType"/>
+      <xs:attribute name="elevation" type="xs:nonNegativeInteger"/>
+
+      <xs:attribute name="flex">
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="-1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+
+      <xs:attribute name="flexDirection">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="row"/>
+            <xs:enumeration value="row-reverse"/>
+            <xs:enumeration value="column"/>
+            <xs:enumeration value="column-reverse"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+
+      <xs:attribute name="flexGrow" type="xs:integer"/>
+
+      <xs:attribute name="flexShrink" type="xs:integer"/>
+
+      <xs:attribute name="flexWrap">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="wrap"/>
+            <xs:enumeration value="nowrap"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+
+      <xs:attribute name="fontFamily"/>
+      <xs:attribute name="fontSize" type="xs:positiveInteger"/>
+      <xs:attribute name="fontStyle">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="normal"/>
+            <xs:enumeration value="italic"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+
+      <xs:attribute name="fontWeight">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="normal"/>
+            <xs:enumeration value="bold"/>
+            <xs:enumeration value="100"/>
+            <xs:enumeration value="200"/>
+            <xs:enumeration value="300"/>
+            <xs:enumeration value="400"/>
+            <xs:enumeration value="500"/>
+            <xs:enumeration value="600"/>
+            <xs:enumeration value="700"/>
+            <xs:enumeration value="800"/>
+            <xs:enumeration value="900"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+
+      <xs:attribute name="height" type="hv:pointsOrPercentType" />
+
+      <xs:attribute name="id" type="xs:NCName"/>
+
+      <xs:attribute name="justifyContent">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="flex-start" />
+            <xs:enumeration value="flex-end" />
+            <xs:enumeration value="center" />
+            <xs:enumeration value="space-between" />
+            <xs:enumeration value="space-around" />
+            <xs:enumeration value="space-evenly" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+
+      <xs:attribute name="left" type="hv:pointsOrPercentType"/>
+      <xs:attribute name="lineHeight" type="xs:integer"/>
+      <xs:attribute name="margin" type="xs:integer"/>
+      <xs:attribute name="marginBottom" type="xs:integer"/>
+      <xs:attribute name="marginHorizontal" type="xs:integer"/>
+      <xs:attribute name="marginLeft" type="xs:integer"/>
+      <xs:attribute name="marginRight" type="xs:integer"/>
+      <xs:attribute name="marginTop" type="xs:integer"/>
+      <xs:attribute name="marginVertical" type="xs:integer"/>
+      <xs:attribute name="maxHeight" type="hv:pointsOrPercentType"/>
+      <xs:attribute name="maxWidth" type="hv:pointsOrPercentType"/>
+      <xs:attribute name="minHeight" type="hv:pointsOrPercentType"/>
+      <xs:attribute name="minWidth" type="hv:pointsOrPercentType"/>
+
+      <xs:attribute name="opacity">
+        <xs:simpleType>
+          <xs:restriction base="xs:decimal">
+            <xs:minInclusive value="0.0"/>
+            <xs:maxInclusive value="1.0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+
+      <xs:attribute name="overflow">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="visible" />
+            <xs:enumeration value="hidden" />
+            <xs:enumeration value="scroll" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+
+      <xs:attribute name="padding" type="hv:pointsOrPercentType"/>
+      <xs:attribute name="paddingBottom" type="hv:pointsOrPercentType"/>
+      <xs:attribute name="paddingHorizontal" type="hv:pointsOrPercentType"/>
+      <xs:attribute name="paddingLeft" type="hv:pointsOrPercentType"/>
+      <xs:attribute name="paddingRight" type="hv:pointsOrPercentType"/>
+      <xs:attribute name="paddingTop" type="hv:pointsOrPercentType"/>
+      <xs:attribute name="paddingVertical" type="hv:pointsOrPercentType"/>
+
+      <xs:attribute name="position">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="absolute" />
+            <xs:enumeration value="relative" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+
+      <xs:attribute name="right" type="hv:pointsOrPercentType"/>
+      <xs:attribute name="shadowColor" type="hv:colorType"/>
+      <xs:attribute name="shadowOffsetX" type="xs:integer"/>
+      <xs:attribute name="shadowOffsetY" type="xs:decimal"/>
+      <xs:attribute name="shadowOpacity" type="xs:decimal"/>
+      <xs:attribute name="shadowRadius" type="xs:decimal"/>
+
+      <xs:attribute name="textAlign">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="auto" />
+            <xs:enumeration value="left" />
+            <xs:enumeration value="right" />
+            <xs:enumeration value="center" />
+            <xs:enumeration value="justify" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+
+      <xs:attribute name="textDecorationLine" type="xs:NCName"/>
+      <xs:attribute name="top" type="hv:pointsOrPercentType"/>
+      <xs:attribute name="width" type="hv:pointsOrPercentType"/>
+
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="modifier">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="hv:style"/>
+      </xs:sequence>
+      <xs:attribute name="focused" type="xs:boolean"/>
+      <xs:attribute name="pressed" type="xs:boolean"/>
+      <xs:attribute name="selected" type="xs:boolean"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="body">
+    <xs:annotation>
+      <xs:documentation>
+        Test!
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="1" ref="hv:header"/>
+        <xs:group ref="hv:viewChildren"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="style" type="xs:NCName"/>
+      <xs:attributeGroup ref="hv:scrollAttributes"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="header">
+    <xs:complexType>
+      <xs:group ref="hv:viewChildren"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="view">
+    <xs:complexType>
+      <xs:group ref="hv:viewChildren"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+      <xs:attributeGroup ref="hv:behaviorAttributes"/>
+      <xs:attributeGroup ref="hv:scrollAttributes"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="image">
+    <xs:complexType>
+      <xs:attribute name="source" use="required" type="xs:anyURI"/>
+      <xs:attribute name="style" use="required"/>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+      <xs:attributeGroup ref="hv:behaviorAttributes"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="text">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:text"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:behavior"/>
+      </xs:sequence>
+      <xs:attribute name="numberOfLines" type="xs:positiveInteger"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+      <xs:attributeGroup ref="hv:behaviorAttributes"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="behavior">
+    <xs:complexType>
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="alert:option" />
+      </xs:sequence>
+      <xs:attributeGroup ref="hv:behaviorAttributes"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="list">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:item"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:behavior"/>
+      </xs:sequence>
+      <xs:attribute name="itemHeight" type="xs:positiveInteger"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+      <xs:attributeGroup ref="hv:behaviorAttributes"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="section-list">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:section"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:behavior"/>
+      </xs:sequence>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+      <xs:attributeGroup ref="hv:behaviorAttributes"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="section">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="1" ref="hv:section-title"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:item"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="section-title">
+    <xs:complexType>
+      <xs:group ref="hv:nonListViewChildren"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+      <xs:attributeGroup ref="hv:behaviorAttributes"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="item">
+    <xs:complexType>
+      <xs:group ref="hv:nonListViewChildren"/>
+      <xs:attribute name="key" use="required" />
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+      <xs:attributeGroup ref="hv:behaviorAttributes"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="spinner">
+    <xs:complexType>
+      <xs:attribute name="color" type="hv:colorType" />
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="form">
+    <xs:complexType>
+      <xs:group ref="hv:viewChildren"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="date-field">
+    <xs:complexType>
+      <xs:attribute name="name" use="required" type="xs:string"/>
+      <xs:attribute name="label-format" type="xs:string"/>
+      <xs:attribute name="mode">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="calendar"/>
+            <xs:enumeration value="spinner"/>
+            <xs:enumeration value="default"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="value" type="xs:string"/>
+      <xs:attribute name="placeholder" type="xs:string"/>
+      <xs:attribute name="placeholderTextColor" type="hv:colorType"/>
+      <xs:attribute name="min" type="hv:dateType"/>
+      <xs:attribute name="max" type="hv:dateType"/>
+      <xs:attribute name="field-style"/>
+      <xs:attribute name="field-text-style"/>
+      <xs:attribute name="modal-style"/>
+      <xs:attribute name="modal-text-style"/>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="picker-field">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="hv:picker-item"/>
+      </xs:sequence>
+      <xs:attribute name="name" use="required" type="xs:string"/>
+      <xs:attribute name="value" type="xs:string"/>
+      <xs:attribute name="placeholder" type="xs:string"/>
+      <xs:attribute name="placeholderTextColor" type="hv:colorType"/>
+      <xs:attribute name="done-label" type="xs:string"/>
+      <xs:attribute name="cancel-label" type="xs:string"/>
+      <xs:attribute name="field-style"/>
+      <xs:attribute name="field-text-style"/>
+      <xs:attribute name="modal-style"/>
+      <xs:attribute name="modal-text-style"/>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="picker-item">
+    <xs:complexType>
+      <xs:attribute name="label" use="required" type="xs:string"/>
+      <xs:attribute name="value" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="switch">
+    <xs:complexType>
+      <xs:attribute name="name" use="required" type="xs:string"/>
+      <xs:attribute name="value">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="on"/>
+            <xs:enumeration value="off"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+      <xs:attribute name="style"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="text-field">
+    <xs:complexType>
+      <xs:attribute name="name" use="required" type="xs:string"/>
+      <xs:attribute name="value" type="xs:string"/>
+      <xs:attribute name="placeholder" type="xs:string"/>
+      <xs:attribute name="placeholderTextColor" type="hv:colorType"/>
+      <xs:attribute name="keyboard-type">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="default"/>
+            <xs:enumeration value="number-pad"/>
+            <xs:enumeration value="decimal-pad"/>
+            <xs:enumeration value="phone-pad"/>
+            <xs:enumeration value="email-address"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="mask" type="xs:string"/>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="auto-focus" type="xs:boolean"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="text-area">
+    <xs:complexType>
+      <xs:attribute name="name" use="required" type="xs:string"/>
+      <xs:attribute name="value" type="xs:string"/>
+      <xs:attribute name="placeholder" type="xs:string"/>
+      <xs:attribute name="placeholderTextColor" type="hv:colorType"/>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+      <xs:attribute name="style"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="select-single">
+    <xs:complexType>
+      <xs:group ref="hv:viewChildren"/>
+      <xs:attribute name="name" use="required" type="xs:string"/>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+      <xs:attribute name="style"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="select-multiple">
+    <xs:complexType>
+      <xs:group ref="hv:viewChildren"/>
+      <xs:attribute name="name" use="required" type="xs:string"/>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+      <xs:attribute name="style"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="option">
+    <xs:complexType>
+      <xs:group ref="hv:baseChildren"/>
+      <xs:attributeGroup ref="hv:behaviorAttributes"/>
+      <xs:attribute name="value" type="xs:string"/>
+      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="hide" type="xs:boolean"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="selected" type="xs:boolean"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/schema/intercom.xsd
+++ b/schema/intercom.xsd
@@ -1,0 +1,10 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  attributeFormDefault="qualified"
+  elementFormDefault="qualified"
+  targetNamespace="https://instawork.com/hyperview-intercom"
+>
+  <xs:attributeGroup name="intercomAttributes">
+    <xs:attribute name="action" type="xs:string" />
+    <xs:attribute name="topic" type="xs:string" />
+  </xs:attributeGroup>
+</xs:schema>

--- a/schema/phone.xsd
+++ b/schema/phone.xsd
@@ -1,0 +1,10 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  attributeFormDefault="qualified"
+  elementFormDefault="qualified"
+  targetNamespace="https://instawork.com/hyperview-phone"
+>
+
+  <xs:attributeGroup name="phoneAttributes">
+    <xs:attribute name="number" type="xs:string" />
+  </xs:attributeGroup>
+</xs:schema>

--- a/schema/phone.xsd
+++ b/schema/phone.xsd
@@ -3,7 +3,6 @@
   elementFormDefault="qualified"
   targetNamespace="https://instawork.com/hyperview-phone"
 >
-
   <xs:attributeGroup name="phoneAttributes">
     <xs:attribute name="number" type="xs:string" />
   </xs:attributeGroup>

--- a/schema/redux.xsd
+++ b/schema/redux.xsd
@@ -1,0 +1,10 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  attributeFormDefault="qualified"
+  elementFormDefault="qualified"
+  targetNamespace="https://instawork.com/hyperview-redux"
+>
+  <xs:attributeGroup name="reduxAttributes">
+    <xs:attribute name="action" type="xs:string" />
+    <xs:attribute name="extra" type="xs:string" />
+  </xs:attributeGroup>
+</xs:schema>

--- a/schema/share.xsd
+++ b/schema/share.xsd
@@ -3,7 +3,6 @@
   elementFormDefault="qualified"
   targetNamespace="https://instawork.com/hyperview-share"
 >
-
   <xs:attributeGroup name="shareAttributes">
     <xs:attribute name="dialogTitle" type="xs:string" />
     <xs:attribute name="message" type="xs:string" />

--- a/schema/share.xsd
+++ b/schema/share.xsd
@@ -1,0 +1,14 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  attributeFormDefault="qualified"
+  elementFormDefault="qualified"
+  targetNamespace="https://instawork.com/hyperview-share"
+>
+
+  <xs:attributeGroup name="shareAttributes">
+    <xs:attribute name="dialogTitle" type="xs:string" />
+    <xs:attribute name="message" type="xs:string" />
+    <xs:attribute name="subject" type="xs:string" />
+    <xs:attribute name="title" type="xs:string" />
+    <xs:attribute name="url" type="xs:string" />
+  </xs:attributeGroup>
+</xs:schema>

--- a/schema/sms.xsd
+++ b/schema/sms.xsd
@@ -3,7 +3,6 @@
   elementFormDefault="qualified"
   targetNamespace="https://instawork.com/hyperview-sms"
 >
-
   <xs:attributeGroup name="smsAttributes">
     <xs:attribute name="number" type="xs:string" />
   </xs:attributeGroup>

--- a/schema/sms.xsd
+++ b/schema/sms.xsd
@@ -1,0 +1,10 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  attributeFormDefault="qualified"
+  elementFormDefault="qualified"
+  targetNamespace="https://instawork.com/hyperview-sms"
+>
+
+  <xs:attributeGroup name="smsAttributes">
+    <xs:attribute name="number" type="xs:string" />
+  </xs:attributeGroup>
+</xs:schema>


### PR DESCRIPTION
Adding an XML schema for Hyperview that can be used for validation, docs generation, IDE tools, etc.

- The schema files live under the `schema/` directory. `hyperview.xsd` is the main schema, and it imports other schemas for the various namespaces we use.
- I added a command `yarn test:validate-xml` that validates the schema against the XML files under `examples/`.
- I fixed up the examples that contained easy-to-fix issues like wrong namespaces, missing attributes, etc.

However, some examples cannot be validated due to an issue in the Hyperview spec. The schema revealed a conflict between two features:
- Many elements like `<option>` use the attribute `value` to hold the input value.
- The `set-value` behavior uses the attribute `value` to update any input element.
This means that an `<option>` field that triggers a behavior to set another field is ambiguous, because `value` has two meanings.

We will need to resolve this issue in the spec before completing the schema.