### PR TITLE
Add defensive check before registerInputHandler in view component.

### DIFF
--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -97,7 +97,9 @@ export default class HvView extends PureComponent<HvComponentProps> {
         props.scrollEventThrottle = 16;
         props.getTextInputRefs = () => inputRefs;
         const registerInputHandler = ref => {
-          inputRefs.push(ref);
+          if (ref !== null) {
+            inputRefs.push(ref);
+          }
         };
         viewOptions = { ...viewOptions, registerInputHandler };
       }


### PR DESCRIPTION
- Requirement:
   add defensive check before registerInputHandler in view component.

- Issue:
   Since hyperview uses KeyboardAwareScrollView in 'react-native-keyboard-aware-scrollview', if inputRefs contain null, it would cause some random problems in some certain scenarioes as below:

1. ['Add defensive checks before calling isFocused #44',](https://github.com/wix/react-native-keyboard-aware-scrollview/pull/44#issuecomment-789619704)
2. #232 

- For references:
![image](https://user-images.githubusercontent.com/12246394/109928380-5b4a4c80-7d00-11eb-8f5b-300452afde16.png)
[Caveats with callback refs](https://reactjs.org/docs/refs-and-the-dom.html#caveats-with-callback-refs)
