### PR TITLE
Switch to new date picker component

### DIFF
--- a/__mocks__/@react-native-community/datetimepicker.js
+++ b/__mocks__/@react-native-community/datetimepicker.js
@@ -1,0 +1,3 @@
+// @flow
+
+export default () => null;

--- a/demo/package.json
+++ b/demo/package.json
@@ -8,6 +8,7 @@
     "eject": "expo eject"
   },
   "dependencies": {
+    "@react-native-community/datetimepicker": "3.0.0",
     "expo": "^39.0.0",
     "hyperview": "0.32.0",
     "react": "16.13.1",

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -2121,6 +2121,15 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
+"@react-native-community/datetimepicker@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-3.0.0.tgz#93747bcabbebff191547edd07103cf2ea15acf8c"
+  integrity sha512-GqKnUd5oZ5iy0PhkeRimxrgHiJur6zUYJaU4OI3JnInKuTqbuBRviHackIhTHIJtIKyGPRnHXrH1XhWiHlf4AQ==
+  dependencies:
+    invariant "^2.2.4"
+  optionalDependencies:
+    react-native-windows "^0.62.0-0"
+
 "@react-navigation/core@^3.7.8":
   version "3.7.8"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-3.7.8.tgz#9c2c191dea8d97b2644f18917d885d4943cb8bff"
@@ -3925,6 +3934,11 @@ cli-spinners@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.3.0.tgz#0632239a4b5aa4c958610142c34bb7a651fc8df5"
   integrity sha512-Xs2Hf2nzrvJMFKimOR7YR0QwZ8fc0u98kdtwN1eNAZzNQgH3vK2pXzff6GJtKh7S5hoJ87ECiAiZFS2fb5Ii2w==
 
+cli-spinners@^2.2.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.5.0.tgz#12763e47251bf951cb75c201dfa58ff1bcb2d047"
+  integrity sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==
+
 cli-table3@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.0.tgz#b7b1bc65ca8e7b5cef9124e13dc2b21e2ce4faee"
@@ -4379,6 +4393,14 @@ create-react-class@^15.6.2:
   integrity sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==
   dependencies:
     fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
+create-react-class@^15.6.3:
+  version "15.7.0"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.7.0.tgz#7499d7ca2e69bb51d13faf59bd04f0c65a1d6c1e"
+  integrity sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==
+  dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
@@ -5168,7 +5190,7 @@ envinfo@7.5.0:
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.5.0.tgz#91410bb6db262fb4f1409bd506e9ff57e91023f4"
   integrity sha512-jDgnJaF/Btomk+m3PZDTTCb5XIIIX3zYItnCRfF73zVgvinLoRomuhi75Y4su0PtQxWz4v66XnLLckyvyJTOIQ==
 
-envinfo@^7.7.2:
+envinfo@^7.5.0, envinfo@^7.7.2:
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.7.3.tgz#4b2d8622e3e7366afb8091b23ed95569ea0208cc"
   integrity sha512-46+j5QxbPWza0PB1i15nZx0xQ4I/EfQxg9J8Had3b408SV63nEtor2e+oiY63amTo9KTuh2a3XLObNwduxYwwA==
@@ -6383,7 +6405,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -7136,6 +7158,11 @@ internal-ip@4.3.0, internal-ip@^4.3.0:
   dependencies:
     default-gateway "^4.2.0"
     ipaddr.js "^1.9.0"
+
+interpret@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 invariant@2.2.4, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
@@ -8271,7 +8298,7 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-mem@^4.0.0:
+mem@^4.0.0, mem@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
   integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
@@ -10797,6 +10824,25 @@ react-native-webview@9.4.0:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"
 
+react-native-windows@^0.62.0-0:
+  version "0.62.12"
+  resolved "https://registry.yarnpkg.com/react-native-windows/-/react-native-windows-0.62.12.tgz#84baa0619532546ef63f2276c2f74ee02819c4ca"
+  integrity sha512-QjBhvYEVWAuGT1I9XC/KVTSHIMYIitVpNQYcmUKAFfgF1SA4JV7PHJJGqE04lmrmQh2Z1eB/ONRVOtmsVa/EQQ==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    cli-spinners "^2.2.0"
+    create-react-class "^15.6.3"
+    envinfo "^7.5.0"
+    fbjs "^1.0.0"
+    glob "^7.1.1"
+    ora "^3.4.0"
+    prop-types "^15.7.2"
+    regenerator-runtime "^0.13.2"
+    shelljs "^0.7.8"
+    username "^5.1.0"
+    uuid "^3.3.2"
+    xml-parser "^1.2.1"
+
 "react-native@https://github.com/expo/react-native/archive/sdk-39.0.3.tar.gz":
   version "0.63.2"
   resolved "https://github.com/expo/react-native/archive/sdk-39.0.3.tar.gz#481924772788f0c04373b2bc2512d92fa264867d"
@@ -10936,6 +10982,13 @@ recast@~0.11.12:
     esprima "~3.1.0"
     private "~0.1.5"
     source-map "~0.5.0"
+
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+  dependencies:
+    resolve "^1.1.6"
 
 recursive-readdir@2.2.2:
   version "2.2.2"
@@ -11165,7 +11218,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -11585,6 +11638,15 @@ shell-quote@^1.6.1:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
+
+shelljs@^0.7.8:
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
+  integrity sha1-3svPh0sNHl+3LhSxZKloMEjprLM=
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 side-channel@^1.0.3:
   version "1.0.3"
@@ -12942,6 +13004,14 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
+username@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/username/-/username-5.1.0.tgz#a7f9325adce2d0166448cdd55d4985b1360f2508"
+  integrity sha512-PCKbdWw85JsYMvmCv5GH3kXmM66rCd9m1hBEDutPNv94b/pqCMT4NtcKyeWYvLFiE8b+ha1Jdl8XAaUdPn5QTg==
+  dependencies:
+    execa "^1.0.0"
+    mem "^4.3.0"
+
 utif@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/utif/-/utif-2.0.1.tgz#9e1582d9bbd20011a6588548ed3266298e711759"
@@ -13591,6 +13661,13 @@ xml-parse-from-string@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz#a9029e929d3dbcded169f3c6e28238d95a5d5a28"
   integrity sha1-qQKekp09vN7RafPG4oI42VpdWig=
+
+xml-parser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/xml-parser/-/xml-parser-1.2.1.tgz#c31f4c34f2975db82ad013222120592736156fcd"
+  integrity sha1-wx9MNPKXXbgq0BMiISBZJzYVb80=
+  dependencies:
+    debug "^2.2.0"
 
 xml2js@^0.4.23, xml2js@^0.4.5:
   version "0.4.23"

--- a/examples/ui_elements/forms/date_field.xml
+++ b/examples/ui_elements/forms/date_field.xml
@@ -51,6 +51,7 @@
         </modifier>
       </style>
       <style id="Input__Text"
+             color="black"
              fontSize="16"
              fontWeight="normal"></style>
       <style id="Input--Error"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test": "yarn generate test && yarn test:flow && yarn test:lint && yarn test:render && yarn test:unit && yarn test:validate-xml"
   },
   "dependencies": {
+    "@react-native-community/datetimepicker": "^3.0.3",
     "react-native-webview": "9.4.0",
     "tiny-emitter": "2.1.0",
     "url-parse": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "yarn generate test && yarn test:flow && yarn test:lint && yarn test:render && yarn test:unit && yarn test:validate-xml"
   },
   "dependencies": {
-    "@react-native-community/datetimepicker": "^3.0.3",
+    "@react-native-community/datetimepicker": "3.0.3",
     "react-native-webview": "9.4.0",
     "tiny-emitter": "2.1.0",
     "url-parse": "1.4.3",

--- a/src/components/hv-date-field/index.js
+++ b/src/components/hv-date-field/index.js
@@ -182,7 +182,9 @@ export default class HvDateField extends PureComponent<
     const maxValue: ?DOMString = this.props.element.getAttribute('max');
     const minDate: ?Date = HvDateField.createDateFromString(minValue);
     const maxDate: ?Date = HvDateField.createDateFromString(maxValue);
+    const displayMode: ?DOMString = this.props.element.getAttribute('mode');
     const props: Object = {
+      display: displayMode,
       value: this.state.pickerValue,
       mode: 'date',
       onChange,

--- a/src/components/hv-date-field/index.js
+++ b/src/components/hv-date-field/index.js
@@ -172,9 +172,12 @@ export default class HvDateField extends PureComponent<
 
   /**
    * Renders the date picker component, with the given min and max dates.
-   * This is used on iOS only.
+   * Used for both iOS and Android. However, on iOS this component is rendered inline,
+   * and on Android it's rendered as a modal. Thus, the on-change callback needs to be
+   * handled differently in each Platform, and on iOS we need to wrap this component
+   * in our own modal for consistency.
    */
-  renderPicker = (onChange: (evt: Event, date: Date) => void): ReactNode => {
+  renderPicker = (onChange: (evt: Event, date?: Date) => void): ReactNode => {
     const minValue: ?DOMString = this.props.element.getAttribute('min');
     const maxValue: ?DOMString = this.props.element.getAttribute('max');
     const minDate: ?Date = HvDateField.createDateFromString(minValue);
@@ -203,7 +206,7 @@ export default class HvDateField extends PureComponent<
     if (!this.state.focused) {
       return null;
     }
-    const onChange = (evt: Event, date: Date) => {
+    const onChange = (evt: Event, date?: Date) => {
       if (date === undefined) {
         // Modal was dismissed (cancel button)
         this.onModalCancel();
@@ -256,7 +259,7 @@ export default class HvDateField extends PureComponent<
 
     // On iOS, store the changed value in the temp state until the modal
     // is saved.
-    const onChange = (evt: Event, date: Date) => {
+    const onChange = (evt: Event, date?: Date) => {
       this.setState({ pickerValue: date });
     };
 

--- a/src/components/hv-date-field/index.js
+++ b/src/components/hv-date-field/index.js
@@ -17,8 +17,6 @@ import type {
   StyleSheets,
 } from 'hyperview/src/types';
 import {
-  DatePickerAndroid,
-  DatePickerIOS,
   Modal,
   Platform,
   Text,
@@ -28,6 +26,7 @@ import {
 import React, { PureComponent } from 'react';
 import { createProps, createStyleProp } from 'hyperview/src/services';
 import { DateFormatContext } from 'hyperview/src';
+import DateTimePicker from '@react-native-community/datetimepicker';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import type { Node as ReactNode } from 'react';
 import type { State } from './types';
@@ -122,15 +121,6 @@ export default class HvDateField extends PureComponent<
     return prevState;
   }
 
-  componentDidUpdate = (prevProps: HvComponentProps, prevState: State) => {
-    // TODO: move to React hooks once we adopt them across the codebase.
-    if (Platform.OS === 'android') {
-      if (!prevState.fieldPressed && this.state.fieldPressed) {
-        this.showPickerAndroid();
-      }
-    }
-  };
-
   toggleFieldPress = () => {
     this.setState(prevState => ({ fieldPressed: !prevState.fieldPressed }));
   };
@@ -181,54 +171,18 @@ export default class HvDateField extends PureComponent<
   };
 
   /**
-   * Date picker on Android is implemented as an async function.
-   * This gets triggered when field pressed state changes from false to true.
-   * This is used on Android only.
-   */
-  showPickerAndroid = async () => {
-    const maxValue: ?DOMString = this.props.element.getAttribute('max');
-    const minValue: ?DOMString = this.props.element.getAttribute('min');
-    const mode: ?string = this.props.element.getAttribute('mode');
-    const minDate: ?Date = HvDateField.createDateFromString(minValue);
-    const maxDate: ?Date = HvDateField.createDateFromString(maxValue);
-    const options: Object = {
-      date: this.state.pickerValue,
-    };
-    if (minDate) {
-      options.minDate = minDate;
-    }
-    if (maxDate) {
-      options.maxDate = maxDate;
-    }
-    options.mode = mode || 'default';
-    const openAction = await DatePickerAndroid.open(options);
-    const { action, year, month, day } = openAction;
-    if (action === DatePickerAndroid.dateSetAction) {
-      // Selected year, month (0-11), day
-      this.setState({ pickerValue: new Date(year, month, day) });
-      this.onModalDone();
-    } else {
-      this.onModalCancel();
-    }
-  };
-
-  /**
    * Renders the date picker component, with the given min and max dates.
    * This is used on iOS only.
    */
-  renderPickeriOS = (): ReactNode => {
+  renderPicker = (onChange: (evt: Event, date: Date) => void): ReactNode => {
     const minValue: ?DOMString = this.props.element.getAttribute('min');
     const maxValue: ?DOMString = this.props.element.getAttribute('max');
     const minDate: ?Date = HvDateField.createDateFromString(minValue);
     const maxDate: ?Date = HvDateField.createDateFromString(maxValue);
-    const onDateChange = (value: Date) => {
-      this.setState({ pickerValue: value });
-    };
-
     const props: Object = {
-      date: this.state.pickerValue,
+      value: this.state.pickerValue,
       mode: 'date',
-      onDateChange,
+      onChange,
     };
     if (minDate) {
       props.minimumDate = minDate;
@@ -237,7 +191,28 @@ export default class HvDateField extends PureComponent<
       props.maximumDate = maxDate;
     }
 
-    return <DatePickerIOS {...props} />;
+    return <DateTimePicker {...props} />;
+  };
+
+  /**
+   * Unlike iOS, the Android picker natively uses a modal. So we don't need
+   * to wrap it in an extra component, just render it when we want the modal
+   * to appear.
+   */
+  renderPickerModalAndroid = (): ?ReactNode => {
+    if (!this.state.focused) {
+      return null;
+    }
+    const onChange = (evt: Event, date: Date) => {
+      if (date === undefined) {
+        // Modal was dismissed (cancel button)
+        this.onModalCancel();
+      } else {
+        this.setState({ pickerValue: date });
+        this.onModalDone();
+      }
+    };
+    return this.renderPicker(onChange);
   };
 
   /**
@@ -246,10 +221,6 @@ export default class HvDateField extends PureComponent<
    * This is used on iOS only.
    */
   renderPickerModaliOS = (): ReactNode => {
-    if (Platform.OS === 'android') {
-      return null;
-    }
-
     const element: Element = this.props.element;
     const stylesheets: StyleSheets = this.props.stylesheets;
     const options: HvComponentOptions = this.props.options;
@@ -283,6 +254,12 @@ export default class HvDateField extends PureComponent<
       element.getAttribute('cancel-label') || 'Cancel';
     const doneLabel: string = element.getAttribute('done-label') || 'Done';
 
+    // On iOS, store the changed value in the temp state until the modal
+    // is saved.
+    const onChange = (evt: Event, date: Date) => {
+      this.setState({ pickerValue: date });
+    };
+
     return (
       <Modal
         animationType="slide"
@@ -312,7 +289,7 @@ export default class HvDateField extends PureComponent<
                 </View>
               </TouchableWithoutFeedback>
             </View>
-            {this.renderPickeriOS()}
+            {this.renderPicker(onChange)}
           </View>
         </View>
       </Modal>
@@ -375,8 +352,10 @@ export default class HvDateField extends PureComponent<
       styleAttr: 'field-style',
     });
 
-    const iosPicker =
-      Platform.OS === 'ios' ? this.renderPickerModaliOS() : null;
+    const picker =
+      Platform.OS === 'ios'
+        ? this.renderPickerModaliOS()
+        : this.renderPickerModalAndroid();
 
     return (
       <TouchableWithoutFeedback
@@ -388,7 +367,7 @@ export default class HvDateField extends PureComponent<
           <DateFormatContext.Consumer>
             {formatter => this.renderLabel(formatter)}
           </DateFormatContext.Consumer>
-          {iosPicker}
+          {picker}
         </View>
       </TouchableWithoutFeedback>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,6 +68,13 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@react-native-community/datetimepicker@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-3.0.3.tgz#711b4cb7fd195ab7ae867b8feab176ce46e765c8"
+  integrity sha512-znltGqSyELRpS/JchT/6MraTRqC83INekEyAkH+0gBrDzv0SwFKwVWacv1tF5D1y5VrHcSrcFB3T/tBsksUgwA==
+  dependencies:
+    invariant "^2.2.4"
+
 "@storybook/addon-actions@3.3.15":
   version "3.3.15"
   resolved "http://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.3.15.tgz#2831e52947dc258208dd17804b479f7acc62d859"

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,7 +68,7 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@react-native-community/datetimepicker@^3.0.3":
+"@react-native-community/datetimepicker@3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-3.0.3.tgz#711b4cb7fd195ab7ae867b8feab176ce46e765c8"
   integrity sha512-znltGqSyELRpS/JchT/6MraTRqC83INekEyAkH+0gBrDzv0SwFKwVWacv1tF5D1y5VrHcSrcFB3T/tBsksUgwA==


### PR DESCRIPTION
[Asana](https://app.asana.com/0/923014529014430/1198498895658493/f)

The `<date-field>` component was using the deprecated `DatePickeriOS` and `DatePickerAndroid` components from core. These don't render correctly on iOS 14. To fix the issue, I'm switching to the [community version](https://github.com/react-native-datetimepicker/datetimepicker) of this component.

Changes:
- `DateTimePicker` now has a unified component API for iOS and Android. I removed the old async callback for Android.
- New `renderPickerModalAndroid` shares code with iOS but adds focus handling and a callback that handles dismiss action.
- Updated to the prop changes documented [here](https://github.com/react-native-datetimepicker/datetimepicker#migration-from-the-older-components).

### Testing
- [x] iOS 13 Simulator
- [x] iOS 14 Simulator
- [x] Android