### PR TITLE
Set test props for <picker-field> on Android

### DIFF
--- a/src/components/hv-picker-field/index.js
+++ b/src/components/hv-picker-field/index.js
@@ -26,7 +26,11 @@ import {
   View,
 } from 'react-native';
 import React, { PureComponent } from 'react';
-import { createProps, createStyleProp } from 'hyperview/src/services';
+import {
+  createProps,
+  createStyleProp,
+  createTestProps,
+} from 'hyperview/src/services';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import type { Node as ReactNode } from 'react';
 import type { State } from './types';
@@ -275,8 +279,12 @@ export default class HvPickerField extends PureComponent<
       ...options,
       styleAttr: 'field-text-style',
     });
+    const viewProps = {
+      style: fieldStyle,
+      ...createTestProps(element),
+    };
     const pickerComponent = this.renderPicker(textStyle);
-    return <View style={fieldStyle}>{pickerComponent}</View>;
+    return <View {...viewProps}>{pickerComponent}</View>;
   };
 
   /**

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -110,7 +110,7 @@ export const createStyleProp = (
  * Sets the element's id attribute as a test id and accessibility label
  * (for testing automation purposes).
  */
-export const createTestProps = (element: Element): {} => {
+export const createTestProps = (element: Element): {testID?: string, accessibilityLabel?: string} => {
   const testProps = {};
   const id: ?DOMString = element.getAttribute('id');
   if (!id) {

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -110,7 +110,9 @@ export const createStyleProp = (
  * Sets the element's id attribute as a test id and accessibility label
  * (for testing automation purposes).
  */
-export const createTestProps = (element: Element): {testID?: string, accessibilityLabel?: string} => {
+export const createTestProps = (
+  element: Element,
+): { testID?: string, accessibilityLabel?: string } => {
   const testProps = {};
   const id: ?DOMString = element.getAttribute('id');
   if (!id) {

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -13,6 +13,7 @@ import * as Render from 'hyperview/src/services/render';
 import * as Xml from 'hyperview/src/services/xml';
 import { DEFAULT_PRESS_OPACITY, HV_TIMEOUT_ID_ATTR } from './types';
 import type {
+  DOMString,
   Document,
   Element,
   HvComponentOnUpdate,
@@ -105,6 +106,22 @@ export const createStyleProp = (
   return styleRules;
 };
 
+/**
+ * Sets the element's id attribute as a test id and accessibility label
+ * (for testing automation purposes).
+ */
+export const createTestProps = (element: Element): {} => {
+  const testProps = {};
+  const id: ?DOMString = element.getAttribute('id');
+  if (!id) {
+    return testProps;
+  }
+  return {
+    testID: id,
+    accessibilityLabel: id,
+  };
+};
+
 export const createProps = (
   element: Element,
   stylesheets: StyleSheets,
@@ -127,19 +144,13 @@ export const createProps = (
         props[attr.name] = attr.value === 'true';
       } else {
         props[attr.name] = attr.value;
-
-        // Add the id attribute as a test id and accessibility label
-        // (for testing automation purposes).
-        if (attr.name === 'id') {
-          props.testID = attr.value;
-          props.accessibilityLabel = attr.value;
-        }
       }
     }
   }
 
   props.style = createStyleProp(element, stylesheets, options);
-  return props;
+  const testProps = createTestProps(element);
+  return { ...props, ...testProps };
 };
 
 export const later = (delayMs: number): Promise<void> =>

--- a/src/services/index.test.js
+++ b/src/services/index.test.js
@@ -8,7 +8,19 @@
  *
  */
 
-import { encodeXml } from '.';
+import { createProps, createTestProps, encodeXml } from '.';
+import { DOMParser } from 'xmldom-instawork';
+import { createStylesheets } from 'hyperview/src/services/stylesheets';
+
+const parser = new DOMParser();
+const createElement = (id: ?string) => {
+  const doc = parser.parseFromString('<doc></doc>');
+  const el = doc.createElement('<el>');
+  if (id) {
+    el.setAttribute('id', id);
+  }
+  return el;
+};
 
 describe('encodeXml', () => {
   it('encodes XML entities in an XML string', () => {
@@ -18,6 +30,55 @@ describe('encodeXml', () => {
       ),
     ).toEqual(
       '&lt;behavior href=&quot;https://hyperview.org/foo=bar&amp;bar=baz&quot; action=&apos;new&apos; /&gt;',
+    );
+  });
+});
+
+describe('createTestProps', () => {
+  it('sets testID from id attribute', () => {
+    expect(createTestProps(createElement('myID'))).toHaveProperty(
+      'testID',
+      'myID',
+    );
+  });
+
+  it('sets accessibilityLabel from id attribute', () => {
+    expect(createTestProps(createElement('myID'))).toHaveProperty(
+      'accessibilityLabel',
+      'myID',
+    );
+  });
+
+  it('returns empty object if no id attribute present', () => {
+    expect(createTestProps(createElement(null))).toEqual({});
+  });
+
+  it('returns empty id attribute is empty', () => {
+    expect(createTestProps(createElement(''))).toEqual({});
+  });
+});
+
+describe('createProps', () => {
+  const styleSheets = createStylesheets(parser.parseFromString('<doc></doc>'));
+
+  it('sets id from id attribute', () => {
+    expect(createProps(createElement('myID'), styleSheets, {})).toHaveProperty(
+      'id',
+      'myID',
+    );
+  });
+
+  it('sets testID from id attribute', () => {
+    expect(createProps(createElement('myID'), styleSheets, {})).toHaveProperty(
+      'testID',
+      'myID',
+    );
+  });
+
+  it('sets accessibilityLabel from id attribute', () => {
+    expect(createProps(createElement('myID'), styleSheets, {})).toHaveProperty(
+      'accessibilityLabel',
+      'myID',
     );
   });
 });


### PR DESCRIPTION
Asana: https://app.asana.com/0/923014529014430/1190686856226427/f

On iOS, we do some custom rendering for the `<picker-field>` input. The input was rendered as a `View` component with the appropriate `id`, `testID`, and `accessibilityLabel` props.

On Android, we were using the native `Picker` directly and weren't propagating props. I created a method `createTestProps` to just set the test-related props on the Android component. 