### PR TITLE
Set cors to `*` demo `test:xmlserver` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test:lint": "eslint src && prettier --check '**/*.xsd' '**/*.xml'",
     "test:render": "npx patch-package && jest test/render.test.js --forceExit",
     "test:unit": "jest --testPathPattern src",
-    "test:xmlserver": "http-server -c-1 -p 8085 ./examples",
+    "test:xmlserver": "http-server --cors='*' -c-1 -p 8085 ./examples",
     "test:validate-xml": "find examples/ -name '*.xml' | xargs xmllint --schema schema/hyperview.xsd --noout",
     "test": "yarn generate test && yarn test:flow && yarn test:lint && yarn test:render && yarn test:unit && yarn test:validate-xml"
   },


### PR DESCRIPTION
Following `Getting started` guide I stuck on demo-project refusing to load because of cors missing allow header:
 
![Screenshot_20210524_231912](https://user-images.githubusercontent.com/963412/119448923-cc3d4700-bce6-11eb-8f90-2f79e1848b8e.png)

This PR sets cors to `*` for `http-server` so that the demo-app can be accessed without spending any extra time on investigating why it's not loading. 
