### PR TITLE
translate id to different props depending on Platform.OS

### DIFF
--- a/src/services/index.js
+++ b/src/services/index.js
@@ -27,6 +27,7 @@ import { FORM_NAMES, LOCAL_NAME, NODE_TYPE } from 'hyperview/src/types';
 import HyperRef from 'hyperview/src/core/hyper-ref';
 import React from 'react';
 import type { StyleSheet } from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
+import { Platform } from 'react-native';
 
 /**
  * This file is currently a dumping place for every functions used accross
@@ -118,10 +119,10 @@ export const createTestProps = (
   if (!id) {
     return testProps;
   }
-  return {
-    testID: id,
-    accessibilityLabel: id,
-  };
+  if (Platform.OS === 'ios') {
+    return { testID: id };
+  }
+  return { accessibilityLabel: id };
 };
 
 export const createProps = (


### PR DESCRIPTION
since there has conflict between properties testID and accessibilityLabel, they can not be set together.
need to specify a dedicated one depending on current rendering platform