### PR TITLE
Fix: Doc state

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ export default class HyperScreen extends React.Component {
 
     this.behaviorRegistry = Behaviors.getRegistry(this.props.behaviors);
     this.componentRegistry = Components.getRegistry(this.props.components);
-    this.navigation = new Navigation(this.getNavigation());
+    this.navigation = new Navigation(props.entrypointUrl, this.getNavigation());
   }
 
   setDoc = (doc) => {

--- a/src/index.js
+++ b/src/index.js
@@ -91,11 +91,6 @@ export default class HyperScreen extends React.Component {
     this.navigation = new Navigation(props.entrypointUrl, this.getNavigation());
   }
 
-  setDoc = (doc) => {
-    this.doc = doc;
-    this.setState({ doc });
-  }
-
   getNavigationState = (props) => {
     if (props.navigation) {
       return props.navigation.state;

--- a/src/services/navigation/index.js
+++ b/src/services/navigation/index.js
@@ -19,13 +19,14 @@ const QUERY_SEPARATOR = '?';
 const getHrefKey = (href: string): string => href.split(QUERY_SEPARATOR)[0];
 
 export default class Navigation {
-  url: string = null;
-  document: Document = null;
+  url: string;
+  document: ?Document = null;
   navigation: NavigationProps;
   preloadScreens: { [number]: Element } = {};
   routeKeys: { [string]: string } = {};
 
-  constructor(navigation: NavigationProps) {
+  constructor(url: string, navigation: NavigationProps) {
+    this.url = url;
     this.navigation = navigation;
   }
 
@@ -67,7 +68,7 @@ export default class Navigation {
     const url = UrlService.addFormDataToUrl(baseUrl, formData);
 
     let preloadScreen = null;
-    if (showIndicatorId) {
+    if (showIndicatorId && this.document) {
       const screens: NodeList<Element> = this.document.getElementsByTagNameNS(
         Namespaces.HYPERVIEW,
         'screen',

--- a/src/services/navigation/index.js
+++ b/src/services/navigation/index.js
@@ -19,15 +19,13 @@ const QUERY_SEPARATOR = '?';
 const getHrefKey = (href: string): string => href.split(QUERY_SEPARATOR)[0];
 
 export default class Navigation {
-  url: string;
-  document: Document;
+  url: string = null;
+  document: Document = null;
   navigation: NavigationProps;
   preloadScreens: { [number]: Element } = {};
   routeKeys: { [string]: string } = {};
 
-  constructor(url: string, document: Document, navigation: NavigationProps) {
-    this.url = url;
-    this.document = document;
+  constructor(navigation: NavigationProps) {
     this.navigation = navigation;
   }
 


### PR DESCRIPTION
Add `doc` instance property to `HyperviewScreen`, and update it at the same time as `state.doc`. When accessing the DOM for read/write operation, use `doc` / use `state.doc` when rendering. Also simplify `Navigation` constructor.
