### PR TITLE
Feature: front-end form validate tentative idea

### DIFF
--- a/demo/behaviors/verify.js
+++ b/demo/behaviors/verify.js
@@ -1,0 +1,147 @@
+import type { DOMString, Document, Element } from 'hyperview/src/types';
+import { shallowCloneToRoot } from 'hyperview/src/services';
+
+const verifyBehavior = {
+  action: 'verify',
+  callback: (element: Element,
+    onUpdate: HvComponentOnUpdate,
+    getRoot: HvGetRoot,
+    updateRoot: HvUpdateRoot) => {
+    _verify({
+      element,
+      onUpdate,
+      getRoot,
+      updateRoot
+    })
+  }
+};
+
+const _verify = ({ element,
+  onUpdate,
+  getRoot,
+  updateRoot }) => {
+  let doc: Document = getRoot();
+  let newRoot: Document;
+  let isValid = false;
+  let isNeedUpdate: boolean = false;
+
+  const _needUpdateElement = (el: Element) => {
+    isNeedUpdate = true;
+    newRoot = shallowCloneToRoot(el);
+    // need update doc, otherwise old doc.documentElement === null here.
+    doc = newRoot;
+  };
+
+  const _updateLinkageFields = () => {
+    const updateMethod = methods['update'];
+    if (updateMethod?.length > 0) {
+      updateMethod.forEach((obj: { fields: []; rule: Function }) => {
+        if (obj.fields?.includes(name)) {
+          obj.rule(name, newValue, doc, _needUpdateElement);
+        }
+      });
+    }
+  };
+
+  const _showSubmitButton = (isShowSubmit: boolean) => {
+    const submitBtnInActive = doc.getElementById('ID_SubmitBtn_NonActive');
+    const submitBtnActive = doc.getElementById('ID_SubmitBtn_Active');
+    if (!submitBtnInActive || !submitBtnActive) {
+      return;
+    }
+    const isInactiveHide = submitBtnInActive.getAttribute('hide');
+    const isActiveHide = submitBtnActive.getAttribute('hide');
+
+    if (isShowSubmit && isActiveHide === 'true' && isInactiveHide !== 'true') {
+      // enable active button, disable inactive button
+      submitBtnInActive.setAttribute('hide', true);
+      submitBtnActive.setAttribute('hide', false);
+      _needUpdateElement(submitBtnInActive);
+      _needUpdateElement(submitBtnActive);
+    } else if (!isShowSubmit && isInactiveHide === 'true' && isActiveHide !== 'true') {
+      // disable active button if needed
+      submitBtnActive.setAttribute('hide', true);
+      submitBtnInActive.setAttribute('hide', false);
+      _needUpdateElement(submitBtnInActive);
+      _needUpdateElement(submitBtnActive);
+    }
+  };
+
+  const targetElement: Element = element.tagName === 'behavior' ? element.parentNode : element;
+  const name: string = targetElement.getAttribute('name') || '';
+  const newValue: string = targetElement.getAttribute('value') || '';
+  // get verify code snippet
+  const code = doc.getElementById('ID_VerifyCode')?.textContent;
+  if (!code) {
+    return;
+  }
+
+  const methods = Function('return (' + code + ')')();
+  const verifyMethods = methods['verify'];
+  verifyMethods.find((obj: { fields: []; rule: Function }) => {
+    if (obj.fields?.includes(name)) {
+      isValid = obj.rule(newValue);
+      return true;
+    }
+  });
+
+  // find the next errer message element, the next element MUST be error message element
+  let errMsgElement = targetElement.nextSibling;
+  while (errMsgElement && errMsgElement.nodeType !== 1) {
+    errMsgElement = errMsgElement.nextSibling;
+  }
+  if (errMsgElement) {
+    const isHide = errMsgElement.getAttribute('hide');
+    if (isValid === false && isHide === 'true') {
+      // invalid, show error msg
+      errMsgElement.setAttribute('hide', false);
+      _needUpdateElement(errMsgElement);
+    } else if (isValid && isHide !== 'true') {
+      // valid, hide error msg
+      errMsgElement.setAttribute('hide', true);
+      _needUpdateElement(errMsgElement);
+    }
+  }
+
+  // verify all input field, to determine if active submit button
+  if (isValid) {
+    // update linkage fields if needed
+    _updateLinkageFields();
+    const allValid = verifyMethods.every((obj: { fields: []; rule: Function }) => {
+      return (
+        obj.fields &&
+        obj.fields.every((item: string) => {
+          const el = doc.getElementById('ID_' + item);
+          if (el) {
+            const value = el.getAttribute('value');
+            return obj.rule(value);
+          }
+        })
+      );
+    });
+
+    if (allValid) {
+      _showSubmitButton(true);
+    }
+  } else {
+    _showSubmitButton(false);
+  }
+
+  // If using delay, we need to undo the indicators shown earlier.
+  // if (delay > 0) {
+  //   newRoot = Behaviors.setIndicatorsAfterLoad(
+  //     showIndicatorIds,
+  //     hideIndicatorIds,
+  //     newRoot,
+  //   );
+  // }
+  // Update the DOM with the new shown state and finished indicators.
+
+  if (isNeedUpdate) {
+    updateRoot(newRoot);
+  }
+};
+
+export default verifyBehavior;
+
+

--- a/demo/screens/HyperviewScreen.js
+++ b/demo/screens/HyperviewScreen.js
@@ -10,6 +10,7 @@ import React, { PureComponent } from 'react';
 import Hyperview from 'hyperview';
 import moment from 'moment';
 import HandleBack from '../components/HandleBack';
+import { SafeAreaView } from "react-navigation";
 import verifyBehavior from '../behaviors/verify'
 
 export default class HyperviewScreen extends React.PureComponent {
@@ -72,20 +73,22 @@ export default class HyperviewScreen extends React.PureComponent {
     const entrypointUrl = navigation.state.params.url;
 
     return (
-      <HandleBack>
-        <Hyperview
-          back={this.goBack}
-          closeModal={this.closeModal}
-          entrypointUrl={entrypointUrl}
-          fetch={this.fetchWrapper}
-          navigate={this.navigate}
-          navigation={navigation}
-          openModal={this.openModal}
-          push={this.push}
-          formatDate={this.formatDate}
-          behaviors={[verifyBehavior]}
-        />
-      </HandleBack>
+      <SafeAreaView style={{ flex: 1 }}>
+        <HandleBack>
+          <Hyperview
+            back={this.goBack}
+            closeModal={this.closeModal}
+            entrypointUrl={entrypointUrl}
+            fetch={this.fetchWrapper}
+            navigate={this.navigate}
+            navigation={navigation}
+            openModal={this.openModal}
+            push={this.push}
+            formatDate={this.formatDate}
+            behaviors={[verifyBehavior]}
+          />
+        </HandleBack>
+      </SafeAreaView>
     );
   }
 }

--- a/demo/screens/HyperviewScreen.js
+++ b/demo/screens/HyperviewScreen.js
@@ -10,6 +10,7 @@ import React, { PureComponent } from 'react';
 import Hyperview from 'hyperview';
 import moment from 'moment';
 import HandleBack from '../components/HandleBack';
+import verifyBehavior from '../behaviors/verify'
 
 export default class HyperviewScreen extends React.PureComponent {
   goBack = (params, key) => {
@@ -82,6 +83,7 @@ export default class HyperviewScreen extends React.PureComponent {
           openModal={this.openModal}
           push={this.push}
           formatDate={this.formatDate}
+          behaviors={[verifyBehavior]}
         />
       </HandleBack>
     );

--- a/examples/frontend_form_validate/index.xml
+++ b/examples/frontend_form_validate/index.xml
@@ -1,5 +1,4 @@
-<doc lang="en"
-  xmlns="https://hyperview.org/hyperview">
+<doc lang="en" xmlns="https://hyperview.org/hyperview">
   <screen>
     <styles>
       <style id="Header" borderBottomWidth="1" borderColor="#eee" flexDirection="row" paddingLeft="21" paddingRight="20" paddingBottom="10" paddingTop="10" />
@@ -155,7 +154,7 @@
           <view style="Padding-Zone" />
         </view>
       </form>
-      <text id="ID_VerifyCode" hide="true"></text>
+      <text id="ID_VerifyCode" hide="true" />
     </body>
   </screen>
 </doc>

--- a/examples/frontend_form_validate/index.xml
+++ b/examples/frontend_form_validate/index.xml
@@ -1,0 +1,161 @@
+<doc lang="en"
+  xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style id="Header" borderBottomWidth="1" borderColor="#eee" flexDirection="row" paddingLeft="21" paddingRight="20" paddingBottom="10" paddingTop="10" />
+      <style id="Header__Back" color="black" fontSize="18" fontWeight="600" />
+      <style id="Input" borderBottomColor="#E1E1E1" borderBottomWidth="1" borderColor="#4E4D4D" fontSize="16" fontWeight="normal" paddingBottom="8" paddingTop="8" />
+      <style id="Button-Big-Default" fontSize="16" backgroundColor="#fff" height="48" />
+      <style id="Button-Big-Primary" fontSize="16" height="48" />
+      <style id="Button" borderColor="#F52B39" backgroundColor="#F52B39" borderWidth="1" borderRadius="20" justifyContent="center" paddingLeft="26" paddingRight="26" height="40" />
+      <style id="Button-Disabled" backgroundColor="lightgrey" />
+      <style id="Button-Label" color="#fff" fontSize="16" />
+      <style id="Text-Center" textAlign="center" justifyContent='center' alignItems='center' />
+      <style id="Shadow" elevation="6" shadowColor="#ccc" shadowOffsetX="0" shadowOffsetY="0" shadowOpacity="1" shadowRadius="6" />
+      <style id="Section-Wrap" display="flex" paddingLeft="20" paddingRight="20" justifyContent="center" />
+      <style id="Section-1" backgroundColor="#fff" display="flex" borderRadius="12" padding="16" marginBottom="10" />
+      <style id="Tips" fontSize="14" marginBottom="10" />
+      <style id="Text1" fontSize="14" color="#5A6170" />
+      <style id="Main-Red" color="#ED1B2E" />
+      <style id="M-20" margin="20" />
+      <style id="M-T-10" marginTop="10" />
+      <style id="Color-Warning" color="#F52B39" />
+      <style id="Padding-Zone" paddingBottom="100" />
+    </styles>
+    <body>
+      <!-- load form verify code -->
+      <behavior trigger="load" once="true" action="replace" href="/frontend_form_validate/verify.js" target="ID_VerifyCode" />
+      <!-- header start -->
+      <header style="Header" id="ID_Header">
+        <text action="back" href="#" style="Header__Back">
+          &lt; Back
+        </text>
+      </header>
+      <!-- header of interception, when user click back button after fill some fields, the interception alert will show. -->
+      <header style="Header" id="ID_Header_Interception" hide="true">
+        <text style="Header__Back">
+          &lt; Back Interception
+          <behavior xmlns:alert="https://hyperview.org/hyperview-alert" trigger="press" action="alert" alert:title="Tip" alert:message="Are you sure to leave this page, and drop the things you have entered?">
+            <alert:option alert:label="OK" href="#" action="back" />
+            <alert:option alert:label="Cancel" />
+          </behavior>
+        </text>
+      </header>
+      <!-- header end -->
+      <form id="getSavingPlansForm" scroll="true">
+        <view>
+          <text style="Tips M-20">
+            Front-end form validation.
+            All validations are finished on the front-end, there is no any http request.
+          </text>
+          <view style="Section-Wrap">
+            <!-- Name  -->
+            <text style="Tips">
+            1. Name is required, otherwise will report error when blur.
+            </text>
+            <view style="Section-1 Shadow">
+              <text style="Text1 M-T-10">
+                Goal name
+                <text style="Main-Red">*</text>
+              </text>
+              <text-field id="ID_GoalName" name="GoalName" placeholder="please input name" placeholderTextColor="#8D9494" style="Input">
+                <behavior trigger="blur" action="verify" />
+              </text-field>
+              <!-- text-field element MUST be followed by a view(contains error message) element. -->
+              <view hide="true">
+                <text style="Color-Warning">please input correct name</text>
+              </view>
+            </view>
+            <!-- Age  -->
+            <text style="Tips">
+              2. Retirement age should be &gt;=50, otherwise will report error when blur.
+            </text>
+            <view style="Section-1 Shadow">
+              <text style="Text1 M-T-10">
+                Retire Age (&gt;=50)
+                <text style="Main-Red">*</text>
+              </text>
+              <text-field id="ID_UserAge" name="UserAge" placeholder="please input age" placeholderTextColor="#8D9494" style="Input">
+                <behavior trigger="blur" action="verify" />
+              </text-field>
+              <!-- text-field element MUST be followed by a view(contains error message) element. -->
+              <view hide="true">
+                <text style="Color-Warning">please input correct age</text>
+              </view>
+            </view>
+            <text style="Tips">
+                3.1 The following fields have linkage effects. when one is modified, the others will automatically change accordingly.
+            </text>
+            <text style="Tips">
+                3.2 In addition, when there are changes, the interception pop-up window will show when the back button in the upper left corner of the page is clicked.
+            </text>
+            <view style="Section-1 Shadow">
+              <!-- Amount1  -->
+              <text style="Text1 M-T-10">
+                Amount1
+                <text style="Main-Red">*</text>
+              </text>
+              <text-field id="ID_Amount1Name" name="Amount1Name" data-oldvalue="0" placeholder="please input amount1" placeholderTextColor="#8D9494" style="Input">
+                <behavior trigger="blur" action="verify" />
+              </text-field>
+              <!--· text-field element MUST be followed by a view(contains error message) element. -->
+              <view hide="true">
+                <text style="Color-Warning">please input correct amount1</text>
+              </view>
+              <!-- Amount2  -->
+              <text style="Text1 M-T-10">
+                Amount2
+                <text style="Main-Red">*</text>
+              </text>
+              <text-field id="ID_Amount2Name" name="Amount2Name" data-oldvalue="0" placeholder="please input amount2" placeholderTextColor="#8D9494" style="Input">
+                <behavior trigger="blur" action="verify" />
+              </text-field>
+              <!--· text-field element MUST be followed by a view(contains error message) element. -->
+              <view hide="true">
+                <text style="Color-Warning">please input correct amount2</text>
+              </view>
+              <!-- Amount3  -->
+              <text style="Text1 M-T-10">
+                Amount3
+                <text style="Main-Red">*</text>
+              </text>
+              <text-field id="ID_Amount3Name" name="Amount3Name" data-oldvalue="0" placeholder="please input amount3" placeholderTextColor="#8D9494" style="Input">
+                <behavior trigger="blur" action="verify" />
+              </text-field>
+              <!--· text-field element MUST be followed by a view(contains error message) element. -->
+              <view hide="true">
+                <text style="Color-Warning">please input correct amount3</text>
+              </view>
+              <!-- Sum  -->
+              <text style="Text1 M-T-10">
+                Sum
+                <text style="Main-Red">*</text>
+              </text>
+              <text-field id="ID_SumName" name="SumName" data-oldvalue="0" placeholder="please input sum" placeholderTextColor="#8D9494" style="Input">
+                <behavior trigger="blur" action="verify" />
+              </text-field>
+              <!--· text-field element MUST be followed by a view(contains error message) element. -->
+              <view hide="true">
+                <text style="Color-Warning">please input correct Sum</text>
+              </view>
+            </view>
+          </view>
+          <view style="M-20">
+            <text style="Tips">
+              4. The submit button will activate when all above fileds validate success. and will deactivate when one or more validate fail.
+            </text>
+            <view id="ID_SubmitBtn_Active" hide="true" style="Button Button-Big-Primary">
+              <behavior href="/ui_elements/image.xml" action="push" target="getSavingPlansForm" verb="get" />
+              <text style="Button-Label Text-Center">Submit</text>
+            </view>
+            <view id="ID_SubmitBtn_NonActive" style="Button Button-Big-Primary Button-Disabled">
+              <text style="Button-Label Text-Center">Submit</text>
+            </view>
+          </view>
+          <view style="Padding-Zone" />
+        </view>
+      </form>
+      <text id="ID_VerifyCode" hide="true"></text>
+    </body>
+  </screen>
+</doc>

--- a/examples/frontend_form_validate/verify.js
+++ b/examples/frontend_form_validate/verify.js
@@ -1,0 +1,129 @@
+<text id="ID_VerifyCode" hide="true">
+// <![CDATA[
+{
+  "verify" : [
+    {
+      fields: ["GoalName"],
+      rule: function(v) {
+        if(v) {
+          return true;
+        }
+        return false;
+      },
+    },
+    {
+      fields: ["UserAge"],
+      rule: function(v) {
+        v = parseInt(v);
+        if(v >= 50) {
+          return true;
+        }
+        return false;
+      },
+    },
+    {
+      fields: ["Amount1Name", "Amount2Name", "Amount3Name"],
+      rule: function(v) {
+        const re = /^\d{1,3}$/;
+        if(re.test(v)) {
+          return true;
+        }
+        return false;
+      },
+    },
+    {
+      fields: ["SumName"],
+      rule: function(v) {
+        const re = /^\d{1,4}$/;
+        if(re.test(v)) {
+          return true;
+        }
+        return false;
+      },
+    },
+  ],
+  "update" : [
+    {
+      fields: ["Amount1Name", "Amount2Name", "Amount3Name"],
+      rule: function(name, val, doc, needUpdateElement) {
+        const targets = ["SumName"];
+        const fields = ["Amount1Name", "Amount2Name", "Amount3Name"];
+        const el = doc.getElementById("ID_" + name);
+        const oldValue = el?.getAttribute("data-oldvalue") || 0;
+        const delta = parseInt(val) - parseInt(oldValue);
+        console.log("delta: ", delta);
+        if(delta === 0) {return;}
+        const enableHeaderInterceptor = () => {
+          // replace header to show intercept dialog when click back icon, instead of back to previous page.
+          const elInterceptor = doc.getElementById("ID_Header_Interception");
+          if(!elInterceptor || elInterceptor.getAttribute("hide") !== 'true') {return}
+          const elBack = doc.getElementById("ID_Header");
+          if(!elBack) {return}
+          elBack.setAttribute('hide', 'true');
+          elInterceptor.setAttribute('hide', 'false');
+          needUpdateElement(elBack);
+          needUpdateElement(elInterceptor);
+        }
+        let sum = 0;
+        fields.forEach(item => {
+          const field = doc.getElementById("ID_" + item);
+          if(field) {
+            let value = field.getAttribute("value") || 0;
+            sum += parseInt(value);
+          }
+        })
+        const target = doc.getElementById("ID_SumName");
+        enableHeaderInterceptor();
+        // MUST call needUpdateElement() at the last end!
+        el.setAttribute("data-oldvalue", val);
+        needUpdateElement(el);
+        target.setAttribute("value", sum);
+        needUpdateElement(target);
+      }
+    },
+    {
+      fields: ["SumName"],
+      rule: function(name, val, doc, needUpdateElement) {
+        const fields = [
+          {name: "Amount1Name", ratio: "10%"},
+          {name: "Amount2Name", ratio: "30%"},
+          {name: "Amount3Name", ratio: "60%"}
+        ];
+        const el = doc.getElementById("ID_" + name);
+        const oldValue = el?.getAttribute("data-oldvalue") || 0;
+        const delta = parseInt(val) - parseInt(oldValue);
+        console.log("delta: ", delta);
+        if(delta === 0) {return;}
+        const enableHeaderInterceptor = () => {
+          // replace header to show intercept dialog when click back icon, instead of back to previous page.
+          const elInterceptor = doc.getElementById("ID_Header_Interception");
+          if(!elInterceptor || elInterceptor.getAttribute("hide") !== 'true') {return}
+          const elBack = doc.getElementById("ID_Header");
+          if(!elBack) {return}
+          elBack.setAttribute('hide', 'true');
+          elInterceptor.setAttribute('hide', 'false');
+          needUpdateElement(elBack);
+          needUpdateElement(elInterceptor);
+        }
+        const elementsUpdate = [];
+        fields.forEach(({name, ratio}) => {
+          const field = doc.getElementById("ID_" + name);
+          if(field) {
+            let value = Math.floor(val * parseInt(ratio) / 100);
+            field.setAttribute("data-oldvalue", field.getAttribute("value"));
+            field.setAttribute("value", value);
+            elementsUpdate.push(field);
+          }
+        })
+        // MUST call needUpdateElement() at the last end!
+        enableHeaderInterceptor();
+        elementsUpdate.forEach(item => needUpdateElement(item));
+        el.setAttribute("data-oldvalue", val);
+        needUpdateElement(el);
+      }
+    },
+  ]
+}
+
+// ]]>
+</text>

--- a/examples/index.xml
+++ b/examples/index.xml
@@ -114,6 +114,17 @@
           </view>
           <text style="Item__Chevron">&gt;</text>
         </item>
+        <item
+          href="/frontend_form_validate/index.xml"
+          key="frontend_form_validate"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <view style="Item__Left">
+            <text style="Item__Label">Front-end form validation</text>
+          </view>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
       </list>
     </body>
   </screen>


### PR DESCRIPTION
This PR probably should not raised in the form of PR, it only  provided an experimental idea to validate form field in front-end.
![demo-frontend-form-validate](https://user-images.githubusercontent.com/12246394/119456113-e7eb3080-bd6c-11eb-8f43-dcea5f3339d0.gif)

The basic idea is:
1.  The code of form validate logic written by Javascript is located in server side: `examples/frontend_form_validate/verify.js `. and injected to `examples/frontend_form_validate/index.xml` when page loaded.
2. In client side, it's triggered by a custom behavior as below, to load the `form validate code`, and run it.
```xml
<behavior trigger="blur" action="verify" />
```

This is just an experimental method for reference. 
The biggest advantage is: 
-  form-validate is completely done in front-end, without any http request.

And the biggest disadvantages are:
- There are lots of hard code ID or file format in `xml` or `js` file.
- Potential security issues maybe injected by Javascript.


Please help check it, we'd love to hear your opinion or comment about it.
because in our app, we need do a few action about user info fill and submit, and the function of front-end form validation is vital to us.

thank you very much.