### PR TITLE
fix: refine flow when action=navigate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -173,7 +173,6 @@ export default class HyperScreen extends React.Component {
       this.needsLoad = false;
     }
   }
-  
   /**
    * Performs a full load of the screen.
    */

--- a/src/index.js
+++ b/src/index.js
@@ -173,6 +173,7 @@ export default class HyperScreen extends React.Component {
       this.needsLoad = false;
     }
   }
+
   /**
    * Performs a full load of the screen.
    */

--- a/src/index.js
+++ b/src/index.js
@@ -161,6 +161,7 @@ export default class HyperScreen extends React.Component {
     if (preloadScreen && this.navigation.getPreloadScreen(preloadScreen)) {
       this.navigation.remove(preloadScreen);
     }
+    this.navigation.removeRouteKey(this.state.url)
   }
 
   /**
@@ -172,7 +173,7 @@ export default class HyperScreen extends React.Component {
       this.needsLoad = false;
     }
   }
-
+  
   /**
    * Performs a full load of the screen.
    */

--- a/src/services/navigation/index.js
+++ b/src/services/navigation/index.js
@@ -60,8 +60,8 @@ export default class Navigation {
 
   removeRouteKey = (href: string): void => {
     delete routeKeys[getHrefKey(href)];
-  } 
-  
+  };
+
   navigate = (
     href: string,
     action: NavAction,
@@ -91,13 +91,13 @@ export default class Navigation {
     }
 
     const routeParams = { delay, preloadScreen, url };
-    
+
     switch (action) {
       case NAV_ACTIONS.PUSH:
         this.navigation.push(routeParams);
         break;
       case NAV_ACTIONS.NAVIGATE: {
-        const key = this.getRouteKey(url)
+        const key = this.getRouteKey(url);
         if (key) {
           this.navigation.navigate(routeParams, this.getRouteKey(url));
         } else {

--- a/src/services/navigation/index.js
+++ b/src/services/navigation/index.js
@@ -18,6 +18,8 @@ const QUERY_SEPARATOR = '?';
 
 const getHrefKey = (href: string): string => href.split(QUERY_SEPARATOR)[0];
 
+const routeKeys: { [string]: string } = {};
+
 export default class Navigation {
   url: string;
 
@@ -26,8 +28,6 @@ export default class Navigation {
   navigation: NavigationProps;
 
   preloadScreens: { [number]: Element } = {};
-
-  routeKeys: { [string]: string } = {};
 
   constructor(url: string, navigation: NavigationProps) {
     this.url = url;
@@ -52,12 +52,16 @@ export default class Navigation {
     delete this.preloadScreens[id];
   };
 
-  getRouteKey = (href: string): ?string => this.routeKeys[getHrefKey(href)];
+  getRouteKey = (href: string): ?string => routeKeys[getHrefKey(href)];
 
   setRouteKey = (href: string, key: string): void => {
-    this.routeKeys[getHrefKey(href)] = key;
+    routeKeys[getHrefKey(href)] = key;
   };
 
+  removeRouteKey = (href: string): void => {
+    delete routeKeys[getHrefKey(href)];
+  } 
+  
   navigate = (
     href: string,
     action: NavAction,
@@ -87,13 +91,18 @@ export default class Navigation {
     }
 
     const routeParams = { delay, preloadScreen, url };
-
+    
     switch (action) {
       case NAV_ACTIONS.PUSH:
         this.navigation.push(routeParams);
         break;
       case NAV_ACTIONS.NAVIGATE: {
-        this.navigation.navigate(routeParams, this.getRouteKey(url));
+        const key = this.getRouteKey(url)
+        if (key) {
+          this.navigation.navigate(routeParams, this.getRouteKey(url));
+        } else {
+          this.navigation.push(routeParams);
+        }
         break;
       }
       case NAV_ACTIONS.NEW:


### PR DESCRIPTION
**Please note the only difference with #258 is that, #258 add some demo to verify the revises.**
please see which one to merge according to needs. and close the other one.

there are 2 revises in this PR:
1. Revise the variable `routeKeys` to global, or else it will be a local variable in every instance of Class HyperScreen.  
    The issue is when run `this.navigation.navigate()` to an intermediate page, it will always navigate back to the first page(component) in the navigation stack (in demo, it will be the examples/index.xml), and replace the first page with its own content.

2. Revise in the `navigation/index.js` to fix below issue: 
  When navigate to a new page (not in navigation stack yet), it will alse navigate back to the first page(component) in the navigation stack (in demo, it will be the examples/index.xml), and replace the first page with its own content.



