### PR TITLE
filter null before remove routeKey

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,9 @@ export default class HyperScreen extends React.Component {
     if (preloadScreen && this.navigation.getPreloadScreen(preloadScreen)) {
       this.navigation.remove(preloadScreen);
     }
-    this.navigation.removeRouteKey(this.state.url)
+    if (this.state.url) {
+      this.navigation.removeRouteKey(this.state.url)
+    }
   }
 
   /**


### PR DESCRIPTION
hi @adamstep , this PR fix below error:
`this.state.url` will be null in some case during development, so add a protection. 
pls check, thanks.

![image](https://user-images.githubusercontent.com/12246394/118467844-c075e180-b736-11eb-91e1-de802f504a3c.png)
