### PR TITLE
Support secure-text for text fields

### DIFF
--- a/docs/reference_textfield.md
+++ b/docs/reference_textfield.md
@@ -37,6 +37,7 @@ A `<text-field>` element can appear anywhere within a `<form>` element.
 - [`id`](#id)
 - [`hide`](#hide)
 - [`auto-focus`](#auto-focus)
+- [`secure-text`](#secure-text)
 
 #### `name`
 
@@ -130,3 +131,11 @@ If `hide="true"`, the element will not be rendered on screen. If the element or 
 | **false** (default), true | No       |
 
 If `auto-focus="true"`, the element will steal focus the moment it's rendered.
+
+#### `secure-text`
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
+
+If `secure-text="true"`, the input in the text field will be obscured. Appropriate to use for passwords or other sensitive information.

--- a/examples/ui_elements/forms/text_input.xml
+++ b/examples/ui_elements/forms/text_input.xml
@@ -195,6 +195,29 @@
                       style="input"
                       value="" />
         </view>
+
+        <view style="FormGroup">
+          <text style="label">Secure Text</text>
+          <text-field placeholder="Password"
+                      placeholderTextColor="#8D9494"
+                      name="text"
+                      style="input"
+                      secure-text="true"
+                      value="" />
+        </view>
+
+        <view style="FormGroup">
+          <text style="label">Secure Text + Mask</text>
+          <text-field keyboard-type="number-pad"
+                      placeholder="SSN"
+                      placeholderTextColor="#8D9494"
+                      mask="999 99 9999"
+                      name="text"
+                      style="input"
+                      secure-text="true"
+                      value="" />
+        </view>
+
       </view>
     </body>
   </screen>

--- a/examples/ui_elements/index.xml
+++ b/examples/ui_elements/index.xml
@@ -71,7 +71,7 @@
           <text style="Item__Chevron">&gt;</text>
         </item>
         <item href="/ui_elements/keyboard_avoiding_view.xml"
-              key="scroll-view"
+              key="keyboard-avoiding-view"
               show-during-load="loadingScreen"
               style="Item">
           <text style="Item__Label">Keyboard Avoiding View</text>

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -950,6 +950,7 @@
       <xs:attribute name="hide" type="xs:boolean"/>
       <xs:attribute name="style" type="hv:styleList"/>
       <xs:attribute name="auto-focus" type="xs:boolean"/>
+      <xs:attribute name="secure-text" type="xs:boolean"/>
       <xs:attribute name="underlineColorAndroid" type="hv:color"/>
       <xs:attribute name="clearButtonMode">
         <xs:simpleType>

--- a/src/components/hv-text-field/index.js
+++ b/src/components/hv-text-field/index.js
@@ -75,6 +75,7 @@ export default class HvTextField extends PureComponent<
     const props = {
       ...createProps(element, stylesheets, { ...options, focused }),
       autoFocus: element.getAttribute('auto-focus') === 'true',
+      secureTextEntry: element.getAttribute('secure-text') === 'true',
       ref: options.registerInputHandler,
       multiline: false,
       value: this.state.value,


### PR DESCRIPTION
Implements support for https://reactnative.dev/docs/textinput#securetextentry

Asana ticket: https://app.asana.com/0/923014529014430/1160236008112745/f

<img width="351" alt="Screen Shot 2020-10-30 at 10 07 19 AM" src="https://user-images.githubusercontent.com/1034502/97736217-94e02200-1a98-11eb-8eff-c1d998b18bf7.png">
