### PR TITLE
Fix date picker

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "expo": "~37.0.3",
-    "hyperview": "0.27.0",
+    "hyperview": "0.30.2",
     "react": "~16.9.0",
     "react-dom": "~16.9.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -6750,10 +6750,10 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-hyperview@0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/hyperview/-/hyperview-0.27.0.tgz#8d7f46e5b7429c979902ca9af83c2b80c9591007"
-  integrity sha512-gxXOe1DJuvN9YCD48oDlhz2775iLvnuL8f3Q5mCmj09Ayzj3C5TxUtP56VbcMp1NxCPbfml2AqU582fFwINqMQ==
+hyperview@0.30.2:
+  version "0.30.2"
+  resolved "https://registry.yarnpkg.com/hyperview/-/hyperview-0.30.2.tgz#713da3c3bb877369da71543d4b49e5dc6bccbd68"
+  integrity sha512-4IF8qxWVqnDmJAHdz+2MRW4hgo9466aPmW5M5/LEkT+4RvT9q/JSxIk86n5ILkgMlhvlgcFHYcPPQsphLrOWqA==
   dependencies:
     react-native-webview "9.4.0"
     tiny-emitter "2.1.0"

--- a/src/components/hv-date-field/index.js
+++ b/src/components/hv-date-field/index.js
@@ -76,9 +76,9 @@ export default class HvDateField extends PureComponent<
     if (!date) {
       return '';
     }
-    const year = date.getUTCFullYear();
-    const month = date.getUTCMonth() + 1;
-    const day = date.getUTCDate();
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
     return `${year}-${month}-${day}`;
   };
 


### PR DESCRIPTION
Generate dates in local timezone instead of UTC, so that formatting remains consistent. Also update demo app Hyperview version.

https://app.asana.com/0/244065166232575/1182609012386243/f

Tested by manually setting local TZ to IST.
| Before | After |
|-------|-------|
| ![date-picker-before mov](https://user-images.githubusercontent.com/309515/86170601-39912980-bad0-11ea-8140-f4c4cf5ff513.gif) | ![date-picker-after mov](https://user-images.githubusercontent.com/309515/86170616-3e55dd80-bad0-11ea-90c6-72c31814c420.gif) |

