### PR TITLE
Fix: Filter out empty sections to avoid erratic section list rendering

### DIFF
--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -109,7 +109,7 @@ export default class HvSectionList extends PureComponent<
           this.props.onUpdate,
           this.props.options,
         ),
-      sections,
+      sections: sections.filter(s => s.data.length > 0),
       style,
     };
 


### PR DESCRIPTION
[Asana](https://app.asana.com/0/0/1200065980819932/f)
[Related issue](https://github.com/Instawork/mobile/pull/2296)

Sometimes, when certain sections are empty, the `SectionList` rendering the gigs behaves erratically and can be incomplete. 
When you pull to refresh, it does end up rendering correctly. But the first time after filtering on gigs, the rendering is incomplete.

Filtered empty sections to remedy this. 

## Demo

1. I tried with gigs on April 1, 6, 7, and 8. Then I set the date filters to filter out gigs before April 2ns which means the section for April 1st is empty. 

| Without removing empty sections  | After removing empty sections |
| ------------- | ------------- |
| https://user-images.githubusercontent.com/2883006/112315391-1b0f3600-8cd0-11eb-87d9-fec66c672221.mp4 | https://user-images.githubusercontent.com/2883006/112315418-23677100-8cd0-11eb-9af9-40f33d077d3a.mp4 |

2. Clearing the filters (with the fix) remains unaffected 
https://user-images.githubusercontent.com/2883006/112315757-6f1a1a80-8cd0-11eb-9fdd-ac1d813adcff.mp4