### PR TITLE
Update react-native-webview to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "yarn generate test && yarn test:flow && yarn test:lint && yarn test:render && yarn test:unit"
   },
   "dependencies": {
-    "react-native-webview": "5.12.0",
+    "react-native-webview": "9.4.0",
     "tiny-emitter": "2.1.0",
     "url-parse": "1.4.3",
     "xmldom-instawork": "0.0.1"

--- a/src/components/hv-web-view/index.js
+++ b/src/components/hv-web-view/index.js
@@ -16,6 +16,8 @@ import { LOCAL_NAME } from 'hyperview/src/types';
 import WebView from 'react-native-webview';
 import { createProps } from 'hyperview/src/services';
 
+const NOOP = () => {};
+
 export default class HvWebView extends PureComponent<HvComponentProps> {
   static namespaceURI = Namespaces.HYPERVIEW;
   static localName = LOCAL_NAME.WEB_VIEW;
@@ -33,6 +35,7 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
     return (
       <WebView
         injectedJavaScript={injectedJavaScript}
+        onMessage={NOOP} // https://github.com/react-native-community/react-native-webview/issues/1311
         renderLoading={() => <ActivityIndicator color={color} />}
         source={source}
         startInLoadingState

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,7 +3251,12 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -7271,11 +7276,12 @@ react-native-tab-view@^0.0.65:
   dependencies:
     prop-types "^15.5.8"
 
-react-native-webview@5.12.0:
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-5.12.0.tgz#e673f72a287829444ddcbc7ea2f28f2e5862f9fb"
+react-native-webview@9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-9.4.0.tgz#108da34a6c7e1c032dcabc942b7e4947ca1d8028"
+  integrity sha512-BBOFUuza0p04+7fNi7TJmB0arpDJzGxHYwTCgI4vj5n/fl7u4jbm7ETp88mf7lo9lP6C6HGLo38KnEy1aXCQkg==
   dependencies:
-    escape-string-regexp "1.0.5"
+    escape-string-regexp "2.0.0"
     invariant "2.2.4"
 
 react-native@0.52.2:


### PR DESCRIPTION
- Update `react-native-webview` to `9.4.0`
- Set `onMessage` to no-op to preserve `injectedJavaScript` functionality (as [not-so-well documented here](https://github.com/react-native-community/react-native-webview/issues/1311))