### PR TITLE
Fix: Apply placeholder text color on Android

### DIFF
--- a/src/components/hv-picker-field/index.js
+++ b/src/components/hv-picker-field/index.js
@@ -279,6 +279,15 @@ export default class HvPickerField extends PureComponent<
       ...options,
       styleAttr: 'field-text-style',
     });
+
+    const value: ?DOMString = element.getAttribute('value');
+    const placeholderTextColor: ?DOMString = element.getAttribute(
+      'placeholderTextColor',
+    );
+    if (!value && placeholderTextColor) {
+      textStyle.push({ color: placeholderTextColor });
+    }
+
     const viewProps = {
       style: fieldStyle,
       ...createTestProps(element),


### PR DESCRIPTION
[Asana](https://app.asana.com/0/923014529014430/1199397741510365/f)

## Summary
Apply placeholder text color on Android picker

## Screenshot
<img width="589" alt="Screenshot 2021-01-06 at 3 56 46 PM" src="https://user-images.githubusercontent.com/2883006/103762943-22af2f00-503f-11eb-93c3-b5e86aeab60b.png">
