### PR TITLE
Add missing flow type annotations

### DIFF
--- a/src/components/hv-date-field/types.js
+++ b/src/components/hv-date-field/types.js
@@ -22,7 +22,7 @@ export type FieldProps = {|
   focused: boolean,
   onPress: () => void,
   options: HvComponentOptions,
-  stylesheets: StyleSheets,
+  stylesheets: ?StyleSheets,
   value: ?Date,
 |};
 

--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -63,7 +63,7 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
   render() {
     const styleAttr = this.props.element.getAttribute('style');
     const style = styleAttr
-      ? styleAttr.split(' ').map(s => this.props.stylesheets.regular[s])
+      ? styleAttr.split(' ').map(s => (this.props.stylesheets || {}).regular[s])
       : null;
 
     const horizontal =

--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -62,7 +62,7 @@ export default class HvSectionList extends PureComponent<
   render() {
     const styleAttr = this.props.element.getAttribute('style');
     const style = styleAttr
-      ? styleAttr.split(' ').map(s => this.props.stylesheets.regular[s])
+      ? styleAttr.split(' ').map(s => (this.props.stylesheets || {}).regular[s])
       : null;
 
     const sectionElements = this.props.element.getElementsByTagNameNS(

--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -44,7 +44,8 @@ export default class HvSectionList extends PureComponent<
       this.props.element.getAttribute('show-during-load') || null;
     const hideIndicatorIds =
       this.props.element.getAttribute('hide-during-load') || null;
-    const delay = this.props.element.getAttribute('delay');
+    const delayString = this.props.element.getAttribute('delay');
+    const delay = delayString ? parseInt(delayString, 10) : null;
     const once = this.props.element.getAttribute('once') || null;
 
     this.props.onUpdate(path, action, this.props.element, {

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -119,7 +119,8 @@ export default class HyperRef extends PureComponent<Props, State> {
         const showIndicatorId = behaviorElement.getAttribute(
           ATTRIBUTES.SHOW_DURING_LOAD,
         );
-        const delay = behaviorElement.getAttribute(ATTRIBUTES.DELAY);
+        const delayString = behaviorElement.getAttribute(ATTRIBUTES.DELAY);
+        const delay = delayString ? parseInt(delayString, 10) : null;
         onUpdate(href, action, element, { delay, showIndicatorId });
       };
     }
@@ -134,7 +135,8 @@ export default class HyperRef extends PureComponent<Props, State> {
         const hideIndicatorIds = behaviorElement.getAttribute(
           ATTRIBUTES.HIDE_DURING_LOAD,
         );
-        const delay = behaviorElement.getAttribute(ATTRIBUTES.DELAY);
+        const delayString = behaviorElement.getAttribute(ATTRIBUTES.DELAY);
+        const delay = delayString ? parseInt(delayString, 10) : null;
         const once = behaviorElement.getAttribute(ATTRIBUTES.ONCE);
         onUpdate(href, action, element, {
           delay,

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -149,8 +149,7 @@ export default class HyperRef extends PureComponent<Props, State> {
       };
     }
     // Custom behavior
-    return () =>
-      onUpdate(null, action, element, { behaviorElement, custom: true });
+    return () => onUpdate(null, action, element, { behaviorElement });
   };
 
   triggerLoadBehaviors = () => {

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -116,12 +116,12 @@ export default class HyperRef extends PureComponent<Props, State> {
     if (Object.values(NAV_ACTIONS).indexOf(action) >= 0) {
       return () => {
         const href = behaviorElement.getAttribute(ATTRIBUTES.HREF);
-        const showIndicatorId = behaviorElement.getAttribute(
+        const showIndicatorIds = behaviorElement.getAttribute(
           ATTRIBUTES.SHOW_DURING_LOAD,
         );
         const delayString = behaviorElement.getAttribute(ATTRIBUTES.DELAY);
         const delay = delayString ? parseInt(delayString, 10) : null;
-        onUpdate(href, action, element, { delay, showIndicatorId });
+        onUpdate(href, action, element, { delay, showIndicatorIds });
       };
     }
     if (Object.values(UPDATE_ACTIONS).indexOf(action) >= 0) {

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -193,7 +193,7 @@ export default class HyperRef extends PureComponent<Props, State> {
 
     const styleAttr = this.props.element.getAttribute(ATTRIBUTES.HREF_STYLE);
     const hrefStyle = styleAttr
-      ? styleAttr.split(' ').map(s => this.props.stylesheets.regular[s])
+      ? styleAttr.split(' ').map(s => (this.props.stylesheets || {}).regular[s])
       : null;
 
     // $FlowFixMe

--- a/src/core/hyper-ref/types.js
+++ b/src/core/hyper-ref/types.js
@@ -21,7 +21,7 @@ export type Props = {|
   element: Element,
   onUpdate: HvComponentOnUpdate,
   options: HvComponentOptions,
-  stylesheets: StyleSheets,
+  stylesheets: ?StyleSheets,
 |};
 
 export type State = {|

--- a/src/index.js
+++ b/src/index.js
@@ -111,12 +111,15 @@ export default class HyperScreen extends React.Component<Props, State> {
     const preloadScreen = params.preloadScreen
       ? this.navigation.getPreloadScreen(params.preloadScreen)
       : null;
+    // $FlowFixMe: we currently have a type mismatch, where state.doc is a Document type, but preload screens are Element types
     const preloadStyles: ?StyleSheets = preloadScreen ? Stylesheets.createStylesheets(preloadScreen) : {};
 
     this.needsLoad = true;
     if (preloadScreen) {
+      // $FlowFixMe: we currently have a type mismatch, where state.doc is a Document type, but preload screens are Element types
+      const doc: Document = preloadScreen;
       this.setState({
-        doc: preloadScreen,
+        doc,
         error: null,
         styles: preloadStyles,
         url,
@@ -158,9 +161,11 @@ export default class HyperScreen extends React.Component<Props, State> {
         ? this.navigation.getPreloadScreen(newPreloadScreen)
         : null;
 
-      const doc = preloadScreen || this.doc;
-      // eslint-disable-next-line react/no-access-state-in-setstate
-      const styles = preloadScreen ? Stylesheets.createStylesheets(preloadScreen) : this.state.styles;
+      // $FlowFixMe: we currently have a type mismatch, where state.doc is a Document type, but preload screens are Element types
+      const doc: Document = preloadScreen || this.doc;
+
+      // $FlowFixMe: we currently have a type mismatch, where state.doc is a Document type, but preload screens are Element types
+      const styles = preloadScreen ? Stylesheets.createStylesheets(preloadScreen) : this.state.styles; // eslint-disable-line react/no-access-state-in-setstate
 
       this.setState({ doc, styles, url: newUrl });
     }

--- a/src/index.js
+++ b/src/index.js
@@ -39,10 +39,6 @@ export default class HyperScreen extends React.Component {
   constructor(props) {
     super(props);
 
-    this.onUpdate = this.onUpdate.bind(this);
-    this.reload = this.reload.bind(this);
-
-    this.updateActions = ['replace', 'replace-inner', 'append', 'prepend'];
     this.parser = new Dom.Parser(
       this.props.fetch,
       this.props.onParseBefore,

--- a/src/index.js
+++ b/src/index.js
@@ -79,13 +79,13 @@ export default class HyperScreen extends React.Component<Props, State> {
     // `this.doc`. When rendering, we should use `this.state.doc`.
     this.doc = null;
     this.oldSetState = this.setState;
-    const { oldSetState } = this;
     // $FlowFixMe: this.setState is not writeable
     this.setState = (...args) => {
       if (args[0].doc !== undefined) {
         this.doc = args[0].doc;
       }
-      oldSetState(...args);
+      // $FlowFixMe: this.oldSetState is defined
+      this.oldSetState(...args);
     }
     // </HACK>
 
@@ -254,16 +254,17 @@ export default class HyperScreen extends React.Component<Props, State> {
         <Loading />
       );
     }
-    const [body] = this.state.doc.getElementsByTagNameNS(Namespaces.HYPERVIEW, 'body');
-    const screenElement = Render.renderElement(
-      body,
-      this.state.styles,
-      this.onUpdate,
-      {
-        componentRegistry: this.componentRegistry,
-        screenUrl: this.state.url,
-      },
-    );
+    const body = this.state.doc.getElementsByTagNameNS(Namespaces.HYPERVIEW, 'body').item(0);
+    const screenElement = body
+      ? Render.renderElement(
+          body,
+          this.state.styles,
+          this.onUpdate,
+          {
+            componentRegistry: this.componentRegistry,
+            screenUrl: this.state.url,
+          },
+      ): null;
 
     return (
       <Contexts.DateFormatContext.Provider value={this.props.formatDate}>

--- a/src/services/dom/parser.js
+++ b/src/services/dom/parser.js
@@ -10,12 +10,12 @@
 
 import * as Errors from './errors';
 import * as UrlService from 'hyperview/src/services/url';
-import type { BeforeAfterParseHandler, Fetch, HttpMethod } from './types';
-import { CONTENT_TYPE, HTTP_HEADERS, HTTP_METHODS } from './types';
+import type { BeforeAfterParseHandler, Fetch } from './types';
+import { CONTENT_TYPE, HTTP_HEADERS } from './types';
+import type { Document, HttpVerb } from 'hyperview/src/types';
+import { HTTP_VERBS, LOCAL_NAME } from 'hyperview/src/types';
 import { DOMParser } from 'xmldom-instawork';
 import { Dimensions } from 'react-native';
-import type { Document } from 'hyperview/src/types';
-import { LOCAL_NAME } from 'hyperview/src/types';
 import { getFirstTag } from './helpers';
 import { version } from 'hyperview/package.json';
 
@@ -61,20 +61,20 @@ export class Parser {
   load = async (
     baseUrl: string,
     data: ?FormData,
-    method: ?HttpMethod = HTTP_METHODS.GET,
+    verb: ?HttpVerb = HTTP_VERBS.GET,
   ): Promise<Document> => {
     // For GET requests, we can't include a body so we encode the form data as a query
     // string in the URL.
     const url =
-      method === HTTP_METHODS.GET && data
+      verb === HTTP_VERBS.GET && data
         ? UrlService.addFormDataToUrl(baseUrl, data)
         : baseUrl;
 
     const options = {
       // For non-GET requests, include the formdata as the body of the request.
-      body: method === HTTP_METHODS.GET ? undefined : data,
+      body: verb === HTTP_VERBS.GET ? undefined : data,
       headers,
-      method,
+      method: verb,
     };
 
     const response: Response = await this.fetch(url, options);
@@ -121,9 +121,9 @@ export class Parser {
   loadElement = async (
     baseUrl: string,
     data: ?FormData,
-    method: ?HttpMethod = HTTP_METHODS.GET,
+    verb: ?HttpVerb = HTTP_VERBS.GET,
   ): Promise<Document> => {
-    const doc = await this.load(baseUrl, data, method);
+    const doc = await this.load(baseUrl, data, verb);
     const docElement = getFirstTag(doc, LOCAL_NAME.DOC);
     if (docElement) {
       throw new Errors.XMLRestrictedElementFound(LOCAL_NAME.DOC, baseUrl);

--- a/src/services/dom/types.js
+++ b/src/services/dom/types.js
@@ -15,13 +15,6 @@ export const HTTP_HEADERS = {
   X_HYPERVIEW_VERSION: 'X-Hyperview-Version',
 };
 
-export const HTTP_METHODS = {
-  GET: 'get',
-  POST: 'post',
-};
-
-export type HttpMethod = $Values<typeof HTTP_METHODS>;
-
 export const CONTENT_TYPE = {
   APPLICATION_XML: 'application/xml',
   TEXT_HTML: 'text/html',

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -36,7 +36,7 @@ import React from 'react';
 
 export const createStyleProp = (
   element: Element,
-  stylesheets: StyleSheets,
+  stylesheets: ?StyleSheets,
   options: HvComponentOptions,
 ): Array<StyleSheet> => {
   const styleAttr: string = options.styleAttr || 'style';
@@ -47,12 +47,12 @@ export const createStyleProp = (
   const styleValue: string = element.getAttribute(styleAttr) || '';
   const styleIds: Array<string> = Xml.splitAttributeList(styleValue);
   let styleRules: Array<StyleSheet> = styleIds.map(
-    styleId => stylesheets.regular[styleId],
+    styleId => (stylesheets || {}).regular[styleId],
   );
 
   if (options.pressed) {
     let pressedRules = styleIds
-      .map(styleId => stylesheets.pressed[styleId])
+      .map(styleId => (stylesheets || {}).pressed[styleId])
       .filter(Boolean);
     if (pressedRules.length === 0) {
       pressedRules = [{ opacity: DEFAULT_PRESS_OPACITY }];
@@ -62,21 +62,21 @@ export const createStyleProp = (
 
   if (options.focused) {
     const focusedRules = styleIds
-      .map(s => stylesheets.focused[s])
+      .map(s => (stylesheets || {}).focused[s])
       .filter(Boolean);
     styleRules = styleRules.concat(focusedRules);
   }
 
   if (options.selected) {
     const selectedRules = styleIds
-      .map(s => stylesheets.selected[s])
+      .map(s => (stylesheets || {}).selected[s])
       .filter(Boolean);
     styleRules = styleRules.concat(selectedRules);
   }
 
   if (options.pressedSelected) {
     const pressedSelectedRules = styleIds
-      .map(s => stylesheets.pressedSelected[s])
+      .map(s => (stylesheets || {}).pressedSelected[s])
       .filter(Boolean);
     styleRules = styleRules.concat(pressedSelectedRules);
   }
@@ -104,7 +104,7 @@ export const createTestProps = (
 
 export const createProps = (
   element: Element,
-  stylesheets: StyleSheets,
+  stylesheets: ?StyleSheets,
   options: HvComponentOptions,
 ) => {
   const numericRules = ['numberOfLines'];
@@ -140,7 +140,7 @@ export const later = (delayMs: number): Promise<void> =>
 export const addHref = (
   component: any,
   element: Element,
-  stylesheets: StyleSheets,
+  stylesheets: ?StyleSheets,
   onUpdate: HvComponentOnUpdate,
   options: HvComponentOptions,
 ) => {

--- a/src/services/navigation/index.js
+++ b/src/services/navigation/index.js
@@ -25,7 +25,7 @@ export default class Navigation {
 
   navigation: NavigationProps;
 
-  preloadScreens: { [number]: Element } = {};
+  preloadScreens: { [number]: Document } = {};
 
   routeKeys: { [string]: string } = {};
 
@@ -38,14 +38,14 @@ export default class Navigation {
     this.url = url;
   };
 
-  setDocument = (document: Document) => {
+  setDocument = (document: ?Document) => {
     this.document = document;
   };
 
-  getPreloadScreen = (id: number): ?Element => this.preloadScreens[id];
+  getPreloadScreen = (id: number): ?Document => this.preloadScreens[id];
 
-  setPreloadScreen = (id: number, element: Element): void => {
-    this.preloadScreens[id] = element;
+  setPreloadScreen = (id: number, document: Document): void => {
+    this.preloadScreens[id] = document;
   };
 
   removePreloadScreen = (id: number): void => {

--- a/src/services/navigation/index.js
+++ b/src/services/navigation/index.js
@@ -25,7 +25,7 @@ export default class Navigation {
 
   navigation: NavigationProps;
 
-  preloadScreens: { [number]: Document } = {};
+  preloadScreens: { [number]: Element } = {};
 
   routeKeys: { [string]: string } = {};
 
@@ -42,10 +42,10 @@ export default class Navigation {
     this.document = document;
   };
 
-  getPreloadScreen = (id: number): ?Document => this.preloadScreens[id];
+  getPreloadScreen = (id: number): ?Element => this.preloadScreens[id];
 
-  setPreloadScreen = (id: number, document: Document): void => {
-    this.preloadScreens[id] = document;
+  setPreloadScreen = (id: number, element: Element): void => {
+    this.preloadScreens[id] = element;
   };
 
   removePreloadScreen = (id: number): void => {
@@ -77,7 +77,7 @@ export default class Navigation {
         Namespaces.HYPERVIEW,
         'screen',
       );
-      const loadingScreen: ?Document = Array.from(screens).find(
+      const loadingScreen: ?Element = Array.from(screens).find(
         s => s && s.getAttribute('id') === showIndicatorIds,
       );
       if (loadingScreen) {

--- a/src/services/navigation/index.js
+++ b/src/services/navigation/index.js
@@ -64,7 +64,7 @@ export default class Navigation {
     element: Element,
     opts: BehaviorOptions,
   ): void => {
-    const { showIndicatorId, delay } = opts;
+    const { showIndicatorIds, delay } = opts;
     const formData: ?FormData = getFormData(element);
 
     // Serialize form data as query params, if present.
@@ -72,13 +72,13 @@ export default class Navigation {
     const url = UrlService.addFormDataToUrl(baseUrl, formData);
 
     let preloadScreen = null;
-    if (showIndicatorId && this.document) {
+    if (showIndicatorIds && this.document) {
       const screens: NodeList<Element> = this.document.getElementsByTagNameNS(
         Namespaces.HYPERVIEW,
         'screen',
       );
-      const loadingScreen: ?Element = Array.from(screens).find(
-        s => s && s.getAttribute('id') === showIndicatorId,
+      const loadingScreen: ?Document = Array.from(screens).find(
+        s => s && s.getAttribute('id') === showIndicatorIds,
       );
       if (loadingScreen) {
         preloadScreen = Date.now(); // Not trully unique but sufficient for our use-case

--- a/src/services/render/index.js
+++ b/src/services/render/index.js
@@ -20,7 +20,7 @@ import React from 'react';
 
 export const renderElement = (
   element: Element,
-  stylesheets: StyleSheets,
+  stylesheets: ?StyleSheets,
   onUpdate: HvComponentOnUpdate,
   options: HvComponentOptions,
 ) => {
@@ -99,7 +99,7 @@ export const renderElement = (
 
 export const renderChildren = (
   element: Element,
-  stylesheets: StyleSheets,
+  stylesheets: ?StyleSheets,
   onUpdate: HvComponentOnUpdate,
   options: HvComponentOptions,
 ) => {

--- a/src/types.js
+++ b/src/types.js
@@ -301,7 +301,7 @@ export type HvComponentProps = {|
   element: Element,
   onUpdate: HvComponentOnUpdate,
   options: HvComponentOptions,
-  stylesheets: StyleSheets,
+  stylesheets: ?StyleSheets,
 |};
 
 export type HvComponentStatics = {

--- a/src/types.js
+++ b/src/types.js
@@ -86,7 +86,6 @@ export type Node = {
   +nodeType: NodeType,
   nodeValue: ?string,
   +ownerDocument: ?Document,
-  +parentNode: ?Node,
   +previousSibling: ?Node,
   appendChild: (newChild: Node) => Node,
   hasAttributes: () => boolean,
@@ -162,6 +161,7 @@ export type Document = Node & {
 };
 
 export type Element = Node & {
+  +parentNode: ?Element,
   cloneNode: (deep: boolean) => Element,
   getAttribute: (name: DOMString) => ?DOMString,
   getAttributeNode: (name: DOMString) => ?Attribute,
@@ -278,6 +278,7 @@ export type HvComponentOptions = {
   delay?: ?number,
   focused?: ?boolean,
   hideIndicatorIds?: ?DOMString,
+  newElement?: ?Element,
   once?: ?DOMString,
   onEnd?: ?() => void,
   onSelect?: ?(value: ?DOMString) => void,
@@ -296,7 +297,7 @@ export type HvComponentOptions = {
 
 export type HvComponentOnUpdate = (
   path: ?DOMString,
-  action: ?DOMString,
+  action: Action,
   element: Element,
   options: HvComponentOptions,
 ) => void;
@@ -377,6 +378,8 @@ export const ACTIONS = {
   SWAP: 'swap',
 };
 
+export type Action = $Values<typeof ACTIONS>;
+
 export const NAV_ACTIONS = {
   BACK: ACTIONS.BACK,
   CLOSE: ACTIONS.CLOSE,
@@ -397,12 +400,12 @@ export const UPDATE_ACTIONS = {
 
 export type UpdateAction = $Values<typeof UPDATE_ACTIONS>;
 
-export type BehaviorOptions = {|
-  newElement: Element,
-  behaviorElement: Element,
+export type BehaviorOptions = {
+  newElement?: ?Element,
+  behaviorElement?: ?Element,
   showIndicatorIds?: ?DOMString,
   delay?: ?number,
-|};
+};
 
 export type NavigationRouteParams = {|
   delay: ?number,

--- a/src/types.js
+++ b/src/types.js
@@ -268,7 +268,7 @@ export type ComponentRegistry = {
 export type HvComponentOptions = {
   behaviorElement?: ?Element,
   componentRegistry?: ComponentRegistry,
-  delay?: ?DOMString,
+  delay?: ?number,
   focused?: ?boolean,
   hideIndicatorIds?: ?DOMString,
   once?: ?DOMString,
@@ -393,7 +393,7 @@ export type BehaviorOptions = {|
   newElement: Element,
   behaviorElement: Element,
   showIndicatorId?: string,
-  delay?: number,
+  delay?: ?number,
 |};
 
 export type NavigationRouteParams = {|

--- a/src/types.js
+++ b/src/types.js
@@ -392,7 +392,7 @@ export type UpdateAction = $Values<typeof UPDATE_ACTIONS>;
 export type BehaviorOptions = {|
   newElement: Element,
   behaviorElement: Element,
-  showIndicatorId?: string,
+  showIndicatorIds?: ?DOMString,
   delay?: ?number,
 |};
 

--- a/src/types.js
+++ b/src/types.js
@@ -419,3 +419,44 @@ export type NavigationProps = {|
 |};
 
 export const ON_EVENT_DISPATCH = 'hyperview:on-event';
+
+// See all options available at
+// https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch
+export type FetchInitOptions = {
+  headers: { [string]: any },
+};
+
+export type Fetch = (input: any, init: FetchInitOptions) => Promise<Response>;
+
+// eslint-disable-next-line instawork/exact-object-types
+export type NavigationState = {
+  key: string,
+  params: { [string]: any },
+};
+
+export type Navigation = {
+  state: NavigationState,
+};
+
+export type Props = {|
+  back: (params: ?NavigationRouteParams) => void,
+  behaviors: HvBehavior[],
+  closeModal: (routeParams?: ?NavigationRouteParams) => void,
+  components: HvComponent[],
+  entrypointUrl: string,
+  fetch: Fetch,
+  formatDate: (date: ?Date, format: ?string) => string,
+  navigate: (routeParams: ?NavigationRouteParams) => void,
+  navigation: Navigation,
+  onParseAfter?: (url: string) => void,
+  onParseBefore?: (url: string) => void,
+  openModal: (params: ?NavigationRouteParams) => void,
+  push: (routeParams: ?NavigationRouteParams) => void,
+|};
+
+export type State = {|
+  doc: ?Document,
+  error: ?Error,
+  styles: ?StyleSheets,
+  url: string,
+|};

--- a/src/types.js
+++ b/src/types.js
@@ -265,6 +265,13 @@ export type ComponentRegistry = {
   },
 };
 
+export const HTTP_VERBS = {
+  GET: 'get',
+  POST: 'post',
+};
+
+export type HttpVerb = $Values<typeof HTTP_VERBS>;
+
 export type HvComponentOptions = {
   behaviorElement?: ?Element,
   componentRegistry?: ComponentRegistry,
@@ -284,6 +291,7 @@ export type HvComponentOptions = {
   showIndicatorIds?: ?DOMString,
   styleAttr?: ?DOMString,
   targetId?: ?DOMString,
+  verb?: ?HttpVerb,
 };
 
 export type HvComponentOnUpdate = (


### PR DESCRIPTION
With this change, all JS files in the project have now flow type annotations.
PR was broken down into digestible commits, it's recommended to review them individually:

- Reading stylesheet content on potentially undefined objects d1b80de
- Uniform type `number` for `delay` option a4e3d3c
- Uniform option `showIndicatorIds` 4a442fb
- Common HTTP verb/method definition bacdae8
- Type annotation fixes in navigation service 6e5a069
- Remove unused code 4a5a7d8 / 0d14ad0
- Add props/state types for Hyperview component 313b7fd
- Add missing annotations to src/index.js a9449e1
- Fix code to comply to types 3e37772

TODO:
- [x] QA using demo app