### PR TITLE
Allow selectable="true" attribute

### DIFF
--- a/docs/reference_text.md
+++ b/docs/reference_text.md
@@ -56,6 +56,7 @@ A `<view>` element can only appear anywhere within a `<screen>` element.
 - [`numberOfLines`](#numberoflines)
 - [`id`](#id)
 - [`hide`](#hide)
+- [`selectable`](#selectable)
 
 #### Behavior attributes
 
@@ -92,3 +93,11 @@ A global attribute uniquely identifying the element in the whole document.
 | **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.
+
+#### `selectable`
+
+| Type    | Required |
+| ------- | -------- |
+| boolean | No       |
+
+A boolean that allows users to select the content of `<text>` element.

--- a/examples/ui_elements/text.xml
+++ b/examples/ui_elements/text.xml
@@ -74,12 +74,13 @@
         <text style="Description">Text</text>
         <text style="Basic">Hello, world!</text>
         <text style="Description">Nested Text</text>
-        <text style="Basic">Hello, 
-        <text style="Bold">World of 
+        <text style="Basic">Hello,
+        <text style="Bold">World of
         <text style="Color">HyperView!</text></text></text>
         <text style="Basic">
 <![CDATA[Escaped with <![CDATA[]>: <hello><world>]]>
         </text>
+        <text style="Basic" selectable="true">Select me!</text>
       </view>
     </body>
   </screen>

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -675,6 +675,7 @@
       <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
+      <xs:attribute name="selectable" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
     </xs:complexType>
   </xs:element>

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -114,7 +114,7 @@ export const createProps = (
   options: HvComponentOptions,
 ) => {
   const numericRules = ['numberOfLines'];
-  const booleanRules = ['multiline'];
+  const booleanRules = ['multiline', 'selectable'];
 
   const props = {};
   if (!element.attributes) {


### PR DESCRIPTION
This is to be used on `<text>` elements and allow user selection on long press.

Relates to https://app.asana.com/0/518926233438259/1155044724972251/f