### PR TITLE
POC: disappearing tooltip

### DIFF
--- a/examples/index.xml
+++ b/examples/index.xml
@@ -54,7 +54,6 @@
     <body style="Body">
       <header style="Header">
         <text style="Header__Title">Hyperview Examples</text>
-
       </header>
       <list>
         <item href="/ui_elements/index.xml"

--- a/examples/index.xml
+++ b/examples/index.xml
@@ -54,6 +54,7 @@
     <body style="Body">
       <header style="Header">
         <text style="Header__Title">Hyperview Examples</text>
+
       </header>
       <list>
         <item href="/ui_elements/index.xml"

--- a/examples/ui_elements/index.xml
+++ b/examples/ui_elements/index.xml
@@ -56,15 +56,18 @@
     <body style="Body">
       <header style="Header">
 
-        <view style="tooltip-wrapper">
+        <!-- wrapper around the button and the tooltip -->
+        <view>
           <text action="back"
                 href="#"
             style="Header__Back">
             Back
           </text>
 
+          <!-- behavior to hide the tooltip should be outside of the tooltip to avoid RN error -->
           <behavior trigger="load" action="hide" delay="5000" target="backTooltip" />
           <view id="backTooltip" style="tooltip">
+            <!-- tooltip can open a screen on press -->
             <behavior href="/ui_elements/text.xml" />
             <text style="tooltip__text">Earn $50 for each friend who joins.
               Tap to learn more.
@@ -73,7 +76,6 @@
         </view>
 
         <text style="Header__Title">UI Elements</text>
-
       </header>
       <list>
         <item href="/ui_elements/view.xml"

--- a/examples/ui_elements/index.xml
+++ b/examples/ui_elements/index.xml
@@ -8,6 +8,7 @@
              borderBottomWidth="1"
              flexDirection="row"
              height="72"
+             zIndex="100"
              paddingLeft="24"
              paddingRight="24"
              paddingTop="24" />
@@ -47,13 +48,32 @@
       <style id="Item__Chevron"
              fontSize="18"
              fontWeight="bold" />
+
+      <style id="tooltip" overflow="visible" position="absolute" backgroundColor="#C56BFF" boderRadius="8" padding="8" width="200" top="8" />
+      <style id="tooltip__text" color="white" />
+
     </styles>
     <body style="Body">
       <header style="Header">
-        <text action="back"
-              href="#"
-              style="Header__Back">Back</text>
+
+        <view style="tooltip-wrapper">
+          <text action="back"
+                href="#"
+            style="Header__Back">
+            Back
+          </text>
+
+          <behavior trigger="load" action="hide" delay="5000" target="backTooltip" />
+          <view id="backTooltip" style="tooltip">
+            <behavior href="/ui_elements/text.xml" />
+            <text style="tooltip__text">Earn $50 for each friend who joins.
+              Tap to learn more.
+            </text>
+          </view>
+        </view>
+
         <text style="Header__Title">UI Elements</text>
+
       </header>
       <list>
         <item href="/ui_elements/view.xml"

--- a/src/services/stylesheets/index.js
+++ b/src/services/stylesheets/index.js
@@ -101,6 +101,7 @@ const STYLE_ATTRIBUTE_CONVERTERS = {
   right: numberOrPercent,
   top: numberOrPercent,
   width: numberOrPercent,
+  zIndex: number,
 
   // view attributes
   borderRightColor: string,


### PR DESCRIPTION
Example of a floating tooltip that disappears after 5 seconds:
![2020-09-09 10 50 29](https://user-images.githubusercontent.com/1034502/92636691-a2451100-f28c-11ea-9034-32fcc46eaccb.gif)

NOTE: to get this working, I needed to add z-index support for styles. This requires a new HV version in the app. On older versions, the tooltip will be partially under the scrolling list.