### PR TITLE
Extract XML fetching code in its own service

### DIFF
--- a/demo/screens/HyperviewScreen.js
+++ b/demo/screens/HyperviewScreen.js
@@ -58,7 +58,6 @@ export default class HyperviewScreen extends React.PureComponent {
       headers: {
         // Don't cache requests for the demo
         'Cache-Control': 'no-cache, no-store, must-revalidate',
-        Accept: 'application/xml',
         Pragma: 'no-cache',
         Expires: 0,
         ...init.headers,

--- a/docs/reference_behavior_attributes.md
+++ b/docs/reference_behavior_attributes.md
@@ -284,9 +284,9 @@ An unspecified `href` looks like "#". This can only be used with `back` and `clo
 
 ## verb
 
-| Type                                        | Required |
-| ------------------------------------------- | -------- |
-| **get** (default), post, put, patch, delete | No       |
+| Type                    | Required |
+| ----------------------- | -------- |
+| **get** (default), post | No       |
 
 The `verb` attribute defines the HTTP method used to request the content specified by `href`. If not specified, defaults to "get".
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
     },
     "modulePathIgnorePatterns": [
       "./demo/"
+    ],
+    "setupFiles": [
+      "./test/setup.js"
     ]
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -296,18 +296,16 @@ export default class HyperScreen extends React.Component {
    */
   fetchElement = async (href, method, root, formData) => {
     if (href[0] === '#') {
-      return new Promise((resolve, reject) => {
-        const element = root.getElementById(href.slice(1));
-        if (element) {
-          resolve(element.cloneNode(true));
-        }
-        reject();
-      });
+      const element = root.getElementById(href.slice(1));
+      if (element) {
+        return element.cloneNode(true);
+      }
+      throw new Error();
     }
 
     try {
       const url = UrlService.getUrlFromHref(href, this.state.url, method);
-      const document = await this.parser.load(url, formData, );
+      const document = await this.parser.load(url, formData);
       return document.documentElement;
     } catch (err) {
       this.setState({

--- a/src/services/dom/errors.js
+++ b/src/services/dom/errors.js
@@ -1,0 +1,13 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export class ParserWarning extends Error {}
+export class ParserError extends Error {}
+export class ParserFatalError extends Error {}

--- a/src/services/dom/index.js
+++ b/src/services/dom/index.js
@@ -14,7 +14,7 @@ import { CONTENT_TYPE, HTTP_HEADERS, HTTP_METHODS } from './types';
 import { ParserError, ParserFatalError, ParserWarning } from './errors';
 import { DOMParser } from 'xmldom-instawork';
 import { Dimensions } from 'react-native';
-import type { Document as DocumentType } from 'hyperview/src/types';
+import type { Document } from 'hyperview/src/types';
 import { version } from 'hyperview/package.json';
 
 const { width, height } = Dimensions.get('window');
@@ -58,7 +58,7 @@ export class Parser {
     baseUrl: string,
     data: ?FormData,
     method: ?HttpMethod = HTTP_METHODS.GET,
-  ): any => {
+  ): Promise<Document> => {
     // For GET requests, we can't include a body so we encode the form data as a query
     // string in the URL.
     const url =
@@ -79,7 +79,7 @@ export class Parser {
     if (this.onBeforeParse) {
       this.onBeforeParse(url);
     }
-    const document: DocumentType = parser.parseFromString(responseText);
+    const document = parser.parseFromString(responseText);
     if (this.onAfterParse) {
       this.onAfterParse(url);
     }

--- a/src/services/dom/index.js
+++ b/src/services/dom/index.js
@@ -1,0 +1,88 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import * as UrlService from 'hyperview/src/services/url';
+import type { BeforeAfterParseHandler, Fetch, HttpMethod } from './types';
+import { CONTENT_TYPE, HTTP_HEADERS, HTTP_METHODS } from './types';
+import { ParserError, ParserFatalError, ParserWarning } from './errors';
+import { DOMParser } from 'xmldom-instawork';
+import { Dimensions } from 'react-native';
+import type { Document as DocumentType } from 'hyperview/src/types';
+import { version } from 'hyperview/package.json';
+
+const { width, height } = Dimensions.get('window');
+const headers = {
+  [HTTP_HEADERS.ACCEPT]: CONTENT_TYPE.APPLICATION_XML,
+  [HTTP_HEADERS.X_HYPERVIEW_VERSION]: version,
+  [HTTP_HEADERS.X_HYPERVIEW_DIMENSIONS]: `${width}w ${height}h`,
+};
+
+const parser = new DOMParser({
+  locator: {},
+  errorHandler: {
+    error: (error: string) => {
+      throw new ParserError(error);
+    },
+    fatalError: (error: string) => {
+      throw new ParserFatalError(error);
+    },
+    warning: (error: string) => {
+      throw new ParserWarning(error);
+    },
+  },
+});
+
+export class Parser {
+  fetch: Fetch;
+  onBeforeParse: ?BeforeAfterParseHandler;
+  onAfterParse: ?BeforeAfterParseHandler;
+
+  constructor(
+    fetch: Fetch,
+    onBeforeParse: ?BeforeAfterParseHandler,
+    onAfterParse: ?BeforeAfterParseHandler,
+  ) {
+    this.fetch = fetch;
+    this.onBeforeParse = onBeforeParse;
+    this.onAfterParse = onAfterParse;
+  }
+
+  load = async (
+    baseUrl: string,
+    data: ?FormData,
+    method: ?HttpMethod = HTTP_METHODS.GET,
+  ): any => {
+    // For GET requests, we can't include a body so we encode the form data as a query
+    // string in the URL.
+    const url =
+      method === HTTP_METHODS.GET && data
+        ? UrlService.addFormDataToUrl(baseUrl, data)
+        : baseUrl;
+
+    const options = {
+      // For non-GET requests, include the formdata as the body of the request.
+      body: method === HTTP_METHODS.GET ? undefined : data,
+      headers,
+      method,
+    };
+
+    const response: Response = await this.fetch(url, options);
+    const responseText: string = await response.text();
+
+    if (this.onBeforeParse) {
+      this.onBeforeParse(url);
+    }
+    const document: DocumentType = parser.parseFromString(responseText);
+    if (this.onAfterParse) {
+      this.onAfterParse(url);
+    }
+    return document;
+  };
+}

--- a/src/services/dom/index.test.js
+++ b/src/services/dom/index.test.js
@@ -1,0 +1,131 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import * as Dom from 'hyperview/src/services/dom';
+import * as UrlService from 'hyperview/src/services/url';
+
+// Mock instawork-xmldom module
+const mockExpectedDocument = { foo: 'bar' };
+const mockParseFromString = jest.fn().mockReturnValue(mockExpectedDocument);
+jest.mock('xmldom-instawork', () => {
+  const DOMParser = () => null;
+  DOMParser.prototype.parseFromString = (...args) =>
+    mockParseFromString.apply(this, args);
+  return { DOMParser };
+});
+
+// Mock other dependencies
+const fetchMock: () => Promise<Response> = jest.fn();
+const responseTextMock: () => void = jest.fn();
+fetchMock.mockResolvedValue({ text: responseTextMock });
+const beforeParseMock: () => void = jest.fn();
+const afterParseMock: () => void = jest.fn();
+const urlServiceAddFormDataToUrlMock: () => void = jest.spyOn(
+  UrlService,
+  'addFormDataToUrl',
+);
+const parser = new Dom.Parser(fetchMock, beforeParseMock, afterParseMock);
+
+describe('Parser', () => {
+  afterEach(() => {
+    mockParseFromString.mockClear();
+    fetchMock.mockClear();
+    responseTextMock.mockClear();
+    beforeParseMock.mockClear();
+    afterParseMock.mockClear();
+    urlServiceAddFormDataToUrlMock.mockClear();
+  });
+
+  describe('load', () => {
+    describe('simple GET', () => {
+      it('calls fetch with correct params', async () => {
+        const url = 'http://foo/bar';
+        const expectedOptions = {
+          body: undefined,
+          headers: {
+            Accept: 'application/xml',
+            'X-Hyperview-Dimensions': '750w 1334h',
+            'X-Hyperview-Version': '0.24.2',
+          },
+          method: 'GET',
+        };
+        const responseText = 'foobarbaz';
+        responseTextMock.mockResolvedValue(responseText);
+
+        const document = await parser.load(url);
+
+        expect(urlServiceAddFormDataToUrlMock).toHaveBeenCalledTimes(0);
+        expect(mockParseFromString).toHaveBeenCalledWith(responseText);
+        expect(beforeParseMock).toHaveBeenCalledWith(url);
+        expect(afterParseMock).toHaveBeenCalledWith(url);
+        expect(fetchMock).toHaveBeenCalledWith(url, expectedOptions);
+        expect(document).toEqual(mockExpectedDocument);
+      });
+    });
+
+    describe('GET with data', () => {
+      it('calls fetch with correct params', async () => {
+        const url = 'http://foo/bar';
+        const data = new FormData();
+        data.append('foo', 'bar');
+        data.append('bar', 'baz');
+        const expectedUrl = 'http://foo/bar?foo=bar&bar=baz';
+        urlServiceAddFormDataToUrlMock.mockReturnValue(expectedUrl);
+        const responseText = 'foobarbaz';
+        responseTextMock.mockResolvedValue(responseText);
+
+        const document = await parser.load(url, data);
+
+        expect(urlServiceAddFormDataToUrlMock).toHaveBeenCalledWith(url, data);
+        expect(mockParseFromString).toHaveBeenCalledWith(responseText);
+        expect(beforeParseMock).toHaveBeenCalledWith(expectedUrl);
+        expect(afterParseMock).toHaveBeenCalledWith(expectedUrl);
+        expect(fetchMock).toHaveBeenCalledWith(expectedUrl, {
+          body: undefined,
+          headers: {
+            Accept: 'application/xml',
+            'X-Hyperview-Dimensions': '750w 1334h',
+            'X-Hyperview-Version': '0.24.2',
+          },
+          method: 'GET',
+        });
+        expect(document).toEqual(mockExpectedDocument);
+      });
+    });
+
+    describe('POST', () => {
+      it('calls fetch with correct params', async () => {
+        const url = 'http://foo/bar';
+        const data = new FormData();
+        data.append('foo', 'bar');
+        data.append('bar', 'baz');
+        const responseText = 'foobarbaz';
+        responseTextMock.mockResolvedValue(responseText);
+
+        const document = await parser.load(url, data, 'POST');
+
+        expect(urlServiceAddFormDataToUrlMock).toHaveBeenCalledTimes(0);
+        expect(mockParseFromString).toHaveBeenCalledWith(responseText);
+        expect(beforeParseMock).toHaveBeenCalledWith(url);
+        expect(afterParseMock).toHaveBeenCalledWith(url);
+        expect(fetchMock).toHaveBeenCalledWith(url, {
+          body: data,
+          headers: {
+            Accept: 'application/xml',
+            'X-Hyperview-Dimensions': '750w 1334h',
+            'X-Hyperview-Version': '0.24.2',
+          },
+          method: 'POST',
+        });
+        expect(document).toEqual(mockExpectedDocument);
+      });
+    });
+  });
+});

--- a/src/services/dom/types.js
+++ b/src/services/dom/types.js
@@ -1,0 +1,37 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export const HTTP_HEADERS = {
+  ACCEPT: 'Accept',
+  CONTENT_TYPE: 'Content-Type',
+  X_HYPERVIEW_VERSION: 'X-Hyperview-Version',
+  X_HYPERVIEW_DIMENSIONS: 'X-Hyperview-Dimensions',
+};
+
+export const HTTP_METHODS = {
+  GET: 'GET',
+  POST: 'POST',
+};
+
+export type HttpMethod = $Values<typeof HTTP_METHODS>;
+
+export const CONTENT_TYPE = {
+  APPLICATION_XML: 'application/xml',
+  TEXT_HTML: 'text/html',
+};
+
+export type Fetch = (
+  url: string,
+  options: { headers: { [string]: any } },
+) => Promise<Response>;
+
+export type ErrorHandler = (error: Error) => void;
+
+export type BeforeAfterParseHandler = (url: string) => void;

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,15 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+class FormData {
+  append: (string, string) => void = () => {};
+}
+
+global.FormData = FormData;


### PR DESCRIPTION
Goals of this code change:
- centralize code that loads remote content, currently spread out between `load` and `fetchElement`
- use async/await style instead of chained promise to ease readability and avoid variable mutations
- in a future PR, have a better handling for error responses that can containt non-xml content type (i.e. Django errors responses are text/html)
- more tests and flow coverage (src/index.js is explicitely ignored by linters as it contains too many issues)

Regarding the naming of the service, I choose `dom` even if right now it has little to do with DOM manipulation. The reasoning is to have a common place for abstractions of the `xmldom` module, and the goal would be to eventually move most of the DOM helpers currently living in [src/services/index.js (currently used a dumping ground for shared functions)](https://github.com/Instawork/hyperview/blob/master/src/services/index.js#L33-L36). I'm open to suggestions for a better name if any.

Implementation notes:
I choose a instantiable class over a simple function, so that the component props `fetch`, `onParseBefore` and `onParseAfter` could only be injected once.
I've also incorporated in this class the responsability to set the `Accept=application/xml` header, hence why it was removed from the demo app.