### PR TITLE
Hyperview schema: add missing support

### DIFF
--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -290,6 +290,17 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:simpleType name="ID">
+    <xs:restriction base="xs:token" />
+  </xs:simpleType>
+
+  <xs:simpleType name="IDREF">
+    <xs:restriction base="hv:ID" />
+  </xs:simpleType>
+
+  <xs:simpleType name="IDREFS">
+    <xs:list itemType="hv:ID" />
+  </xs:simpleType>
 
   <xs:simpleType name="styleList">
     <xs:list itemType="xs:NCName" />
@@ -343,12 +354,12 @@
 
   <xs:attributeGroup name="behaviorAttributes">
     <xs:attribute name="action" type="hv:action" />
-    <xs:attribute name="target" type="xs:IDREF"/>
+    <xs:attribute name="target" type="hv:IDREF"/>
     <xs:attribute name="href" type="xs:string"/>
     <xs:attribute name="once" type="xs:boolean"/>
     <xs:attribute name="trigger" type="hv:trigger"/>
-    <xs:attribute name="show-during-load" type="xs:IDREFS"/>
-    <xs:attribute name="hide-during-load" type="xs:IDREFS"/>
+    <xs:attribute name="show-during-load" type="hv:IDREFS"/>
+    <xs:attribute name="hide-during-load" type="hv:IDREFS"/>
     <xs:attribute name="delay" type="xs:nonNegativeInteger"/>
     <xs:attribute name="verb">
       <xs:simpleType>
@@ -397,7 +408,7 @@
         <xs:element minOccurs="0" maxOccurs="1" ref="hv:styles"/>
         <xs:element minOccurs="1" maxOccurs="1" ref="hv:body"/>
       </xs:sequence>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
     </xs:complexType>
   </xs:element>
 
@@ -655,7 +666,7 @@
   <xs:element name="body">
     <xs:complexType>
       <xs:group ref="hv:viewChildren"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="style" type="hv:styleList"/>
       <xs:attributeGroup ref="hv:scrollAttributes"/>
     </xs:complexType>
@@ -665,7 +676,7 @@
     <xs:complexType>
       <xs:group ref="hv:viewChildren"/>
       <xs:attribute name="style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>
@@ -674,7 +685,7 @@
     <xs:complexType>
       <xs:group ref="hv:viewChildren"/>
       <xs:attribute name="style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
       <xs:attributeGroup ref="hv:scrollAttributes"/>
@@ -685,7 +696,7 @@
     <xs:complexType>
       <xs:attribute name="source" use="required" type="xs:anyURI"/>
       <xs:attribute name="style" type="hv:styleList" use="required"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
     </xs:complexType>
@@ -699,7 +710,7 @@
       </xs:sequence>
       <xs:attribute name="numberOfLines" type="xs:positiveInteger"/>
       <xs:attribute name="style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attribute name="selectable" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
@@ -726,7 +737,7 @@
       </xs:sequence>
       <xs:attribute name="itemHeight" type="xs:positiveInteger"/>
       <xs:attribute name="style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attribute name="shows-scroll-indicator" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:scrollAttributes"/>
@@ -743,7 +754,7 @@
         </xs:choice>
       </xs:sequence>
       <xs:attribute name="style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
     </xs:complexType>
@@ -764,7 +775,7 @@
     <xs:complexType>
       <xs:group ref="hv:nonListViewChildren"/>
       <xs:attribute name="style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
     </xs:complexType>
@@ -783,7 +794,7 @@
       <xs:group ref="hv:nonListViewChildren"/>
       <xs:attribute name="key" use="required" />
       <xs:attribute name="style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
     </xs:complexType>
@@ -792,7 +803,7 @@
   <xs:element name="spinner">
     <xs:complexType>
       <xs:attribute name="color" type="hv:color" />
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>
@@ -801,7 +812,7 @@
     <xs:complexType>
       <xs:group ref="hv:viewChildren"/>
       <xs:attribute name="style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:scrollAttributes"/>
     </xs:complexType>
@@ -829,7 +840,7 @@
       <xs:attribute name="field-text-style" type="hv:styleList"/>
       <xs:attribute name="modal-style" type="hv:styleList"/>
       <xs:attribute name="modal-text-style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>
@@ -849,7 +860,7 @@
       <xs:attribute name="field-text-style" type="hv:styleList"/>
       <xs:attribute name="modal-style" type="hv:styleList"/>
       <xs:attribute name="modal-text-style" type="hv:styleList"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>
@@ -872,7 +883,7 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attribute name="style" type="hv:styleList"/>
     </xs:complexType>
@@ -896,7 +907,7 @@
         </xs:simpleType>
       </xs:attribute>
       <xs:attribute name="mask" type="xs:string"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="auto-focus" type="xs:boolean"/>
@@ -910,7 +921,7 @@
       <xs:attribute name="value" type="xs:string"/>
       <xs:attribute name="placeholder" type="xs:string"/>
       <xs:attribute name="placeholderTextColor" type="hv:color"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attribute name="underlineColorAndroid" type="hv:color"/>
       <xs:attribute name="style"/>
@@ -921,7 +932,7 @@
     <xs:complexType>
       <xs:group ref="hv:viewChildren"/>
       <xs:attribute name="name" use="required" type="xs:string"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attribute name="style" type="hv:styleList"/>
     </xs:complexType>
@@ -931,7 +942,7 @@
     <xs:complexType>
       <xs:group ref="hv:viewChildren"/>
       <xs:attribute name="name" use="required" type="xs:string"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attribute name="style" type="hv:styleList"/>
     </xs:complexType>
@@ -942,7 +953,7 @@
       <xs:group ref="hv:baseChildren"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
       <xs:attribute name="value" type="xs:string"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="selected" type="xs:boolean"/>
@@ -955,7 +966,7 @@
       <xs:attribute name="html" type="xs:string"/>
       <xs:attribute name="activity-indicator-color" type="hv:color"/>
       <xs:attribute name="injected-java-script" type="xs:string"/>
-      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="id" type="hv:ID"/>
     </xs:complexType>
   </xs:element>
 

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -329,6 +329,7 @@
         <xs:element ref="hv:spinner"/>
         <xs:element ref="hv:text"/>
         <xs:element ref="hv:view"/>
+        <xs:any namespace="##other" processContents="lax" />
       </xs:choice>
     </xs:sequence>
   </xs:group>

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -284,6 +284,12 @@
     </xs:union>
   </xs:simpleType>
 
+  <xs:simpleType name="eventName">
+    <xs:restriction base="xs:token">
+      <xs:pattern value="[0-9a-zA-Z\-\./]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
 
   <xs:simpleType name="styleList">
     <xs:list itemType="xs:NCName" />
@@ -352,7 +358,7 @@
         </xs:restriction>
       </xs:simpleType>
     </xs:attribute>
-    <xs:attribute name="event-name" type="xs:NCName"/>
+    <xs:attribute name="event-name" type="hv:eventName"/>
     <xs:attribute name="new-value" type="xs:string"/>
 
     <xs:attributeGroup ref="alert:alertAttributes" />

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -927,6 +927,16 @@
       <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="auto-focus" type="xs:boolean"/>
       <xs:attribute name="underlineColorAndroid" type="hv:color"/>
+      <xs:attribute name="clearButtonMode">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="never"/>
+            <xs:enumeration value="while-editing"/>
+            <xs:enumeration value="unless-editing"/>
+            <xs:enumeration value="always"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
 

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -466,6 +466,16 @@
 
       <xs:attribute name="borderRightWidth" type="xs:nonNegativeInteger"/>
 
+      <xs:attribute name="borderStyle">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="solid"/>
+            <xs:enumeration value="dotted"/>
+            <xs:enumeration value="dashed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+
       <xs:attribute name="borderTopColor" type="hv:color"/>
 
       <xs:attribute name="borderTopWidth" type="xs:nonNegativeInteger"/>

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -946,6 +946,8 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>
+      <!-- Needed to support address-input. Eventually, we should allow attributes from other namespaces. -->
+      <xs:attribute name="type" type="xs:string"/>
     </xs:complexType>
   </xs:element>
 

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -718,6 +718,8 @@
       <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
+      <xs:attribute name="shows-scroll-indicator" type="xs:boolean"/>
+      <xs:attributeGroup ref="hv:scrollAttributes"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
     </xs:complexType>
   </xs:element>

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -301,7 +301,7 @@
 
   <xs:simpleType name="eventName">
     <xs:restriction base="xs:token">
-      <xs:pattern value="[0-9a-zA-Z\-\./]+"/>
+      <xs:pattern value="[0-9a-zA-Z_\-\./]+"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -718,6 +718,9 @@
 
   <xs:element name="image">
     <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:behavior"/>
+      </xs:sequence>
       <xs:attribute name="source" use="required" type="xs:anyURI"/>
       <xs:attribute name="style" type="hv:styleList" use="required"/>
       <xs:attribute name="id" type="hv:ID"/>

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -888,6 +888,7 @@
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="auto-focus" type="xs:boolean"/>
+      <xs:attribute name="underlineColorAndroid" type="hv:color"/>
     </xs:complexType>
   </xs:element>
 
@@ -899,6 +900,7 @@
       <xs:attribute name="placeholderTextColor" type="hv:color"/>
       <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
+      <xs:attribute name="underlineColorAndroid" type="hv:color"/>
       <xs:attribute name="style"/>
     </xs:complexType>
   </xs:element>

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -489,6 +489,14 @@
       <xs:attribute name="borderLeftWidth" type="xs:nonNegativeInteger"/>
 
       <xs:attribute name="borderRadius" type="xs:nonNegativeInteger"/>
+      <xs:attribute name="borderBottomEndRadius" type="xs:nonNegativeInteger"/>
+      <xs:attribute name="borderBottomLeftRadius" type="xs:nonNegativeInteger"/>
+      <xs:attribute name="borderBottomRightRadius" type="xs:nonNegativeInteger"/>
+      <xs:attribute name="borderBottomStartRadius" type="xs:nonNegativeInteger"/>
+      <xs:attribute name="borderTopEndRadius" type="xs:nonNegativeInteger"/>
+      <xs:attribute name="borderTopLeftRadius" type="xs:nonNegativeInteger"/>
+      <xs:attribute name="borderTopRightRadius" type="xs:nonNegativeInteger"/>
+      <xs:attribute name="borderTopStartRadius" type="xs:nonNegativeInteger"/>
 
       <xs:attribute name="borderRightWidth" type="xs:nonNegativeInteger"/>
 

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -307,6 +307,7 @@
         <xs:element ref="hv:behavior"/>
         <xs:element ref="hv:date-field"/>
         <xs:element ref="hv:form"/>
+        <xs:element ref="hv:header"/>
         <xs:element ref="hv:image"/>
         <xs:element ref="hv:option"/>
         <xs:element ref="hv:picker-field"/>
@@ -637,11 +638,7 @@
 
   <xs:element name="body">
     <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:behavior"/>
-        <xs:element minOccurs="0" maxOccurs="1" ref="hv:header"/>
-        <xs:group ref="hv:viewChildren"/>
-      </xs:sequence>
+      <xs:group ref="hv:viewChildren"/>
       <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="style" type="hv:styleList"/>
       <xs:attributeGroup ref="hv:scrollAttributes"/>

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -638,6 +638,7 @@
   <xs:element name="body">
     <xs:complexType>
       <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:behavior"/>
         <xs:element minOccurs="0" maxOccurs="1" ref="hv:header"/>
         <xs:group ref="hv:viewChildren"/>
       </xs:sequence>

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -284,6 +284,21 @@
     </xs:union>
   </xs:simpleType>
 
+  <xs:simpleType name="margin">
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:integer" />
+      </xs:simpleType>
+
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="auto" />
+        </xs:restriction>
+      </xs:simpleType>
+
+    </xs:union>
+  </xs:simpleType>
+
   <xs:simpleType name="eventName">
     <xs:restriction base="xs:token">
       <xs:pattern value="[0-9a-zA-Z\-\./]+"/>
@@ -578,13 +593,13 @@
 
       <xs:attribute name="left" type="hv:pointsOrPercent"/>
       <xs:attribute name="lineHeight" type="xs:integer"/>
-      <xs:attribute name="margin" type="xs:integer"/>
-      <xs:attribute name="marginBottom" type="xs:integer"/>
-      <xs:attribute name="marginHorizontal" type="xs:integer"/>
-      <xs:attribute name="marginLeft" type="xs:integer"/>
-      <xs:attribute name="marginRight" type="xs:integer"/>
-      <xs:attribute name="marginTop" type="xs:integer"/>
-      <xs:attribute name="marginVertical" type="xs:integer"/>
+      <xs:attribute name="margin" type="hv:margin"/>
+      <xs:attribute name="marginBottom" type="hv:margin"/>
+      <xs:attribute name="marginHorizontal" type="hv:margin"/>
+      <xs:attribute name="marginLeft" type="hv:margin"/>
+      <xs:attribute name="marginRight" type="hv:margin"/>
+      <xs:attribute name="marginTop" type="hv:margin"/>
+      <xs:attribute name="marginVertical" type="hv:margin"/>
       <xs:attribute name="maxHeight" type="hv:pointsOrPercent"/>
       <xs:attribute name="maxWidth" type="hv:pointsOrPercent"/>
       <xs:attribute name="minHeight" type="hv:pointsOrPercent"/>


### PR DESCRIPTION
Based on validating against our backend responses, I found several missing pieces of the schema:

- `<body>` can now contain `<behavior>` children
- `margin` styles can be numbers or `auto`
- `event-name` supports underscores, hypens, slashes, and periods.
- Element IDs need to support slashes for now, so we can't use `xs:ID`, `xs:IDREF`, or `xs:IDREFS`. Updated the schema to use tokens for ids.
- added border-radius styles for specific corners or edges
- added support for border styles
- `<header>` can appear more flexibly, not just at the top of `<body>`. This is needed to support wrapping the entire screen in a `<form>`.
- `<image>` can now contain `<behavior>` elements, before it didn't contain children.
- Added support for `type`, `underlineColorAndroid`, and `clearButtonMode` on text fields.
- Added support for `underlineColorAndroid` on text areas.