### PR TITLE
Simpler HTML error rendering

### DIFF
--- a/src/core/components/load-error/index.js
+++ b/src/core/components/load-error/index.js
@@ -10,15 +10,15 @@
 
 import * as Dom from 'hyperview/src/services/dom';
 import React, { PureComponent } from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView, Text, TouchableOpacity, View } from 'react-native';
 import type { Props } from './types';
-import { encodeXml } from 'hyperview/src/services';
+import WebView from 'react-native-webview';
 import styles from './styles';
 
 export default class LoadError extends PureComponent<Props> {
   props: Props;
 
-  getDetailsUri = () => {
+  getHTML = (): ?string => {
     const error = this.props.error;
     if (!__DEV__ || !error || !(error instanceof Dom.ServerError)) {
       return null;
@@ -26,74 +26,51 @@ export default class LoadError extends PureComponent<Props> {
     const { responseText, responseHeaders } = error;
     switch (responseHeaders.get(Dom.HTTP_HEADERS.CONTENT_TYPE)) {
       // Only support HTML server error responses for the time being
-      case Dom.CONTENT_TYPE.TEXT_HTML: {
-        const encodedHtml = encodeXml(responseText);
-        const xml = `<doc xmlns="https://hyperview.org/hyperview">
-          <screen>
-            <styles>
-              <style id="flex" flex="1" />
-              <style id="mt-40" marginTop="40" />
-              <style id="p-16" padding="16" />
-            </styles>
-            <body style="flex">
-              <header style="mt-40">
-                <text style="p-16" action="back" href="#">Back</text>
-              </header>
-              <web-view html="${encodedHtml}" xmlns="https://hyperview.org/hyperview" />
-            </body>
-          </screen>
-        </doc>`;
-        return `data:${Dom.CONTENT_TYPE.APPLICATION_XML};base64,${btoa(
-          xml.replace(/[\u00A0-\u2666]/g, c => `&#${c.charCodeAt(0)};`),
-        )}`;
-      }
+      case Dom.CONTENT_TYPE.TEXT_HTML:
+        return responseText;
       default:
         return null;
     }
   };
 
-  onPressViewDetails = () => {
-    const detailsUri = this.getDetailsUri();
-    if (detailsUri) {
-      this.props.onPressViewDetails(detailsUri);
+  getTitle = () => {
+    const error = this.props.error;
+    if (!__DEV__ || !error) {
+      return 'An error occured';
     }
+    return `${error.name}: ${error.message}`;
   };
 
-  getTitle = (): string => {
-    if (__DEV__ && this.props.error) {
-      return this.props.error.toString();
-    }
-    return 'An error occured';
-  };
-
-  Title = () => <Text>{this.getTitle()}</Text>;
-
-  ReloadButton = () => (
-    <TouchableOpacity onPress={this.props.onPressReload}>
-      <Text style={styles.button}>Reload</Text>
-    </TouchableOpacity>
-  );
-
-  ViewDetailsButton = () => {
-    const detailsUri = this.getDetailsUri();
-    if (detailsUri) {
-      return (
-        <TouchableOpacity onPress={this.onPressViewDetails}>
-          <Text style={styles.button}>View details</Text>
+  Header = () => {
+    const title = this.getTitle();
+    return (
+      <View style={styles.header}>
+        <View>
+          <Text style={styles.title}>{title}</Text>
+        </View>
+        <TouchableOpacity onPress={this.props.onPressReload}>
+          <Text style={styles.button}>Reload</Text>
         </TouchableOpacity>
-      );
+      </View>
+    );
+  };
+
+  Error = () => {
+    const html = this.getHTML();
+    if (!html) {
+      return null;
     }
-    return null;
+    return <WebView source={{ html }} style={{ flex: 1 }} />;
   };
 
   render() {
-    const { ReloadButton, Title, ViewDetailsButton } = this;
+    const { Error, Header } = this;
+
     return (
-      <View style={styles.container}>
-        <Title />
-        <ReloadButton />
-        <ViewDetailsButton />
-      </View>
+      <SafeAreaView style={styles.container}>
+        <Header />
+        <Error />
+      </SafeAreaView>
     );
   }
 }

--- a/src/core/components/load-error/styles.js
+++ b/src/core/components/load-error/styles.js
@@ -16,9 +16,16 @@ export default StyleSheet.create({
     marginTop: 16,
   },
   container: {
-    alignItems: 'center',
     backgroundColor: 'white',
     flex: 1,
     justifyContent: 'center',
+  },
+  header: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    margin: 24,
+  },
+  title: {
+    textAlign: 'center',
   },
 });


### PR DESCRIPTION
Instead of opening HTML error content in a new screen, simply render it in a webview directly on the error screen.

Relates to #165, closes #169

| __DEV__ + HTML Server error | Other |
|-----------------------|-------|
| <img width="584" alt="Screen Shot 2020-06-03 at 2 46 30 PM" src="https://user-images.githubusercontent.com/309515/83693323-ba7d0400-a5aa-11ea-82cd-57e19a229ea5.png"> | <img width="584" alt="Screen Shot 2020-06-03 at 2 46 18 PM" src="https://user-images.githubusercontent.com/309515/83693344-c8cb2000-a5aa-11ea-837e-f5e1e2f1c439.png"> |

