### PR TITLE
Fix: `<section>` schema

### DIFF
--- a/docs/reference_items.md
+++ b/docs/reference_items.md
@@ -28,7 +28,7 @@ The `<items>` element represents a group of items in a list. This group does not
 
 An `<items>` element will only render `<item>` children elements. Other elements will be ignored during rendering.
 
-An `<items>` element only appears as a direct child of a `<list>`.
+An `<items>` element only appears as a direct child of a `<list>` and `<section>`.
 
 ## Attributes
 

--- a/docs/reference_list.md
+++ b/docs/reference_list.md
@@ -24,7 +24,7 @@ The `<list>` element represents a list of items. Unlike child elements of a `<vi
 
 ## Structure
 
-A `<list>` element will only render `<item>` children elements. Other elements will be ignored during rendering.
+A `<list>` element will only render `<item>` and `<items>` children elements. Other elements will be ignored during rendering.
 
 ## Attributes
 

--- a/docs/reference_section.md
+++ b/docs/reference_section.md
@@ -32,7 +32,7 @@ The `<section>` element represents a group of items in a `<section-list>`. A sec
 
 ## Structure
 
-A `<section>` element will only render `<section-title>` and `<item>` children elements. Other elements will be ignored during rendering.
+A `<section>` element will only render `<section-title>`, `<item>` and `<items>` children elements. Other elements will be ignored during rendering.
 
 A `<section>` element can only appear as a direct child of a `<section-list>` element. It will not render on the screen in other contexts.
 

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -813,7 +813,11 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element minOccurs="1" maxOccurs="1" ref="hv:section-title"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:item"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="hv:item"/>
+          <xs:element ref="hv:items"/>
+          <xs:element ref="hv:behavior"/>
+        </xs:choice>
       </xs:sequence>
       <xs:attribute name="id" type="xs:NCName"/>
       <xs:attribute name="hide" type="xs:boolean"/>


### PR DESCRIPTION
Allow `<items/>` and `<behavior/>` tags to be direct childs of `<section>` tag (match `<list>` tag schema)