### PR TITLE
Fix: btoa missing crash

### DIFF
--- a/src/core/components/load-error/index.js
+++ b/src/core/components/load-error/index.js
@@ -20,7 +20,12 @@ export default class LoadError extends PureComponent<Props> {
 
   getDetailsUri = () => {
     const error = this.props.error;
-    if (!__DEV__ || !error || !(error instanceof Dom.ServerError)) {
+    if (
+      !__DEV__ ||
+      !global.btoa ||
+      !error ||
+      !(error instanceof Dom.ServerError)
+    ) {
       return null;
     }
     const { responseText, responseHeaders } = error;
@@ -82,6 +87,8 @@ export default class LoadError extends PureComponent<Props> {
           <Text style={styles.button}>View details</Text>
         </TouchableOpacity>
       );
+    } else if (__DEV__ && !global.btoa) {
+      return <Text>Enable Debug mode to see details</Text>;
     }
     return null;
   };


### PR DESCRIPTION
Add check to ensure `btoa` is defined on the global scope. Default to rendering alternate text suggesting to enable debug mode to see more details.
Given that the HTML error response parsing is already only enabled during `__DEV__` mode, I preferred only allowing the feature to work when debug mode is also enabled, instead of adding a 3rd party library to perform the conversion of the raw HTML to base 64.