### PR TITLE
Split list attributes on all whitespace

### DIFF
--- a/src/behaviors/hv-hide/index.js
+++ b/src/behaviors/hv-hide/index.js
@@ -10,6 +10,7 @@ import type {
   HvUpdateRoot,
 } from 'hyperview/src/types';
 import { later, shallowCloneToRoot } from 'hyperview/src/services';
+import { splitAttributeList } from 'hyperview/src/services/xml';
 
 export default {
   action: 'hide',
@@ -28,12 +29,12 @@ export default {
     const parsedDelay: number = parseInt(delayAttr, 10);
     const delay: number = isNaN(parsedDelay) ? 0 : parsedDelay;
 
-    const showIndicatorIds: Array<string> = (
-      element.getAttribute('show-during-load') || ''
-    ).split(' ');
-    const hideIndicatorIds: Array<string> = (
-      element.getAttribute('hide-during-load') || ''
-    ).split(' ');
+    const showIndicatorIds: Array<string> = splitAttributeList(
+      element.getAttribute('show-during-load') || '',
+    );
+    const hideIndicatorIds: Array<string> = splitAttributeList(
+      element.getAttribute('hide-during-load') || '',
+    );
 
     const hideElement = () => {
       const doc: Document = getRoot();

--- a/src/behaviors/hv-hide/index.js
+++ b/src/behaviors/hv-hide/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as Behaviors from 'hyperview/src/services/behaviors';
+import * as Xml from 'hyperview/src/services/xml';
 import type {
   DOMString,
   Document,
@@ -10,7 +11,6 @@ import type {
   HvUpdateRoot,
 } from 'hyperview/src/types';
 import { later, shallowCloneToRoot } from 'hyperview/src/services';
-import { splitAttributeList } from 'hyperview/src/services/xml';
 
 export default {
   action: 'hide',
@@ -29,10 +29,10 @@ export default {
     const parsedDelay: number = parseInt(delayAttr, 10);
     const delay: number = isNaN(parsedDelay) ? 0 : parsedDelay;
 
-    const showIndicatorIds: Array<string> = splitAttributeList(
+    const showIndicatorIds: Array<string> = Xml.splitAttributeList(
       element.getAttribute('show-during-load') || '',
     );
-    const hideIndicatorIds: Array<string> = splitAttributeList(
+    const hideIndicatorIds: Array<string> = Xml.splitAttributeList(
       element.getAttribute('hide-during-load') || '',
     );
 

--- a/src/behaviors/hv-set-value/index.js
+++ b/src/behaviors/hv-set-value/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as Behaviors from 'hyperview/src/services/behaviors';
+import * as Xml from 'hyperview/src/services/xml';
 import type {
   DOMString,
   Document,
@@ -10,7 +11,6 @@ import type {
   HvUpdateRoot,
 } from 'hyperview/src/types';
 import { later, shallowCloneToRoot } from 'hyperview/src/services';
-import { splitAttributeList } from 'hyperview/src/services/xml';
 
 export default {
   action: 'set-value',
@@ -32,10 +32,10 @@ export default {
     const parsedDelay: number = parseInt(delayAttr, 10);
     const delay: number = isNaN(parsedDelay) ? 0 : parsedDelay;
 
-    const showIndicatorIds: Array<string> = splitAttributeList(
+    const showIndicatorIds: Array<string> = Xml.splitAttributeList(
       element.getAttribute('show-during-load') || '',
     );
-    const hideIndicatorIds: Array<string> = splitAttributeList(
+    const hideIndicatorIds: Array<string> = Xml.splitAttributeList(
       element.getAttribute('hide-during-load') || '',
     );
 

--- a/src/behaviors/hv-set-value/index.js
+++ b/src/behaviors/hv-set-value/index.js
@@ -10,8 +10,7 @@ import type {
   HvUpdateRoot,
 } from 'hyperview/src/types';
 import { later, shallowCloneToRoot } from 'hyperview/src/services';
-
-const ID_SEPARATOR = ' ';
+import { splitAttributeList } from 'hyperview/src/services/xml';
 
 export default {
   action: 'set-value',
@@ -33,12 +32,12 @@ export default {
     const parsedDelay: number = parseInt(delayAttr, 10);
     const delay: number = isNaN(parsedDelay) ? 0 : parsedDelay;
 
-    const showIndicatorIds: Array<string> = (
-      element.getAttribute('show-during-load') || ''
-    ).split(ID_SEPARATOR);
-    const hideIndicatorIds: Array<string> = (
-      element.getAttribute('hide-during-load') || ''
-    ).split(ID_SEPARATOR);
+    const showIndicatorIds: Array<string> = splitAttributeList(
+      element.getAttribute('show-during-load') || '',
+    );
+    const hideIndicatorIds: Array<string> = splitAttributeList(
+      element.getAttribute('hide-during-load') || '',
+    );
 
     const setValue = () => {
       const doc: Document = getRoot();

--- a/src/behaviors/hv-show/index.js
+++ b/src/behaviors/hv-show/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as Behaviors from 'hyperview/src/services/behaviors';
+import * as Xml from 'hyperview/src/services/xml';
 import type {
   DOMString,
   Document,
@@ -10,7 +11,6 @@ import type {
   HvUpdateRoot,
 } from 'hyperview/src/types';
 import { later, shallowCloneToRoot } from 'hyperview/src/services';
-import { splitAttributeList } from 'hyperview/src/services/xml';
 
 export default {
   action: 'show',
@@ -29,10 +29,10 @@ export default {
     const parsedDelay: number = parseInt(delayAttr, 10);
     const delay: number = isNaN(parsedDelay) ? 0 : parsedDelay;
 
-    const showIndicatorIds: Array<string> = splitAttributeList(
+    const showIndicatorIds: Array<string> = Xml.splitAttributeList(
       element.getAttribute('show-during-load') || '',
     );
-    const hideIndicatorIds: Array<string> = splitAttributeList(
+    const hideIndicatorIds: Array<string> = Xml.splitAttributeList(
       element.getAttribute('hide-during-load') || '',
     );
 

--- a/src/behaviors/hv-show/index.js
+++ b/src/behaviors/hv-show/index.js
@@ -10,6 +10,7 @@ import type {
   HvUpdateRoot,
 } from 'hyperview/src/types';
 import { later, shallowCloneToRoot } from 'hyperview/src/services';
+import { splitAttributeList } from 'hyperview/src/services/xml';
 
 export default {
   action: 'show',
@@ -28,12 +29,12 @@ export default {
     const parsedDelay: number = parseInt(delayAttr, 10);
     const delay: number = isNaN(parsedDelay) ? 0 : parsedDelay;
 
-    const showIndicatorIds: Array<string> = (
-      element.getAttribute('show-during-load') || ''
-    ).split(' ');
-    const hideIndicatorIds: Array<string> = (
-      element.getAttribute('hide-during-load') || ''
-    ).split(' ');
+    const showIndicatorIds: Array<string> = splitAttributeList(
+      element.getAttribute('show-during-load') || '',
+    );
+    const hideIndicatorIds: Array<string> = splitAttributeList(
+      element.getAttribute('hide-during-load') || '',
+    );
 
     const showElement = () => {
       const doc: Document = getRoot();

--- a/src/behaviors/hv-toggle/index.js
+++ b/src/behaviors/hv-toggle/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as Behaviors from 'hyperview/src/services/behaviors';
+import * as Xml from 'hyperview/src/services/xml';
 import type {
   DOMString,
   Document,
@@ -10,7 +11,6 @@ import type {
   HvUpdateRoot,
 } from 'hyperview/src/types';
 import { later, shallowCloneToRoot } from 'hyperview/src/services';
-import { splitAttributeList } from 'hyperview/src/services/xml';
 
 export default {
   action: 'toggle',
@@ -29,10 +29,10 @@ export default {
     const parsedDelay: number = parseInt(delayAttr, 10);
     const delay: number = isNaN(parsedDelay) ? 0 : parsedDelay;
 
-    const showIndicatorIds: Array<string> = splitAttributeList(
+    const showIndicatorIds: Array<string> = Xml.splitAttributeList(
       element.getAttribute('show-during-load') || '',
     );
-    const hideIndicatorIds: Array<string> = splitAttributeList(
+    const hideIndicatorIds: Array<string> = Xml.splitAttributeList(
       element.getAttribute('hide-during-load') || '',
     );
 

--- a/src/behaviors/hv-toggle/index.js
+++ b/src/behaviors/hv-toggle/index.js
@@ -10,6 +10,7 @@ import type {
   HvUpdateRoot,
 } from 'hyperview/src/types';
 import { later, shallowCloneToRoot } from 'hyperview/src/services';
+import { splitAttributeList } from 'hyperview/src/services/xml';
 
 export default {
   action: 'toggle',
@@ -28,12 +29,12 @@ export default {
     const parsedDelay: number = parseInt(delayAttr, 10);
     const delay: number = isNaN(parsedDelay) ? 0 : parsedDelay;
 
-    const showIndicatorIds: Array<string> = (
-      element.getAttribute('show-during-load') || ''
-    ).split(' ');
-    const hideIndicatorIds: Array<string> = (
-      element.getAttribute('hide-during-load') || ''
-    ).split(' ');
+    const showIndicatorIds: Array<string> = splitAttributeList(
+      element.getAttribute('show-during-load') || '',
+    );
+    const hideIndicatorIds: Array<string> = splitAttributeList(
+      element.getAttribute('hide-during-load') || '',
+    );
 
     const toggleElement = () => {
       const doc: Document = getRoot();

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ import LoadError from 'hyperview/src/core/components/load-error';
 import Loading from 'hyperview/src/core/components/loading';
 import HyperRef from 'hyperview/src/core/hyper-ref';
 import Navigation, { ANCHOR_ID_SEPARATOR } from 'hyperview/src/services/navigation';
+import { splitAttributeList } from 'hyperview/src/services/xml';
 import React from 'react';
 import { createProps, later, shallowCloneToRoot, getFormData, getElementByTimeoutId, removeTimeoutId, setTimeoutId } from 'hyperview/src/services';
 import { ACTIONS, NAV_ACTIONS, UPDATE_ACTIONS } from 'hyperview/src/types';
@@ -391,8 +392,8 @@ export default class HyperScreen extends React.Component {
       verb, targetId, showIndicatorIds, hideIndicatorIds, delay, once, onEnd, behaviorElement,
     } = options;
 
-    const showIndicatorIdList = showIndicatorIds ? showIndicatorIds.split(' ') : [];
-    const hideIndicatorIdList = hideIndicatorIds ? hideIndicatorIds.split(' ') : [];
+    const showIndicatorIdList = showIndicatorIds ? splitAttributeList(showIndicatorIds) : [];
+    const hideIndicatorIdList = hideIndicatorIds ? splitAttributeList(hideIndicatorIds) : [];
 
     const formData = getFormData(currentElement);
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,13 +14,13 @@ import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
 import * as Stylesheets from 'hyperview/src/services/stylesheets';
 import * as UrlService from 'hyperview/src/services/url';
+import * as Xml from 'hyperview/src/services/xml';
 import { Linking } from 'react-native';
 import { XMLSerializer } from 'xmldom-instawork';
 import LoadError from 'hyperview/src/core/components/load-error';
 import Loading from 'hyperview/src/core/components/loading';
 import HyperRef from 'hyperview/src/core/hyper-ref';
 import Navigation, { ANCHOR_ID_SEPARATOR } from 'hyperview/src/services/navigation';
-import { splitAttributeList } from 'hyperview/src/services/xml';
 import React from 'react';
 import { createProps, later, shallowCloneToRoot, getFormData, getElementByTimeoutId, removeTimeoutId, setTimeoutId } from 'hyperview/src/services';
 import { ACTIONS, NAV_ACTIONS, UPDATE_ACTIONS } from 'hyperview/src/types';
@@ -392,8 +392,8 @@ export default class HyperScreen extends React.Component {
       verb, targetId, showIndicatorIds, hideIndicatorIds, delay, once, onEnd, behaviorElement,
     } = options;
 
-    const showIndicatorIdList = showIndicatorIds ? splitAttributeList(showIndicatorIds) : [];
-    const hideIndicatorIdList = hideIndicatorIds ? splitAttributeList(hideIndicatorIds) : [];
+    const showIndicatorIdList = showIndicatorIds ? Xml.splitAttributeList(showIndicatorIds) : [];
+    const hideIndicatorIdList = hideIndicatorIds ? Xml.splitAttributeList(hideIndicatorIds) : [];
 
     const formData = getFormData(currentElement);
 

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -10,8 +10,8 @@
 
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
+import * as Xml from 'hyperview/src/services/xml';
 import { DEFAULT_PRESS_OPACITY, HV_TIMEOUT_ID_ATTR } from './types';
-import { splitAttributeList } from 'hyperview/src/services/xml';
 import type {
   Document,
   Element,
@@ -66,7 +66,7 @@ export const createStyleProp = (
   }
 
   const styleValue: string = element.getAttribute(styleAttr) || '';
-  const styleIds: Array<string> = splitAttributeList(styleValue);
+  const styleIds: Array<string> = Xml.splitAttributeList(styleValue);
   let styleRules: Array<StyleSheet<*>> = styleIds.map(
     styleId => stylesheets.regular[styleId],
   );

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -10,11 +10,8 @@
 
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
-import {
-  DEFAULT_PRESS_OPACITY,
-  HV_TIMEOUT_ID_ATTR,
-  STYLE_ATTRIBUTE_SEPARATOR,
-} from './types';
+import { DEFAULT_PRESS_OPACITY, HV_TIMEOUT_ID_ATTR } from './types';
+import { splitAttributeList } from 'hyperview/src/services/xml';
 import type {
   Document,
   Element,
@@ -69,7 +66,7 @@ export const createStyleProp = (
   }
 
   const styleValue: string = element.getAttribute(styleAttr) || '';
-  const styleIds: Array<string> = styleValue.split(STYLE_ATTRIBUTE_SEPARATOR);
+  const styleIds: Array<string> = splitAttributeList(styleValue);
   let styleRules: Array<StyleSheet<*>> = styleIds.map(
     styleId => stylesheets.regular[styleId],
   );

--- a/src/services/types.js
+++ b/src/services/types.js
@@ -8,6 +8,5 @@
  *
  */
 
-export const STYLE_ATTRIBUTE_SEPARATOR: string = ' ';
 export const DEFAULT_PRESS_OPACITY: number = 0.7;
 export const HV_TIMEOUT_ID_ATTR: string = '_hv-timeout-id';

--- a/src/services/xml/index.js
+++ b/src/services/xml/index.js
@@ -1,0 +1,17 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * Splits a string by any whitespace and returns an array
+ * containing only the non-whitespace tokens.
+ */
+export const splitAttributeList = (attr: string): Array<string> => {
+  return attr.match(/\S+/g) || [];
+};

--- a/src/services/xml/index.js
+++ b/src/services/xml/index.js
@@ -12,6 +12,5 @@
  * Splits a string by any whitespace and returns an array
  * containing only the non-whitespace tokens.
  */
-export const splitAttributeList = (attr: string): Array<string> => {
-  return attr.match(/\S+/g) || [];
-};
+export const splitAttributeList = (attr: string): Array<string> =>
+  attr.match(/\S+/g) || [];

--- a/src/services/xml/index.test.js
+++ b/src/services/xml/index.test.js
@@ -1,0 +1,45 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { splitAttributeList } from 'hyperview/src/services/xml';
+
+describe('splitAttributeList', () => {
+  it('works with empty string', () => {
+    expect(splitAttributeList('')).toEqual([]);
+  });
+
+  it('works with only whitespace', () => {
+    expect(splitAttributeList('  \n  \t    \n\n')).toEqual([]);
+  });
+
+  it('works with tokens', () => {
+    expect(splitAttributeList('a bc def ghij')).toEqual([
+      'a',
+      'bc',
+      'def',
+      'ghij',
+    ]);
+  });
+
+  it('works with tokens and extra whitespace', () => {
+    expect(splitAttributeList('a  \n   bc\t\t\n   def   \t    ghij')).toEqual([
+      'a',
+      'bc',
+      'def',
+      'ghij',
+    ]);
+  });
+
+  it('works with tokens and leading whitespace', () => {
+    expect(
+      splitAttributeList('\n   \n\n\t    a bc def ghij\n\n\t\t    '),
+    ).toEqual(['a', 'bc', 'def', 'ghij']);
+  });
+});


### PR DESCRIPTION
Based on our XML schema, we have three "list" attributes: `style`, `show-during-load`, and `hide-during-load`. According to the XML schema spec, the items in this string list show be tokenized by any whitespace. However, our implementation was only splitting on spaces, not on characters like newlines.

This hasn't been a problem in the past because our backend strips out all newlines in the response XML to reduce the response to one line. However, we now want the option of responses with newlines, so that we can pinpoint schema errors to a specific line. If the newline occurs in a list attribute, the HXML will not be interpreted correctly. For example:
```xml
<text style="h3\n   font-weight-bold">test</text>
```
The current code will interpret the styles as `h3\n` and `font-weight-bold`, and since it can't find `h3\n` in the stylesheet, the text will have the wrong size.

This PR fixes the issue with a tested helper function that correctly tokenizes the three attributes mentioned above.

### Testing
- [ ] Manually test all demo examples