### PR TITLE
Fix encoding issue with btoa

### DIFF
--- a/src/core/components/load-error/index.js
+++ b/src/core/components/load-error/index.js
@@ -43,7 +43,9 @@ export default class LoadError extends PureComponent<Props> {
             </body>
           </screen>
         </doc>`;
-        return `data:${Dom.CONTENT_TYPE.APPLICATION_XML};base64,${btoa(xml)}`;
+        return `data:${Dom.CONTENT_TYPE.APPLICATION_XML};base64,${btoa(
+          xml.replace(/[\u00A0-\u2666]/g, c => `&#${c.charCodeAt(0)};`),
+        )}`;
       }
       default:
         return null;


### PR DESCRIPTION
Apply conversion suggested [here](https://stackoverflow.com/a/33140101/237637) to resolve an issue with `btoa()` and UTF8 chars.

| Before | After |
|--------|------|
| <img width="584" alt="Screen Shot 2020-06-02 at 1 35 51 PM" src="https://user-images.githubusercontent.com/309515/83567358-54bf4800-a4d6-11ea-8d68-3707b35ad9af.png"> | <img width="584" alt="Screen Shot 2020-06-02 at 1 35 31 PM" src="https://user-images.githubusercontent.com/309515/83567366-56890b80-a4d6-11ea-9f0f-7e55fa5511c1.png"> |

