### PR TITLE
Lowercase HTTP verbs

### DIFF
--- a/docs/example_basic_form.md
+++ b/docs/example_basic_form.md
@@ -131,7 +131,7 @@ Now that we have styling for form group elements, we can incorporate the [`<form
       <text
           style="Submit"
           href="/case_studies/basic_form/submit.xml"
-          verb="POST"
+          verb="post"
           target="myForm"
           action="replace"
           show-during-load="mySpinner"
@@ -145,7 +145,7 @@ Now that we have styling for form group elements, we can incorporate the [`<form
 ```
 The markup above wraps the input in a `<form>` element with id="myForm". Within the form, we've added a submit link with behavior attributes:
 - `href="/case_studies/basic_form/submit.xml"` specifies the remote request path.
-- `verb="POST"` specifies the HTTP request method used to make the request.
+- `verb="post"` specifies the HTTP request method used to make the request.
 - `target="myForm"` and `action="replace"` tells Hyperview that the response content should replace the form on the current screen. This allows the response to show validation errors on the same screen.
 - `show-during-load="mySpinner"` indicates that the spinner should be toggled while making the HTTP request.
 
@@ -160,7 +160,7 @@ The result depends on the server response. Assuming the server determines the fo
   <text
       style="Submit"
       href="/case_studies/basic_form/submit.xml"
-      verb="POST"
+      verb="post"
       target="myForm"
       action="replace"
       show-during-load="mySpinner"

--- a/docs/example_instawork.md
+++ b/docs/example_instawork.md
@@ -299,7 +299,7 @@ The rating containers for stars 1-5 are included in the doc outside of the scree
 
     <view
         href="/biz_app/gigs/shifts/dj4kXoN/feedback"
-        verb="POST"
+        verb="post"
         target="body"
         show-during-load="savingButton"
         hide-during-load="saveButton"

--- a/docs/reference_form.md
+++ b/docs/reference_form.md
@@ -27,7 +27,7 @@ The encoding of the input values depend on the request method:
       value="Great work!"
     />
 
-    <text verb="POST" href="/feedback" target="feedbackForm">Submit</text>
+    <text verb="post" href="/feedback" target="feedbackForm">Submit</text>
   </form>
 </screen>
 ```

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -347,9 +347,7 @@
       <xs:simpleType>
         <xs:restriction base="xs:string">
           <xs:enumeration value="get"/>
-          <xs:enumeration value="GET"/>
           <xs:enumeration value="post"/>
-          <xs:enumeration value="POST"/>
         </xs:restriction>
       </xs:simpleType>
     </xs:attribute>

--- a/src/services/dom/index.test.js
+++ b/src/services/dom/index.test.js
@@ -55,7 +55,7 @@ describe('Parser', () => {
             'X-Hyperview-Dimensions': '750w 1334h',
             'X-Hyperview-Version': version,
           },
-          method: 'GET',
+          method: 'get',
         };
         const responseText = 'foobarbaz';
         responseTextMock.mockResolvedValue(responseText);
@@ -95,7 +95,7 @@ describe('Parser', () => {
             'X-Hyperview-Dimensions': '750w 1334h',
             'X-Hyperview-Version': version,
           },
-          method: 'GET',
+          method: 'get',
         });
         expect(document).toEqual(mockExpectedDocument);
       });
@@ -110,7 +110,7 @@ describe('Parser', () => {
         const responseText = 'foobarbaz';
         responseTextMock.mockResolvedValue(responseText);
 
-        const document = await parser.load(url, data, 'POST');
+        const document = await parser.load(url, data, 'post');
 
         expect(urlServiceAddFormDataToUrlMock).toHaveBeenCalledTimes(0);
         expect(mockParseFromString).toHaveBeenCalledWith(responseText);
@@ -123,7 +123,7 @@ describe('Parser', () => {
             'X-Hyperview-Dimensions': '750w 1334h',
             'X-Hyperview-Version': version,
           },
-          method: 'POST',
+          method: 'post',
         });
         expect(document).toEqual(mockExpectedDocument);
       });

--- a/src/services/dom/types.js
+++ b/src/services/dom/types.js
@@ -16,8 +16,8 @@ export const HTTP_HEADERS = {
 };
 
 export const HTTP_METHODS = {
-  GET: 'GET',
-  POST: 'POST',
+  GET: 'get',
+  POST: 'post',
 };
 
 export type HttpMethod = $Values<typeof HTTP_METHODS>;


### PR DESCRIPTION
Only accept `get` and `post` verbs from XML markup, and update every examples.