### PR TITLE
Fix activity indicator in Android

### DIFF
--- a/src/core/components/loading/index.js
+++ b/src/core/components/loading/index.js
@@ -19,7 +19,7 @@ export default class Loading extends PureComponent<Props> {
   render() {
     return (
       <View style={styles.container}>
-        <ActivityIndicator />
+        <ActivityIndicator color="#8d9494" />
       </View>
     );
   }


### PR DESCRIPTION
React Native 0.63 does not have a default color for `ActivityIndicator` on Android. See [related PR](https://github.com/facebook/react-native/pull/30057).