### PR TITLE
Fix: Picker field changes immediately

### DIFF
--- a/src/components/hv-picker-field/index.js
+++ b/src/components/hv-picker-field/index.js
@@ -157,7 +157,6 @@ export default class HvPickerField extends PureComponent<
     const props = {
       onValueChange: value => {
         this.setState({ pickerValue: value });
-        element.setAttribute('value', value || '');
       },
       selectedValue: this.state.pickerValue,
       style,


### PR DESCRIPTION
[Asana](https://app.asana.com/0/923014529014430/1189353069436699/f)
 [Video ios](https://drive.google.com/file/d/1TY_FnjlGPmcp2ubiBzqKr963S81rgtus/view?usp=sharing)
[Video android](https://drive.google.com/file/d/1IQ-0xBK7Xvr8Dyb5vuklchutH6dXUROk/view?usp=sharing)

The picker field from updating its state immediately. This change will stop that from happening

<img width="250" alt="Screenshot 2020-12-08 at 10 00 36 PM" src="https://user-images.githubusercontent.com/26839409/101512509-159c1300-39a1-11eb-9335-2afa35ccc2e2.png">
