### PR TITLE
Support custom error screen

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -225,13 +225,12 @@ export default class HyperScreen extends React.Component {
    */
   render() {
     if (this.state.error) {
-      return (
-        <LoadError
-          error={this.state.error}
-          onPressReload={() => this.reload()}
-          onPressViewDetails={(uri) => this.props.openModal({url: uri})}
-        />
-      );
+      const errorScreen = this.props.errorScreen || LoadError;
+      return React.createElement(errorScreen, {
+        error: this.state.error,
+        onPressReload: () => this.reload(),
+        onPressViewDetails: (uri) => this.props.openModal({url: uri}),
+      });
     }
     if (!this.state.doc) {
       return (

--- a/src/index.js
+++ b/src/index.js
@@ -228,7 +228,7 @@ export default class HyperScreen extends React.Component {
       const errorScreen = this.props.errorScreen || LoadError;
       return React.createElement(errorScreen, {
         error: this.state.error,
-        onPressReload: () => this.reload(),
+        onPressReload: this.reload,
         onPressViewDetails: (uri) => this.props.openModal({url: uri}),
       });
     }


### PR DESCRIPTION
This PR addresses #267 . Hyperview clients can pass in a React component as an `errorScreen` prop to the `Hyperview` component. This component will be displayed if a screen fails to load due to bad XML parsing or network problems.

Example for `demo/screens/HyperviewScreen.js`:
```js
function ErrorScreen(props) {
  return (
    <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
      <Text style={{fontSize: 24, fontWeight: 'bold', color: 'red'}}>Custom Error Screen</Text>
      <Text style={{color: 'blue'}}>{props.error.name}</Text>
      <Text>{props.error.message}</Text>

    </View>
  );
};

export default class HyperviewScreen extends React.PureComponent {
  // code ommited...

  render() {
    const navigation = this.props.navigation;
    const entrypointUrl = navigation.state.params.url;

    return (
      <Hyperview
        back={this.goBack}
        closeModal={this.closeModal}
        entrypointUrl={entrypointUrl}
        fetch={this.fetchWrapper}
        navigate={this.navigate}
        navigation={navigation}
        openModal={this.openModal}
        push={this.push}
        formatDate={this.formatDate}
        errorScreen={ErrorScreen}
      />
    );
  }
}
```

For a network error the result would look like this:

https://user-images.githubusercontent.com/1034502/118064694-5c2ada80-b350-11eb-986e-252edac6dd95.mov

