### PR TITLE
Fix error screen reload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -230,7 +230,7 @@ export default class HyperScreen extends React.Component {
       const errorScreen = this.props.errorScreen || LoadError;
       return React.createElement(errorScreen, {
         error: this.state.error,
-        onPressReload: this.reload,
+        onPressReload: () => this.reload(),  // Make sure reload() is called without any args
         onPressViewDetails: (uri) => this.props.openModal({url: uri}),
       });
     }


### PR DESCRIPTION
Fix bug introduced in https://github.com/Instawork/hyperview/pull/273 that prevents the error screen reload functionality from working. `reload()` takes an optional href arg, but in the error screen scenario, we want to make sure not to include any args (to reload the screen).