### PR TITLE
Remove some local state from <date-field>

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "xmldom-instawork": "0.0.1"
   },
   "peerDependencies": {
-    "react": ">= 16.6.0",
+    "react": ">= 16.8.0",
     "react-native": " >= 0.57.2",
     "react-native-keyboard-aware-scrollview": "^2.0.0"
   },
@@ -73,12 +73,12 @@
     "mkdirp": "0.5.1",
     "prettier": "1.15.3",
     "pretty-quick": "1.8.0",
-    "react": "16.6.0",
-    "react-dom": "16.2.1",
+    "react": "16.8.0",
+    "react-dom": "16.8.0",
     "react-native": "0.52.2",
     "react-native-keyboard-aware-scrollview": "2.0.0",
     "react-navigation": "1.0.0-beta.11",
-    "react-test-renderer": "16.3.1"
+    "react-test-renderer": "16.8.0"
   },
   "jest": {
     "preset": "react-native",

--- a/src/components/hv-date-field/index.js
+++ b/src/components/hv-date-field/index.js
@@ -16,22 +16,114 @@ import type {
   HvComponentProps,
   StyleSheets,
 } from 'hyperview/src/types';
+import type { FieldLabelProps, FieldProps, ModalButtonProps } from './types';
 import {
   Modal,
   Platform,
+  StyleSheet,
   Text,
   TouchableWithoutFeedback,
   View,
 } from 'react-native';
-import React, { PureComponent } from 'react';
+// $FlowFixMe: update Flow to support typings for React Hooks
+import React, { PureComponent, useState } from 'react';
 import { createProps, createStyleProp } from 'hyperview/src/services';
 import { DateFormatContext } from 'hyperview/src';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import type { Node as ReactNode } from 'react';
-import type { State } from './types';
 import type { StyleSheet as StyleSheetType } from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
 import styles from './styles';
+
+/**
+ * Component used to render the Cancel/Done buttons in the picker modal.
+ */
+const ModalButton = (props: ModalButtonProps) => {
+  const [pressed, setPressed] = useState(false);
+
+  return (
+    <TouchableWithoutFeedback
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      onPress={props.onPress}
+    >
+      <View>
+        <Text style={props.getStyle(pressed)}>{props.label}</Text>
+      </View>
+    </TouchableWithoutFeedback>
+  );
+};
+
+/**
+ * This text label of the field. Contains logic to decide how to format the value
+ * or show the placeholder, including applying the right styles.
+ */
+const FieldLabel = (props: FieldLabelProps) => {
+  const labelStyles: Array<StyleSheetType<*>> = [props.style];
+  if (!props.value && props.placeholderTextColor) {
+    labelStyles.push({ color: props.placeholderTextColor });
+  }
+
+  const label: string = props.value
+    ? props.formatter(props.value, props.labelFormat)
+    : props.placeholder || '';
+
+  return <Text style={labelStyles}>{label}</Text>;
+};
+
+/**
+ * The input field component. This is a box with text in it.
+ * Tapping the box focuses the field and brings up the date picker.
+ */
+const Field = (props: FieldProps) => {
+  // Styles selected based on pressed state of the field.
+  const [pressed, setPressed] = useState(false);
+
+  // Create the props (including styles) for the box of the input field.
+  const viewProps = createProps(props.element, props.stylesheets, {
+    ...props.options,
+    pressed,
+    focused: props.focused,
+    styleAttr: 'field-style',
+  });
+
+  const labelStyle: StyleSheetType<*> = StyleSheet.flatten(
+    createStyleProp(props.element, props.stylesheets, {
+      ...props.options,
+      focused: props.focused,
+      pressed,
+      styleAttr: 'field-text-style',
+    }),
+  );
+
+  return (
+    <TouchableWithoutFeedback
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      onPress={props.onPress}
+    >
+      <View {...viewProps}>
+        <DateFormatContext.Consumer>
+          {formatter => (
+            <FieldLabel
+              focused={props.focused}
+              formatter={formatter}
+              labelFormat={props.element.getAttribute('label-format')}
+              placeholder={props.element.getAttribute('placeholder')}
+              placeholderTextColor={props.element.getAttribute(
+                'placeholderTextColor',
+              )}
+              pressed={pressed}
+              style={labelStyle}
+              value={props.value}
+            />
+          )}
+        </DateFormatContext.Consumer>
+        {props.children}
+      </View>
+    </TouchableWithoutFeedback>
+  );
+};
 
 /**
  * A date field renders a form field with ISO date fields (YYYY-MM-DD).
@@ -39,24 +131,11 @@ import styles from './styles';
  * - On iOS, pressing the field brings up a custom bottom sheet with a picker and action buttons.
  * - On Android, pressing the field brings up the system date picker modal.
  */
-export default class HvDateField extends PureComponent<
-  HvComponentProps,
-  State,
-> {
+export default class HvDateField extends PureComponent<HvComponentProps> {
   static namespaceURI = Namespaces.HYPERVIEW;
   static localName = LOCAL_NAME.DATE_FIELD;
   static localNameAliases = [];
   props: HvComponentProps;
-  state: State;
-
-  constructor(props: HvComponentProps) {
-    super(props);
-    this.state = {
-      fieldPressed: false,
-      donePressed: false,
-      cancelPressed: false,
-    };
-  }
 
   /**
    * Given a Date object, returns an ISO date string (YYYY-MM-DD). If the Date
@@ -82,18 +161,6 @@ export default class HvDateField extends PureComponent<
     }
     const [year, month, day] = value.split('-').map(p => parseInt(p, 10));
     return new Date(year, month - 1, day);
-  };
-
-  toggleFieldPress = () => {
-    this.setState(prevState => ({ fieldPressed: !prevState.fieldPressed }));
-  };
-
-  toggleCancelPress = () => {
-    this.setState(prevState => ({ cancelPressed: !prevState.cancelPressed }));
-  };
-
-  toggleSavePress = () => {
-    this.setState(prevState => ({ donePressed: !prevState.donePressed }));
   };
 
   /**
@@ -233,27 +300,17 @@ export default class HvDateField extends PureComponent<
         styleAttr: 'modal-style',
       },
     );
-    const cancelTextStyle: Array<StyleSheetType<*>> = createStyleProp(
-      element,
-      stylesheets,
-      {
-        ...options,
-        pressed: this.state.cancelPressed,
-        styleAttr: 'modal-text-style',
-      },
-    );
-    const doneTextStyle: Array<StyleSheetType<*>> = createStyleProp(
-      element,
-      stylesheets,
-      {
-        ...options,
-        pressed: this.state.donePressed,
-        styleAttr: 'modal-text-style',
-      },
-    );
+
     const cancelLabel: string =
       element.getAttribute('cancel-label') || 'Cancel';
     const doneLabel: string = element.getAttribute('done-label') || 'Done';
+
+    const getTextStyle = (pressed: boolean): Array<StyleSheetType<*>> =>
+      createStyleProp(element, stylesheets, {
+        ...options,
+        pressed,
+        styleAttr: 'modal-text-style',
+      });
 
     const onChange = (evt: Event, date?: Date) => {
       this.setPickerValue(date);
@@ -269,24 +326,16 @@ export default class HvDateField extends PureComponent<
         <View style={styles.modalWrapper}>
           <View style={modalStyle}>
             <View style={styles.modalActions}>
-              <TouchableWithoutFeedback
-                onPressIn={this.toggleCancelPress}
-                onPressOut={this.toggleCancelPress}
+              <ModalButton
+                getStyle={getTextStyle}
                 onPress={this.onModalCancel}
-              >
-                <View>
-                  <Text style={cancelTextStyle}>{cancelLabel}</Text>
-                </View>
-              </TouchableWithoutFeedback>
-              <TouchableWithoutFeedback
-                onPressIn={this.toggleSavePress}
-                onPressOut={this.toggleSavePress}
+                label={cancelLabel}
+              />
+              <ModalButton
+                getStyle={getTextStyle}
                 onPress={() => this.onModalDone(this.getPickerValue())}
-              >
-                <View>
-                  <Text style={doneTextStyle}>{doneLabel}</Text>
-                </View>
-              </TouchableWithoutFeedback>
+                label={doneLabel}
+              />
             </View>
             {this.renderPicker(onChange)}
           </View>
@@ -296,79 +345,33 @@ export default class HvDateField extends PureComponent<
   };
 
   /**
-   * Renders the text part of the field. If the field has a selected value,
-   * use the provided format to display the value. Otherwise, uses the
-   * placeholder value and style.
-   */
-  renderLabel = (formatter: Function): ReactNode => {
-    const element: Element = this.props.element;
-    const value: ?Date = this.getValue();
-    const stylesheets: StyleSheets = this.props.stylesheets;
-    const options: HvComponentOptions = this.props.options;
-    const placeholderTextColor: ?DOMString = element.getAttribute(
-      'placeholderTextColor',
-    );
-    const focused: boolean = this.isFocused();
-    const pressed: boolean = this.state.fieldPressed;
-    const fieldTextStyle = createStyleProp(element, stylesheets, {
-      ...options,
-      focused,
-      pressed,
-      styleAttr: 'field-text-style',
-    });
-    if (!value && placeholderTextColor) {
-      fieldTextStyle.push({ color: placeholderTextColor });
-    }
-
-    const labelFormat = element.getAttribute('label-format');
-    const label: string = value
-      ? formatter(value, labelFormat)
-      : element.getAttribute('placeholder') || '';
-
-    return <Text style={fieldTextStyle}>{label}</Text>;
-  };
-
-  /**
    * Renders the field (view and text label).
    * Pressing the field will focus it and:
    * - on iOS, bring up a bottom sheet with date picker
    * - on Android, show the system date picker
    */
   render = (): ReactNode => {
-    const element: Element = this.props.element;
-    const stylesheets: StyleSheets = this.props.stylesheets;
-    const options: HvComponentOptions = this.props.options;
-    if (element.getAttribute('hide') === 'true') {
+    if (this.props.element.getAttribute('hide') === 'true') {
       return null;
     }
 
     const focused: boolean = this.isFocused();
-    const pressed: boolean = this.state.fieldPressed;
-    const props = createProps(element, stylesheets, {
-      ...options,
-      focused,
-      pressed,
-      styleAttr: 'field-style',
-    });
-
     const picker =
       Platform.OS === 'ios'
         ? this.renderPickerModaliOS()
         : this.renderPickerModalAndroid();
 
     return (
-      <TouchableWithoutFeedback
-        onPressIn={this.toggleFieldPress}
-        onPressOut={this.toggleFieldPress}
+      <Field
+        element={this.props.element}
+        focused={focused}
         onPress={this.onFieldPress}
+        options={this.props.options}
+        stylesheets={this.props.stylesheets}
+        value={this.getValue()}
       >
-        <View {...props}>
-          <DateFormatContext.Consumer>
-            {formatter => this.renderLabel(formatter)}
-          </DateFormatContext.Consumer>
-          {picker}
-        </View>
-      </TouchableWithoutFeedback>
+        {picker}
+      </Field>
     );
   };
 }

--- a/src/components/hv-date-field/types.js
+++ b/src/components/hv-date-field/types.js
@@ -8,8 +8,37 @@
  *
  */
 
-export type State = {|
-  fieldPressed: boolean,
-  donePressed: boolean,
-  cancelPressed: boolean,
+import * as React from 'react';
+import type {
+  Element,
+  HvComponentOptions,
+  StyleSheets,
+} from 'hyperview/src/types';
+import type { StyleSheet as StyleSheetType } from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
+
+export type FieldProps = {|
+  children?: React.Node,
+  element: Element,
+  focused: boolean,
+  onPress: () => void,
+  options: HvComponentOptions,
+  stylesheets: StyleSheets,
+  value: ?Date,
+|};
+
+export type FieldLabelProps = {|
+  focused: boolean,
+  formatter: (value: ?Date, format: ?string) => string,
+  labelFormat: ?string,
+  placeholder: ?string,
+  placeholderTextColor: ?string,
+  pressed: boolean,
+  style: StyleSheetType<*>,
+  value: ?Date,
+|};
+
+export type ModalButtonProps = {|
+  getStyle: (pressed: boolean) => Array<StyleSheetType<*>>,
+  label: string,
+  onPress: () => void,
 |};

--- a/src/components/hv-date-field/types.js
+++ b/src/components/hv-date-field/types.js
@@ -9,9 +9,6 @@
  */
 
 export type State = {|
-  value: ?Date,
-  pickerValue: Date,
-  focused: boolean,
   fieldPressed: boolean,
   donePressed: boolean,
   cancelPressed: boolean,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7189,14 +7189,15 @@ react-devtools-core@3.0.0:
     shell-quote "^1.6.1"
     ws "^2.0.3"
 
-react-dom@16.2.1:
-  version "16.2.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.1.tgz#5cfb32f66267ece7b3850466bf3b219d4911fc1a"
+react-dom@16.8.0:
+  version "16.8.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.0.tgz#18f28d4be3571ed206672a267c66dd083145a9c4"
+  integrity sha512-dBzoAGYZpW9Yggp+CzBPC7q1HmWSeRc93DWrwbskmG1eHJWznZB/p0l/Sm+69leIGUS91AXPB/qB3WcPnKx8Sw==
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    scheduler "^0.13.0"
 
 react-fuzzy@^0.5.2:
   version "0.5.2"
@@ -7230,9 +7231,10 @@ react-inspector@^2.2.2:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
-react-is@^16.3.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.1.tgz#d624c4650d2c65dbd52c72622bbf389435d9776e"
+react-is@^16.8.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -7384,14 +7386,15 @@ react-style-proptype@^3.0.0:
   dependencies:
     prop-types "^15.5.4"
 
-react-test-renderer@16.3.1:
-  version "16.3.1"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.1.tgz#d9257936d8535bd40f57f3d5a84e7b0452fb17f2"
+react-test-renderer@16.8.0:
+  version "16.8.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.8.0.tgz#a7a635ac0622e79f349e4f42663a7f313d648518"
+  integrity sha512-BJzNYsI9rXMRJOpWh3vNRE+m8+PtObDQn+6yYe+gl3t3hWrlfN4XPOD46RUsBN+XT172JW/rRBe2nkeK5vkY1g==
   dependencies:
-    fbjs "^0.8.16"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
-    react-is "^16.3.1"
+    prop-types "^15.6.2"
+    react-is "^16.8.0"
+    scheduler "^0.13.0"
 
 react-timer-mixin@^0.13.2:
   version "0.13.4"
@@ -7424,14 +7427,15 @@ react-treebeard@^2.1.0:
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
 
-react@16.6.0:
-  version "16.6.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.6.0.tgz#b34761cfaf3e30f5508bc732fb4736730b7da246"
+react@16.8.0:
+  version "16.8.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.0.tgz#8533f0e4af818f448a276eae71681d09e8dd970a"
+  integrity sha512-g+nikW2D48kqgWSPwNo0NH9tIGG3DsQFlrtrQ1kj6W77z5ahyIHG0w8kPpz4Sdj6gyLnz0lEd/xsjOoGge2MYQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.10.0"
+    scheduler "^0.13.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -7857,9 +7861,10 @@ sax@~1.1.1:
   version "1.1.6"
   resolved "http://registry.npmjs.org/sax/-/sax-1.1.6.tgz#5d616be8a5e607d54e114afae55b7eaf2fcc3240"
 
-scheduler@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.10.0.tgz#7988de90fe7edccc774ea175a783e69c40c521e1"
+scheduler@^0.13.0:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Asana: https://app.asana.com/0/923014529014430/1144293982403313/f

As part of the cleanup to remove local state from input components (See #199 and #200), I'm removing local state from `<date-field>`. We no longer keep `focused`, `value`, and `pickerValue` in the state, instead those values are read from the DOM element. When we need to update the values, we call `onUpdate` with a cloned version of the element, which will re-render the component.

Note: There is still some local state to represent whether certain elements are currently pressed. I'll move those to functional components with React hooks in a subsequent PR.

Testing:
- [x] iOS
- [x] Android