### PR TITLE
Use stricter attribute checks in Schema

### DIFF
--- a/examples/styling/text.xml
+++ b/examples/styling/text.xml
@@ -71,6 +71,16 @@
              fontWeight="bold" />
       <style id="Text--Green"
              color="#63CB76" />
+
+      <style id="Text--RGB"
+             color="rgb(255, 0, 255)" />
+      <style id="Text--RGBA"
+             color="rgba(255, 0, 255, 0.5)" />
+      <style id="Text--HSL"
+             color="hsl(230, 100%, 80%)" />
+      <style id="Text-HSLA"
+             color="hsla(230, 100%, 80%, 0.5)" />
+
       <style id="Main"
              flex="1" />
     </styles>
@@ -92,6 +102,12 @@
         <text style="Text Text--Medium Text--SemiBoldWeight">Semi-Bold</text>
         <text style="Text Text--Medium Text--BoldWeight">Bold</text>
         <text style="Text Text--Medium Text--BoldWeight Text--Green">Color</text>
+
+        <text style="Text Text--Medium Text--BoldWeight Text--HSL">HSL Color</text>
+        <text style="Text Text--Medium Text--BoldWeight Text--HSLA">HSLA Color</text>
+
+        <text style="Text Text--Medium Text--BoldWeight Text--RGB">RGB Color</text>
+        <text style="Text Text--Medium Text--BoldWeight Text--RGBA">RGBA Color</text>
       </view>
     </body>
   </screen>

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -288,10 +288,6 @@
     <xs:list itemType="xs:NCName" />
   </xs:simpleType>
 
-  <xs:simpleType name="idList">
-    <xs:list itemType="xs:NCName" />
-  </xs:simpleType>
-
   <xs:group name="baseChildren">
     <xs:sequence>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
@@ -337,12 +333,12 @@
 
   <xs:attributeGroup name="behaviorAttributes">
     <xs:attribute name="action" type="hv:action" />
-    <xs:attribute name="target" type="xs:NCName"/>
+    <xs:attribute name="target" type="xs:IDREF"/>
     <xs:attribute name="href" type="xs:string"/>
     <xs:attribute name="once" type="xs:boolean"/>
     <xs:attribute name="trigger" type="hv:trigger"/>
-    <xs:attribute name="show-during-load" type="hv:idList"/>
-    <xs:attribute name="hide-during-load" type="hv:idList"/>
+    <xs:attribute name="show-during-load" type="xs:IDREFS"/>
+    <xs:attribute name="hide-during-load" type="xs:IDREFS"/>
     <xs:attribute name="delay" type="xs:nonNegativeInteger"/>
     <xs:attribute name="event-name" type="xs:NCName"/>
     <xs:attribute name="new-value" type="xs:string"/>
@@ -382,7 +378,7 @@
         <xs:element minOccurs="0" maxOccurs="1" ref="hv:styles"/>
         <xs:element minOccurs="1" maxOccurs="1" ref="hv:body"/>
       </xs:sequence>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
     </xs:complexType>
   </xs:element>
 
@@ -633,7 +629,7 @@
         <xs:element minOccurs="0" maxOccurs="1" ref="hv:header"/>
         <xs:group ref="hv:viewChildren"/>
       </xs:sequence>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="style" type="hv:styleList"/>
       <xs:attributeGroup ref="hv:scrollAttributes"/>
     </xs:complexType>
@@ -643,7 +639,7 @@
     <xs:complexType>
       <xs:group ref="hv:viewChildren"/>
       <xs:attribute name="style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>
@@ -652,7 +648,7 @@
     <xs:complexType>
       <xs:group ref="hv:viewChildren"/>
       <xs:attribute name="style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
       <xs:attributeGroup ref="hv:scrollAttributes"/>
@@ -663,7 +659,7 @@
     <xs:complexType>
       <xs:attribute name="source" use="required" type="xs:anyURI"/>
       <xs:attribute name="style" type="hv:styleList" use="required"/>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
     </xs:complexType>
@@ -677,7 +673,7 @@
       </xs:sequence>
       <xs:attribute name="numberOfLines" type="xs:positiveInteger"/>
       <xs:attribute name="style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
     </xs:complexType>
@@ -703,7 +699,7 @@
       </xs:sequence>
       <xs:attribute name="itemHeight" type="xs:positiveInteger"/>
       <xs:attribute name="style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
     </xs:complexType>
@@ -718,7 +714,7 @@
         </xs:choice>
       </xs:sequence>
       <xs:attribute name="style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
     </xs:complexType>
@@ -739,7 +735,7 @@
     <xs:complexType>
       <xs:group ref="hv:nonListViewChildren"/>
       <xs:attribute name="style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
     </xs:complexType>
@@ -758,7 +754,7 @@
       <xs:group ref="hv:nonListViewChildren"/>
       <xs:attribute name="key" use="required" />
       <xs:attribute name="style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
     </xs:complexType>
@@ -767,7 +763,7 @@
   <xs:element name="spinner">
     <xs:complexType>
       <xs:attribute name="color" type="hv:color" />
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>
@@ -776,7 +772,7 @@
     <xs:complexType>
       <xs:group ref="hv:viewChildren"/>
       <xs:attribute name="style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:scrollAttributes"/>
     </xs:complexType>
@@ -804,7 +800,7 @@
       <xs:attribute name="field-text-style" type="hv:styleList"/>
       <xs:attribute name="modal-style" type="hv:styleList"/>
       <xs:attribute name="modal-text-style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>
@@ -824,7 +820,7 @@
       <xs:attribute name="field-text-style" type="hv:styleList"/>
       <xs:attribute name="modal-style" type="hv:styleList"/>
       <xs:attribute name="modal-text-style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>
@@ -847,7 +843,7 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attribute name="style" type="hv:styleList"/>
     </xs:complexType>
@@ -871,7 +867,7 @@
         </xs:simpleType>
       </xs:attribute>
       <xs:attribute name="mask" type="xs:string"/>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="auto-focus" type="xs:boolean"/>
@@ -884,7 +880,7 @@
       <xs:attribute name="value" type="xs:string"/>
       <xs:attribute name="placeholder" type="xs:string"/>
       <xs:attribute name="placeholderTextColor" type="hv:color"/>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attribute name="style"/>
     </xs:complexType>
@@ -894,7 +890,7 @@
     <xs:complexType>
       <xs:group ref="hv:viewChildren"/>
       <xs:attribute name="name" use="required" type="xs:string"/>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attribute name="style" type="hv:styleList"/>
     </xs:complexType>
@@ -904,7 +900,7 @@
     <xs:complexType>
       <xs:group ref="hv:viewChildren"/>
       <xs:attribute name="name" use="required" type="xs:string"/>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attribute name="style" type="hv:styleList"/>
     </xs:complexType>
@@ -915,7 +911,7 @@
       <xs:group ref="hv:baseChildren"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
       <xs:attribute name="value" type="xs:string"/>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="selected" type="xs:boolean"/>

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -51,6 +51,21 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:simpleType name="trigger">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="press"/>
+      <xs:enumeration value="longPress"/>
+      <xs:enumeration value="pressIn"/>
+      <xs:enumeration value="pressOut"/>
+      <xs:enumeration value="visible"/>
+      <xs:enumeration value="refresh"/>
+      <xs:enumeration value="load"/>
+      <xs:enumeration value="select"/>
+      <xs:enumeration value="deselect"/>
+      <xs:enumeration value="on-event"/>
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:simpleType name="hex3">
     <xs:restriction base="xs:token">
       <xs:pattern value="#[0-9a-fA-F]{3}"/>
@@ -78,6 +93,18 @@
   <xs:simpleType name="rgba">
     <xs:restriction base="xs:token">
       <xs:pattern value="rgba\(\d{1,3},\s*\d{1,3},\s*\d{1,3},\s*(0?\.\d+|1|1.0+)\)"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="hsl">
+    <xs:restriction base="xs:token">
+      <xs:pattern value="hsl\((\d{1,2}|1\d{2}|2\d{2}|3[0-5][0-9]|360),\s*(\d{1,2}|100)%,\s*(\d{1,2}|100)%\)"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="hsla">
+    <xs:restriction base="xs:token">
+      <xs:pattern value="hsla\((\d{1,2}|1\d{2}|2\d{2}|3[0-5][0-9]|360),\s*(\d{1,2}|100)%,\s*(\d{1,2}|100)%,\s*(0?\.\d+|1|1.0+)\)"/>
     </xs:restriction>
   </xs:simpleType>
 
@@ -232,7 +259,7 @@
   </xs:simpleType>
 
   <xs:simpleType name="color">
-    <xs:union memberTypes="hv:hex3 hv:hex6 hv:hex8 hv:rgb hv:rgba hv:named-color" />
+    <xs:union memberTypes="hv:hex3 hv:hex6 hv:hex8 hv:rgb hv:rgba hv:hsl hv:hsla hv:named-color" />
   </xs:simpleType>
 
   <xs:simpleType name="date">
@@ -258,6 +285,10 @@
 
 
   <xs:simpleType name="styleList">
+    <xs:list itemType="xs:NCName" />
+  </xs:simpleType>
+
+  <xs:simpleType name="idList">
     <xs:list itemType="xs:NCName" />
   </xs:simpleType>
 
@@ -305,17 +336,15 @@
   </xs:group>
 
   <xs:attributeGroup name="behaviorAttributes">
-    <xs:attribute name="action" type="hv:action">
-    </xs:attribute>
-
+    <xs:attribute name="action" type="hv:action" />
     <xs:attribute name="target" type="xs:NCName"/>
     <xs:attribute name="href" type="xs:string"/>
     <xs:attribute name="once" type="xs:boolean"/>
-    <xs:attribute name="trigger" type="xs:NCName"/>
-    <xs:attribute name="show-during-load" type="xs:string"/>
-    <xs:attribute name="hide-during-load" type="xs:string"/>
+    <xs:attribute name="trigger" type="hv:trigger"/>
+    <xs:attribute name="show-during-load" type="hv:idList"/>
+    <xs:attribute name="hide-during-load" type="hv:idList"/>
     <xs:attribute name="delay" type="xs:nonNegativeInteger"/>
-    <xs:attribute name="event-name" type="xs:string"/>
+    <xs:attribute name="event-name" type="xs:NCName"/>
     <xs:attribute name="new-value" type="xs:string"/>
 
     <xs:attributeGroup ref="alert:alertAttributes" />


### PR DESCRIPTION
https://app.asana.com/0/1173541402094433/1173541402094452/f

This PR makes improvements to the schema by adding stricter/more complete types for attributes:
- `trigger` is now an enum of allowed strings
- `event-name` is now an NCName (string with no colons or whitespace)
- `show-during-load` and `hide-during-load` are now space-separated NCNames
- colors support `hsl` and `hsla`.