### PR TITLE
Added support for keyboard avoiding view

### DIFF
--- a/docs/reference_view.md
+++ b/docs/reference_view.md
@@ -112,5 +112,5 @@ If `hide="true"`, the element will not be rendered on screen. If the element or 
 | ------------------------- | -------- |
 | true, **false** (default) | No       |
 
-An attribute to solve the common problem of views that need to move out of the way of the virtual keyboard. It can automatically adjust its position based on the keyboard height. This is useful when you want keyboard avoiding behavior in non-scrollable views. It is applied only in iOS since
+An attribute to solve the common problem of views that need to move out of the way of the virtual keyboard. It can automatically adjust the position of its children based on the keyboard height. This is useful when you want keyboard avoiding behavior in non-scrollable views. It is applied only in iOS since
 Android has built-in support for avoiding keyboard.

--- a/docs/reference_view.md
+++ b/docs/reference_view.md
@@ -52,6 +52,7 @@ A `<view>` element can only appear anywhere within a `<screen>` element.
 - [`scroll-to-input-offset`](#scroll-to-input-offset)
 - [`id`](#id)
 - [`hide`](#hide)
+- [`avoid-keyboard`](#avoid-keyboard)
 
 #### Behavior attributes
 
@@ -104,3 +105,12 @@ A global attribute uniquely identifying the element in the whole document.
 | **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.
+
+#### `avoid-keyboard`
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| true, **false** (default) | No       |
+
+An attribute to solve the common problem of views that need to move out of the way of the virtual keyboard. It can automatically adjust its position based on the keyboard height. This is useful when you want keyboard avoiding behavior in non-scrollable views. It is applied only in iOS since
+Android has built-in support for avoiding keyboard.

--- a/docs/reference_view.md
+++ b/docs/reference_view.md
@@ -112,5 +112,4 @@ If `hide="true"`, the element will not be rendered on screen. If the element or 
 | ------------------------- | -------- |
 | true, **false** (default) | No       |
 
-An attribute to solve the common problem of views that need to move out of the way of the virtual keyboard. It can automatically adjust the position of its children based on the keyboard height. This is useful when you want keyboard avoiding behavior in non-scrollable views. It is applied only in iOS since
-Android has built-in support for avoiding keyboard.
+An attribute to solve the common problem of views that need to move out of the way of the virtual keyboard. It can automatically adjust the position of its children based on the keyboard height. This is useful when you want keyboard avoiding behavior in non-scrollable views. It is applied only in iOS since Android has built-in support for avoiding keyboard.

--- a/examples/ui_elements/index.xml
+++ b/examples/ui_elements/index.xml
@@ -70,6 +70,13 @@
           <text style="Item__Label">Scroll Views</text>
           <text style="Item__Chevron">&gt;</text>
         </item>
+        <item href="/ui_elements/keyboard_avoiding_view.xml"
+              key="scroll-view"
+              show-during-load="loadingScreen"
+              style="Item">
+          <text style="Item__Label">Keyboard Avoiding View</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
         <item href="/ui_elements/text.xml"
               key="text"
               show-during-load="loadingScreen"

--- a/examples/ui_elements/keyboard_avoiding_view.xml
+++ b/examples/ui_elements/keyboard_avoiding_view.xml
@@ -28,20 +28,6 @@
              fontWeight="normal"
              margin="24"
              marginBottom="0" />
-      <style id="Item__Label"
-             fontSize="18"
-             fontWeight="normal" />
-      <style id="Item__Chevron"
-             fontSize="18"
-             fontWeight="bold" />
-      <style id="Border"
-             borderColor="#e1e1e1"
-             borderWidth="1"
-             flex="1"
-             margin="24"
-             padding="8" />
-      <style id="Main"
-             flex="1" />
       <style id="ScrollContainer"
              borderColor="#e1e1e1"
              borderRadius="16"
@@ -54,32 +40,32 @@
              marginLeft="24"
              marginRight="24"
              marginTop="48" />
-      <style id="label"
-						borderColor="#4E4D4D"
-						fontSize="16"
-						fontWeight="bold"
-						lineHeight="24"
-						marginBottom="8" />
-      <style id="input"
-            borderBottomColor="#E1E1E1"
-            borderBottomWidth="1"
-            borderColor="#4E4D4D"
-            flex="1"
-            fontSize="16"
-            fontWeight="normal"
-            paddingBottom="8"
-            paddingTop="8"
-						marginBottom="24">
+      <style id="Label"
+						 borderColor="#4E4D4D"
+						 fontSize="16"
+						 fontWeight="bold"
+						 lineHeight="24"
+						 marginBottom="8" />
+      <style id="Input"
+             borderBottomColor="#E1E1E1"
+             borderBottomWidth="1"
+             borderColor="#4E4D4D"
+             flex="1"
+             fontSize="16"
+             fontWeight="normal"
+             paddingBottom="8"
+             paddingTop="8"
+						 marginBottom="24" />
 			<style id="Footer"
-				backgroundColor="#63CB76"
-				width="100%"
-				padding="24"
-				marginTop="48" />
+						 backgroundColor="#63CB76"
+						 width="100%"
+						 padding="24"
+						 marginTop="48" />
 			<style id="Footer__Description"
-						color="white"
-						fontSize="24"
-						fontWeight="bold"
-						textAlign="center" />
+						 color="white"
+						 fontSize="24"
+						 fontWeight="bold"
+						 textAlign="center" />
     </styles>
     <body style="Body">
       <header style="Header">
@@ -92,14 +78,14 @@
         <text style="Description">Scrollable view with text inputs that open the keyboard</text>
         <view scroll="true" style="ScrollContainer ScrollContainer--Vertical">
 					<view style="FormGroup">
-						<text style="label">Input field 1</text>
-						<text-field placeholder="First name" placeholderTextColor="#8D9494" name="text" style="input" />
+						<text style="Label">Input field 1</text>
+						<text-field placeholder="First name" placeholderTextColor="#8D9494" name="text" style="Input" />
 
-						<text style="label">Input field 2</text>
-						<text-field placeholder="Last name" placeholderTextColor="#8D9494" name="text" style="input" />
+						<text style="Label">Input field 2</text>
+						<text-field placeholder="Last name" placeholderTextColor="#8D9494" name="text" style="Input" />
 
-						<text style="label">Input field 3</text>
-						<text-field placeholder="Address" placeholderTextColor="#8D9494" name="text" style="input" />
+						<text style="Label">Input field 3</text>
+						<text-field placeholder="Address" placeholderTextColor="#8D9494" name="text" style="Input" />
 					</view>
 				</view>
 

--- a/examples/ui_elements/keyboard_avoiding_view.xml
+++ b/examples/ui_elements/keyboard_avoiding_view.xml
@@ -1,0 +1,111 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style id="Header"
+             alignItems="center"
+             backgroundColor="white"
+             borderBottomColor="#eee"
+             borderBottomWidth="1"
+             flexDirection="row"
+             height="72"
+             paddingLeft="24"
+             paddingRight="24"
+             paddingTop="24" />
+      <style id="Header__Back"
+             color="blue"
+             fontSize="16"
+             fontWeight="600"
+             paddingRight="16" />
+      <style id="Header__Title"
+             color="black"
+             fontSize="24"
+             fontWeight="600" />
+      <style id="Body"
+             backgroundColor="white"
+             flex="1" />
+      <style id="Description"
+             fontSize="16"
+             fontWeight="normal"
+             margin="24"
+             marginBottom="0" />
+      <style id="Item__Label"
+             fontSize="18"
+             fontWeight="normal" />
+      <style id="Item__Chevron"
+             fontSize="18"
+             fontWeight="bold" />
+      <style id="Border"
+             borderColor="#e1e1e1"
+             borderWidth="1"
+             flex="1"
+             margin="24"
+             padding="8" />
+      <style id="Main"
+             flex="1" />
+      <style id="ScrollContainer"
+             borderColor="#e1e1e1"
+             borderRadius="16"
+             borderWidth="1"
+             margin="24" />
+      <style id="ScrollContainer--Vertical"
+             flexDirection="column" />
+      <style id="FormGroup"
+             flex="1"
+             marginLeft="24"
+             marginRight="24"
+             marginTop="48" />
+      <style id="label"
+						borderColor="#4E4D4D"
+						fontSize="16"
+						fontWeight="bold"
+						lineHeight="24"
+						marginBottom="8" />
+      <style id="input"
+            borderBottomColor="#E1E1E1"
+            borderBottomWidth="1"
+            borderColor="#4E4D4D"
+            flex="1"
+            fontSize="16"
+            fontWeight="normal"
+            paddingBottom="8"
+            paddingTop="8"
+						marginBottom="24">
+			<style id="Footer"
+				backgroundColor="#63CB76"
+				width="100%"
+				padding="24"
+				marginTop="48" />
+			<style id="Footer__Description"
+						color="white"
+						fontSize="24"
+						fontWeight="bold"
+						textAlign="center" />
+    </styles>
+    <body style="Body">
+      <header style="Header">
+        <text action="back"
+              href="#"
+              style="Header__Back">Back</text>
+        <text style="Header__Title">Keyboard Avoiding View</text>
+      </header>
+      
+        <text style="Description">Scrollable view with text inputs that open the keyboard</text>
+        <view scroll="true" style="ScrollContainer ScrollContainer--Vertical">
+					<view style="FormGroup">
+						<text style="label">Input field 1</text>
+						<text-field placeholder="First name" placeholderTextColor="#8D9494" name="text" style="input" />
+
+						<text style="label">Input field 2</text>
+						<text-field placeholder="Last name" placeholderTextColor="#8D9494" name="text" style="input" />
+
+						<text style="label">Input field 3</text>
+						<text-field placeholder="Address" placeholderTextColor="#8D9494" name="text" style="input" />
+					</view>
+				</view>
+
+        <view avoid-keyboard="true" style="Footer">
+          <text style="Footer__Description">Keyboard Avoiding View</text>
+        </view>
+    </body>
+  </screen>
+</doc>

--- a/examples/ui_elements/keyboard_avoiding_view.xml
+++ b/examples/ui_elements/keyboard_avoiding_view.xml
@@ -28,18 +28,9 @@
              fontWeight="normal"
              margin="24"
              marginBottom="0" />
-      <style id="ScrollContainer"
-             borderColor="#e1e1e1"
-             borderRadius="16"
-             borderWidth="1"
-             margin="24" />
-      <style id="ScrollContainer--Vertical"
-             flexDirection="column" />
       <style id="FormGroup"
              flex="1"
-             marginLeft="24"
-             marginRight="24"
-             marginTop="48" />
+             margin="24" />
       <style id="Label"
 						 borderColor="#4E4D4D"
 						 fontSize="16"
@@ -50,7 +41,6 @@
              borderBottomColor="#E1E1E1"
              borderBottomWidth="1"
              borderColor="#4E4D4D"
-             flex="1"
              fontSize="16"
              fontWeight="normal"
              paddingBottom="8"
@@ -59,8 +49,7 @@
 			<style id="Footer"
 						 backgroundColor="#63CB76"
 						 width="100%"
-						 padding="24"
-						 marginTop="48" />
+						 padding="24" />
 			<style id="Footer__Description"
 						 color="white"
 						 fontSize="24"
@@ -74,24 +63,24 @@
               style="Header__Back">Back</text>
         <text style="Header__Title">Keyboard Avoiding View</text>
       </header>
-      
-        <text style="Description">Scrollable view with text inputs that open the keyboard</text>
-        <view scroll="true" style="ScrollContainer ScrollContainer--Vertical">
-					<view style="FormGroup">
-						<text style="Label">Input field 1</text>
-						<text-field placeholder="First name" placeholderTextColor="#8D9494" name="text" style="Input" />
 
-						<text style="Label">Input field 2</text>
-						<text-field placeholder="Last name" placeholderTextColor="#8D9494" name="text" style="Input" />
+			<text style="Description">View with text inputs that open the keyboard</text>
+			<view style="FormGroup">
+				<text style="Label">Input field 1</text>
+				<text-field placeholder="First name" placeholderTextColor="#8D9494" name="text" style="Input" />
 
-						<text style="Label">Input field 3</text>
-						<text-field placeholder="Address" placeholderTextColor="#8D9494" name="text" style="Input" />
-					</view>
-				</view>
+				<text style="Label">Input field 2</text>
+				<text-field placeholder="Last name" placeholderTextColor="#8D9494" name="text" style="Input" />
 
-        <view avoid-keyboard="true" style="Footer">
+				<text style="Label">Input field 3</text>
+				<text-field placeholder="Address" placeholderTextColor="#8D9494" name="text" style="Input" />
+			</view>
+
+			<view avoid-keyboard="true">
+        <view style="Footer">
           <text style="Footer__Description">Keyboard Avoiding View</text>
         </view>
+			</view>
     </body>
   </screen>
 </doc>

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -720,6 +720,7 @@
       <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="id" type="hv:ID"/>
       <xs:attribute name="hide" type="xs:boolean"/>
+      <xs:attribute name="avoid-keyboard" type="xs:boolean"/>
       <xs:attributeGroup ref="hv:behaviorAttributes"/>
       <xs:attributeGroup ref="hv:scrollAttributes"/>
     </xs:complexType>

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -10,8 +10,8 @@
 
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
-import React, { PureComponent } from 'react';
 import { KeyboardAvoidingView, Platform, ScrollView, View } from 'react-native';
+import React, { PureComponent } from 'react';
 import { addHref, createProps } from 'hyperview/src/services';
 import type { HvComponentProps } from 'hyperview/src/types';
 import type { InternalProps } from './types';

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -11,7 +11,7 @@
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
 import React, { PureComponent } from 'react';
-import { ScrollView, View } from 'react-native';
+import { KeyboardAvoidingView, Platform, ScrollView, View } from 'react-native';
 import { addHref, createProps } from 'hyperview/src/services';
 import type { HvComponentProps } from 'hyperview/src/types';
 import type { InternalProps } from './types';
@@ -36,7 +36,18 @@ export default class HvView extends PureComponent<HvComponentProps> {
     const { skipHref } = viewOptions || {};
     const props: InternalProps = createProps(element, stylesheets, viewOptions);
     const scrollable = !!element.getAttribute('scroll');
+    const keyboardAvoiding = !!element.getAttribute('keyboard-avoid');
     let c = View;
+
+    /**
+     * Useful when you want keyboard avoiding behavior in non-scrollable views.
+     * Note: Android has built-in support for avoiding keyboard.
+     */
+    if (keyboardAvoiding && Platform.OS === 'ios') {
+      c = KeyboardAvoidingView;
+      props.behavior = 'position';
+    }
+
     const inputRefs = [];
     if (scrollable) {
       const textFields = element.getElementsByTagNameNS(

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -36,7 +36,7 @@ export default class HvView extends PureComponent<HvComponentProps> {
     const { skipHref } = viewOptions || {};
     const props: InternalProps = createProps(element, stylesheets, viewOptions);
     const scrollable = !!element.getAttribute('scroll');
-    const keyboardAvoiding = !!element.getAttribute('keyboard-avoid');
+    const keyboardAvoiding = !!element.getAttribute('avoid-keyboard');
     let c = View;
 
     /**

--- a/src/components/hv-view/types.js
+++ b/src/components/hv-view/types.js
@@ -12,6 +12,7 @@ import type { StyleSheet } from 'react-native/Libraries/StyleSheet/StyleSheetTyp
 
 export type InternalProps = {|
   accessibilityLabel?: ?string,
+  behavior?: ?string,
   extraScrollHeight?: ?number,
   keyboardOpeningTime?: ?number,
   keyboardShouldPersistTaps?: ?string,

--- a/src/components/hv-view/types.js
+++ b/src/components/hv-view/types.js
@@ -12,7 +12,7 @@ import type { StyleSheet } from 'react-native/Libraries/StyleSheet/StyleSheetTyp
 
 export type InternalProps = {|
   accessibilityLabel?: ?string,
-  behavior?: ?string,
+  behavior?: 'position',
   extraScrollHeight?: ?number,
   keyboardOpeningTime?: ?number,
   keyboardShouldPersistTaps?: ?string,


### PR DESCRIPTION
[Asana](https://app.asana.com/0/491474088351836/1198503649002413/f)

### Summary
The keyboard is hiding the footer section only on iOS as described in the asana ticket.
We have `KeyboardAwareScrollView` but that can't be used for fixed footers since they need to be outside the scroll view. 

**Changes**:
Allow specifying `avoid-keyboard` attribute on a view. That will wrap the contents in a `KeyboardAvoidingView` for iOS only. Android has built-in support for this functionality.

**Usage**
`<view avoid-keyboard="true">
    {% include 'worker/quiz/questionnaire/footer.xml' %}
  </view>`

### Demo

1. iOS 
![keyboard_avoiding_ios](https://user-images.githubusercontent.com/2883006/96565897-93696980-12e2-11eb-8318-880e245a86fe.gif) 

2. Android
![keyboard_avoid_android](https://user-images.githubusercontent.com/2883006/96565926-9b290e00-12e2-11eb-88a4-a1404ffa6f30.gif)

3. Example Demo
![hv_keyboard_avoiding_view](https://user-images.githubusercontent.com/2883006/96694500-2ddeb100-13a6-11eb-8ffc-4136482c6133.gif)



