### PR TITLE
Case study: two-level menu with <select-single>

### DIFF
--- a/examples/case_studies/cascader.xml
+++ b/examples/case_studies/cascader.xml
@@ -1,117 +1,107 @@
 <doc xmlns="https://hyperview.org/hyperview">
   <screen>
     <styles>
-      <style id="Body" backgroundColor="white" flex="1" paddingTop="24" />
-      <style id="Main" flex="1" marginBottom="40" />
-      <style
-        id="FormGroup"
-        flex="1"
-        marginLeft="24"
-        marginRight="24"
-        marginTop="24"
-      />
-      <style
-        id="Input"
-        borderBottomColor="#E1E1E1"
-        borderBottomWidth="1"
-        borderColor="#4E4D4D"
-        flex="1"
-        fontSize="16"
-        fontWeight="normal"
-        paddingBottom="8"
-        paddingTop="8"
-      >
+      <style backgroundColor="white"
+             flex="1"
+             id="Body"
+             paddingTop="24" />
+      <style flex="1"
+             id="Main"
+             marginBottom="40" />
+      <style flex="1"
+             id="FormGroup"
+             marginLeft="24"
+             marginRight="24"
+             marginTop="24" />
+      <style borderBottomColor="#E1E1E1"
+             borderBottomWidth="1"
+             borderColor="#4E4D4D"
+             flex="1"
+             fontSize="16"
+             fontWeight="normal"
+             id="Input"
+             paddingBottom="8"
+             paddingTop="8">
         <modifier focused="true">
           <style borderBottomColor="#4778FF" />
         </modifier>
       </style>
-      <style id="Input--Error" borderBottomColor="#FF4847" color="#FF4847">
+      <style borderBottomColor="#FF4847"
+             color="#FF4847"
+             id="Input--Error">
         <modifier focused="true">
           <style borderBottomColor="#FF4847" />
         </modifier>
       </style>
-      <style
-        id="Label"
-        borderColor="#4E4D4D"
-        fontSize="16"
-        fontWeight="bold"
-        lineHeight="24"
-        marginBottom="8"
-      />
-      <style
-        id="Help"
-        borderColor="#FF4847"
-        fontSize="16"
-        fontWeight="normal"
-        lineHeight="24"
-        marginTop="16"
-      />
-      <style id="Help--Error" color="#FF4847" />
-      <style
-        id="Submit"
-        color="#4778FF"
-        fontSize="16"
-        fontWeight="bold"
-        lineHeight="24"
-        marginLeft="24"
-        marginTop="16"
-      />
-
-
-      <style id="Select" marginTop="24" />
-      <style
-        id="Select__Separator"
-        borderTopColor="#e1e3e3"
-        borderTopWidth="1"
-        marginLeft="24"
-        marginRight="24"
-      />
-      <style
-        id="Select__Option"
-        alignItems="center"
-        flex="1"
-        flexDirection="row"
-        justifyContent="space-between"
-        paddingBottom="16"
-        paddingLeft="24"
-        paddingRight="24"
-        paddingTop="16"
-      />
-      <style
-        id="Select__RadioOuter"
-        borderColor="#bdc4c4"
-        borderRadius="10"
-        borderWidth="1"
-        height="20"
-        width="20"
-      >
+      <style borderColor="#4E4D4D"
+             fontSize="16"
+             fontWeight="bold"
+             id="Label"
+             lineHeight="24"
+             marginBottom="8" />
+      <style borderColor="#FF4847"
+             fontSize="16"
+             fontWeight="normal"
+             id="Help"
+             lineHeight="24"
+             marginTop="16" />
+      <style color="#FF4847"
+             id="Help--Error" />
+      <style color="#4778FF"
+             fontSize="16"
+             fontWeight="bold"
+             id="Submit"
+             lineHeight="24"
+             marginLeft="24"
+             marginTop="16" />
+      <style id="Select"
+             marginTop="24" />
+      <style borderTopColor="#e1e3e3"
+             borderTopWidth="1"
+             id="Select__Separator"
+             marginLeft="24"
+             marginRight="24" />
+      <style alignItems="center"
+             flex="1"
+             flexDirection="row"
+             id="Select__Option"
+             justifyContent="space-between"
+             paddingBottom="16"
+             paddingLeft="24"
+             paddingRight="24"
+             paddingTop="16" />
+      <style borderColor="#bdc4c4"
+             borderRadius="10"
+             borderWidth="1"
+             height="20"
+             id="Select__RadioOuter"
+             width="20">
         <modifier pressed="true">
-          <style borderColor="#8d9494" borderWidth="1" />
+          <style borderColor="#8d9494"
+                 borderWidth="1" />
         </modifier>
         <modifier selected="true">
-          <style borderColor="#4778ff" borderWidth="2" />
+          <style borderColor="#4778ff"
+                 borderWidth="2" />
         </modifier>
       </style>
-      <style
-        id="Select__RadioInner"
-        borderRadius="5"
-        height="10"
-        marginLeft="3"
-        marginTop="3"
-        opacity="0"
-        width="10"
-      >
+      <style borderRadius="5"
+             height="10"
+             id="Select__RadioInner"
+             marginLeft="3"
+             marginTop="3"
+             opacity="0"
+             width="10">
         <modifier selected="true">
-          <style backgroundColor="#4778ff" opacity="1" />
+          <style backgroundColor="#4778ff"
+                 opacity="1" />
         </modifier>
       </style>
-      <style
-        id="Select__Label"
-        color="black"
-        fontSize="16"
-        fontWeight="normal"
-        lineHeight="18"
-      >
+      <style color="black"
+             fontSize="16"
+             fontWeight="normal"
+             id="Select__Label"
+             lineHeight="18">
         <modifier selected="true">
           <style color="#312f2f" />
         </modifier>
@@ -119,71 +109,83 @@
           <style color="#312f2f" />
         </modifier>
       </style>
-
-
     </styles>
-    <body style="Body" safe-area="true">
-
-      <view scroll="true" style="Main" trigger="refresh" action="reload" href="#">
-
-        <select-single name="level1" style="Select">
-
+    <body safe-area="true"
+          style="Body">
+      <view action="reload"
+            href="#"
+            scroll="true"
+            style="Main"
+            trigger="refresh">
+        <select-single name="level1"
+                       style="Select">
           <view style="Select__Separator" />
-          <option style="Select__Option" value="1">
-            <behavior trigger="select" action="show" target="section1" />
-            <behavior trigger="deselect" action="hide" target="section1" />
-
+          <option style="Select__Option"
+                  value="1">
+            <behavior action="show"
+                      target="section1"
+                      trigger="select" />
+            <behavior action="hide"
+                      target="section1"
+                      trigger="deselect" />
             <text style="Select__Label">Option 1</text>
             <view style="Select__RadioOuter">
               <view style="Select__RadioInner" />
             </view>
           </option>
-
           <view style="Select__Separator" />
-
-          <option style="Select__Option" value="2">
-            <behavior trigger="select" action="show" target="section2" />
-            <behavior trigger="deselect" action="hide" target="section2" />
+          <option style="Select__Option"
+                  value="2">
+            <behavior action="show"
+                      target="section2"
+                      trigger="select" />
+            <behavior action="hide"
+                      target="section2"
+                      trigger="deselect" />
             <text style="Select__Label">Option 2</text>
             <view style="Select__RadioOuter">
               <view style="Select__RadioInner" />
             </view>
           </option>
-
           <view style="Select__Separator" />
-
-          <option style="Select__Option" value="3">
-            <behavior trigger="select" action="show" target="section3" />
-            <behavior trigger="deselect" action="hide" target="section3" />
+          <option style="Select__Option"
+                  value="3">
+            <behavior action="show"
+                      target="section3"
+                      trigger="select" />
+            <behavior action="hide"
+                      target="section3"
+                      trigger="deselect" />
             <text style="Select__Label">Option 3</text>
             <view style="Select__RadioOuter">
               <view style="Select__RadioInner" />
             </view>
           </option>
           <view style="Select__Separator" />
-
         </select-single>
-
-
-        <select-single name="level2" style="Select">
-
-          <view id="section1" hide="true">
+        <select-single name="level2"
+                       style="Select">
+          <view hide="true"
+                id="section1">
             <view style="Select__Separator" />
-            <option style="Select__Option" value="1:1">
+            <option style="Select__Option"
+                    value="1:1">
               <text style="Select__Label">1: 1</text>
               <view style="Select__RadioOuter">
                 <view style="Select__RadioInner" />
               </view>
             </option>
             <view style="Select__Separator" />
-            <option style="Select__Option" value="1:2">
+            <option style="Select__Option"
+                    value="1:2">
               <text style="Select__Label">1: 2</text>
               <view style="Select__RadioOuter">
                 <view style="Select__RadioInner" />
               </view>
             </option>
             <view style="Select__Separator" />
-            <option style="Select__Option" value="1:3">
+            <option style="Select__Option"
+                    value="1:3">
               <text style="Select__Label">1: 3</text>
               <view style="Select__RadioOuter">
                 <view style="Select__RadioInner" />
@@ -191,17 +193,19 @@
             </option>
             <view style="Select__Separator" />
           </view>
-
-          <view id="section2" hide="true">
+          <view hide="true"
+                id="section2">
             <view style="Select__Separator" />
-            <option style="Select__Option" value="2:1">
+            <option style="Select__Option"
+                    value="2:1">
               <text style="Select__Label">2: 1</text>
               <view style="Select__RadioOuter">
                 <view style="Select__RadioInner" />
               </view>
             </option>
             <view style="Select__Separator" />
-            <option style="Select__Option" value="2:2">
+            <option style="Select__Option"
+                    value="2:2">
               <text style="Select__Label">2: 2</text>
               <view style="Select__RadioOuter">
                 <view style="Select__RadioInner" />
@@ -209,10 +213,11 @@
             </option>
             <view style="Select__Separator" />
           </view>
-
-          <view id="section3" hide="true">
+          <view hide="true"
+                id="section3">
             <view style="Select__Separator" />
-            <option style="Select__Option" value="3:3">
+            <option style="Select__Option"
+                    value="3:3">
               <text style="Select__Label">3: 1</text>
               <view style="Select__RadioOuter">
                 <view style="Select__RadioInner" />
@@ -220,9 +225,7 @@
             </option>
             <view style="Select__Separator" />
           </view>
-
         </select-single>
-
       </view>
     </body>
   </screen>

--- a/examples/case_studies/cascader.xml
+++ b/examples/case_studies/cascader.xml
@@ -1,0 +1,229 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style id="Body" backgroundColor="white" flex="1" paddingTop="24" />
+      <style id="Main" flex="1" marginBottom="40" />
+      <style
+        id="FormGroup"
+        flex="1"
+        marginLeft="24"
+        marginRight="24"
+        marginTop="24"
+      />
+      <style
+        id="Input"
+        borderBottomColor="#E1E1E1"
+        borderBottomWidth="1"
+        borderColor="#4E4D4D"
+        flex="1"
+        fontSize="16"
+        fontWeight="normal"
+        paddingBottom="8"
+        paddingTop="8"
+      >
+        <modifier focused="true">
+          <style borderBottomColor="#4778FF" />
+        </modifier>
+      </style>
+      <style id="Input--Error" borderBottomColor="#FF4847" color="#FF4847">
+        <modifier focused="true">
+          <style borderBottomColor="#FF4847" />
+        </modifier>
+      </style>
+      <style
+        id="Label"
+        borderColor="#4E4D4D"
+        fontSize="16"
+        fontWeight="bold"
+        lineHeight="24"
+        marginBottom="8"
+      />
+      <style
+        id="Help"
+        borderColor="#FF4847"
+        fontSize="16"
+        fontWeight="normal"
+        lineHeight="24"
+        marginTop="16"
+      />
+      <style id="Help--Error" color="#FF4847" />
+      <style
+        id="Submit"
+        color="#4778FF"
+        fontSize="16"
+        fontWeight="bold"
+        lineHeight="24"
+        marginLeft="24"
+        marginTop="16"
+      />
+
+
+      <style id="Select" marginTop="24" />
+      <style
+        id="Select__Separator"
+        borderTopColor="#e1e3e3"
+        borderTopWidth="1"
+        marginLeft="24"
+        marginRight="24"
+      />
+      <style
+        id="Select__Option"
+        alignItems="center"
+        flex="1"
+        flexDirection="row"
+        justifyContent="space-between"
+        paddingBottom="16"
+        paddingLeft="24"
+        paddingRight="24"
+        paddingTop="16"
+      />
+      <style
+        id="Select__RadioOuter"
+        borderColor="#bdc4c4"
+        borderRadius="10"
+        borderWidth="1"
+        height="20"
+        width="20"
+      >
+        <modifier pressed="true">
+          <style borderColor="#8d9494" borderWidth="1" />
+        </modifier>
+        <modifier selected="true">
+          <style borderColor="#4778ff" borderWidth="2" />
+        </modifier>
+      </style>
+      <style
+        id="Select__RadioInner"
+        borderRadius="5"
+        height="10"
+        marginLeft="3"
+        marginTop="3"
+        opacity="0"
+        width="10"
+      >
+        <modifier selected="true">
+          <style backgroundColor="#4778ff" opacity="1" />
+        </modifier>
+      </style>
+      <style
+        id="Select__Label"
+        color="black"
+        fontSize="16"
+        fontWeight="normal"
+        lineHeight="18"
+      >
+        <modifier selected="true">
+          <style color="#312f2f" />
+        </modifier>
+        <modifier pressed="true">
+          <style color="#312f2f" />
+        </modifier>
+      </style>
+
+
+    </styles>
+    <body style="Body" safe-area="true">
+
+      <view scroll="true" style="Main" trigger="refresh" action="reload" href="#">
+
+        <select-single name="level1" style="Select">
+
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="1">
+            <behavior trigger="select" action="show" target="section1" />
+            <behavior trigger="deselect" action="hide" target="section1" />
+
+            <text style="Select__Label">Option 1</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+
+          <view style="Select__Separator" />
+
+          <option style="Select__Option" value="2">
+            <behavior trigger="select" action="show" target="section2" />
+            <behavior trigger="deselect" action="hide" target="section2" />
+            <text style="Select__Label">Option 2</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+
+          <view style="Select__Separator" />
+
+          <option style="Select__Option" value="3">
+            <behavior trigger="select" action="show" target="section3" />
+            <behavior trigger="deselect" action="hide" target="section3" />
+            <text style="Select__Label">Option 3</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+
+        </select-single>
+
+
+        <select-single name="level2" style="Select">
+
+          <view id="section1" hide="true">
+            <view style="Select__Separator" />
+            <option style="Select__Option" value="1:1">
+              <text style="Select__Label">1: 1</text>
+              <view style="Select__RadioOuter">
+                <view style="Select__RadioInner" />
+              </view>
+            </option>
+            <view style="Select__Separator" />
+            <option style="Select__Option" value="1:2">
+              <text style="Select__Label">1: 2</text>
+              <view style="Select__RadioOuter">
+                <view style="Select__RadioInner" />
+              </view>
+            </option>
+            <view style="Select__Separator" />
+            <option style="Select__Option" value="1:3">
+              <text style="Select__Label">1: 3</text>
+              <view style="Select__RadioOuter">
+                <view style="Select__RadioInner" />
+              </view>
+            </option>
+            <view style="Select__Separator" />
+          </view>
+
+          <view id="section2" hide="true">
+            <view style="Select__Separator" />
+            <option style="Select__Option" value="2:1">
+              <text style="Select__Label">2: 1</text>
+              <view style="Select__RadioOuter">
+                <view style="Select__RadioInner" />
+              </view>
+            </option>
+            <view style="Select__Separator" />
+            <option style="Select__Option" value="2:2">
+              <text style="Select__Label">2: 2</text>
+              <view style="Select__RadioOuter">
+                <view style="Select__RadioInner" />
+              </view>
+            </option>
+            <view style="Select__Separator" />
+          </view>
+
+          <view id="section3" hide="true">
+            <view style="Select__Separator" />
+            <option style="Select__Option" value="3:3">
+              <text style="Select__Label">3: 1</text>
+              <view style="Select__RadioOuter">
+                <view style="Select__RadioInner" />
+              </view>
+            </option>
+            <view style="Select__Separator" />
+          </view>
+
+        </select-single>
+
+      </view>
+    </body>
+  </screen>
+</doc>

--- a/examples/case_studies/cascader.xml
+++ b/examples/case_studies/cascader.xml
@@ -1,107 +1,115 @@
 <doc xmlns="https://hyperview.org/hyperview">
   <screen>
     <styles>
-      <style backgroundColor="white"
-             flex="1"
-             id="Body"
-             paddingTop="24" />
-      <style flex="1"
-             id="Main"
-             marginBottom="40" />
-      <style flex="1"
-             id="FormGroup"
-             marginLeft="24"
-             marginRight="24"
-             marginTop="24" />
-      <style borderBottomColor="#E1E1E1"
-             borderBottomWidth="1"
-             borderColor="#4E4D4D"
-             flex="1"
-             fontSize="16"
-             fontWeight="normal"
-             id="Input"
-             paddingBottom="8"
-             paddingTop="8">
+      <style backgroundColor="white" flex="1" id="Body" paddingTop="24" />
+      <style flex="1" id="Main" marginBottom="40" />
+      <style
+        flex="1"
+        id="FormGroup"
+        marginLeft="24"
+        marginRight="24"
+        marginTop="24"
+      />
+      <style
+        borderBottomColor="#E1E1E1"
+        borderBottomWidth="1"
+        borderColor="#4E4D4D"
+        flex="1"
+        fontSize="16"
+        fontWeight="normal"
+        id="Input"
+        paddingBottom="8"
+        paddingTop="8"
+      >
         <modifier focused="true">
           <style borderBottomColor="#4778FF" />
         </modifier>
       </style>
-      <style borderBottomColor="#FF4847"
-             color="#FF4847"
-             id="Input--Error">
+      <style borderBottomColor="#FF4847" color="#FF4847" id="Input--Error">
         <modifier focused="true">
           <style borderBottomColor="#FF4847" />
         </modifier>
       </style>
-      <style borderColor="#4E4D4D"
-             fontSize="16"
-             fontWeight="bold"
-             id="Label"
-             lineHeight="24"
-             marginBottom="8" />
-      <style borderColor="#FF4847"
-             fontSize="16"
-             fontWeight="normal"
-             id="Help"
-             lineHeight="24"
-             marginTop="16" />
-      <style color="#FF4847"
-             id="Help--Error" />
-      <style color="#4778FF"
-             fontSize="16"
-             fontWeight="bold"
-             id="Submit"
-             lineHeight="24"
-             marginLeft="24"
-             marginTop="16" />
-      <style id="Select"
-             marginTop="24" />
-      <style borderTopColor="#e1e3e3"
-             borderTopWidth="1"
-             id="Select__Separator"
-             marginLeft="24"
-             marginRight="24" />
-      <style alignItems="center"
-             flex="1"
-             flexDirection="row"
-             id="Select__Option"
-             justifyContent="space-between"
-             paddingBottom="16"
-             paddingLeft="24"
-             paddingRight="24"
-             paddingTop="16" />
-      <style borderColor="#bdc4c4"
-             borderRadius="10"
-             borderWidth="1"
-             height="20"
-             id="Select__RadioOuter"
-             width="20">
+      <style
+        borderColor="#4E4D4D"
+        fontSize="16"
+        fontWeight="bold"
+        id="Label"
+        lineHeight="24"
+        marginBottom="8"
+      />
+      <style
+        borderColor="#FF4847"
+        fontSize="16"
+        fontWeight="normal"
+        id="Help"
+        lineHeight="24"
+        marginTop="16"
+      />
+      <style color="#FF4847" id="Help--Error" />
+      <style
+        color="#4778FF"
+        fontSize="16"
+        fontWeight="bold"
+        id="Submit"
+        lineHeight="24"
+        marginLeft="24"
+        marginTop="16"
+      />
+      <style id="Select" marginTop="24" />
+      <style
+        borderTopColor="#e1e3e3"
+        borderTopWidth="1"
+        id="Select__Separator"
+        marginLeft="24"
+        marginRight="24"
+      />
+      <style
+        alignItems="center"
+        flex="1"
+        flexDirection="row"
+        id="Select__Option"
+        justifyContent="space-between"
+        paddingBottom="16"
+        paddingLeft="24"
+        paddingRight="24"
+        paddingTop="16"
+      />
+      <style
+        borderColor="#bdc4c4"
+        borderRadius="10"
+        borderWidth="1"
+        height="20"
+        id="Select__RadioOuter"
+        width="20"
+      >
         <modifier pressed="true">
-          <style borderColor="#8d9494"
-                 borderWidth="1" />
+          <style borderColor="#8d9494" borderWidth="1" />
         </modifier>
         <modifier selected="true">
-          <style borderColor="#4778ff"
-                 borderWidth="2" />
+          <style borderColor="#4778ff" borderWidth="2" />
         </modifier>
       </style>
-      <style borderRadius="5"
-             height="10"
-             id="Select__RadioInner"
-             marginLeft="3"
-             marginTop="3"
-             opacity="0"
-             width="10">
+      <style
+        borderRadius="5"
+        height="10"
+        id="Select__RadioInner"
+        marginLeft="3"
+        marginTop="3"
+        opacity="0"
+        width="10"
+      >
         <modifier selected="true">
-          <style backgroundColor="#4778ff"
-                 opacity="1" />
+          <style backgroundColor="#4778ff" opacity="1" />
         </modifier>
       </style>
-      <style color="black"
-             fontSize="16"
-             fontWeight="normal"
-             id="Select__Label"
-             lineHeight="18">
+      <style
+        color="black"
+        fontSize="16"
+        fontWeight="normal"
+        id="Select__Label"
+        lineHeight="18"
+      >
         <modifier selected="true">
           <style color="#312f2f" />
         </modifier>
@@ -110,52 +118,37 @@
         </modifier>
       </style>
     </styles>
-    <body safe-area="true"
-          style="Body">
-      <view action="reload"
-            href="#"
-            scroll="true"
-            style="Main"
-            trigger="refresh">
-        <select-single name="level1"
-                       style="Select">
+    <body safe-area="true" style="Body">
+      <view
+        action="reload"
+        href="#"
+        scroll="true"
+        style="Main"
+        trigger="refresh"
+      >
+        <select-single name="level1" style="Select">
           <view style="Select__Separator" />
-          <option style="Select__Option"
-                  value="1">
-            <behavior action="show"
-                      target="section1"
-                      trigger="select" />
-            <behavior action="hide"
-                      target="section1"
-                      trigger="deselect" />
+          <option style="Select__Option" value="1">
+            <behavior action="show" target="section1" trigger="select" />
+            <behavior action="hide" target="section1" trigger="deselect" />
             <text style="Select__Label">Option 1</text>
             <view style="Select__RadioOuter">
               <view style="Select__RadioInner" />
             </view>
           </option>
           <view style="Select__Separator" />
-          <option style="Select__Option"
-                  value="2">
-            <behavior action="show"
-                      target="section2"
-                      trigger="select" />
-            <behavior action="hide"
-                      target="section2"
-                      trigger="deselect" />
+          <option style="Select__Option" value="2">
+            <behavior action="show" target="section2" trigger="select" />
+            <behavior action="hide" target="section2" trigger="deselect" />
             <text style="Select__Label">Option 2</text>
             <view style="Select__RadioOuter">
               <view style="Select__RadioInner" />
             </view>
           </option>
           <view style="Select__Separator" />
-          <option style="Select__Option"
-                  value="3">
-            <behavior action="show"
-                      target="section3"
-                      trigger="select" />
-            <behavior action="hide"
-                      target="section3"
-                      trigger="deselect" />
+          <option style="Select__Option" value="3">
+            <behavior action="show" target="section3" trigger="select" />
+            <behavior action="hide" target="section3" trigger="deselect" />
             <text style="Select__Label">Option 3</text>
             <view style="Select__RadioOuter">
               <view style="Select__RadioInner" />
@@ -163,29 +156,24 @@
           </option>
           <view style="Select__Separator" />
         </select-single>
-        <select-single name="level2"
-                       style="Select">
-          <view hide="true"
-                id="section1">
+        <select-single name="level2" style="Select">
+          <view hide="true" id="section1">
             <view style="Select__Separator" />
-            <option style="Select__Option"
-                    value="1:1">
+            <option style="Select__Option" value="1:1">
               <text style="Select__Label">1: 1</text>
               <view style="Select__RadioOuter">
                 <view style="Select__RadioInner" />
               </view>
             </option>
             <view style="Select__Separator" />
-            <option style="Select__Option"
-                    value="1:2">
+            <option style="Select__Option" value="1:2">
               <text style="Select__Label">1: 2</text>
               <view style="Select__RadioOuter">
                 <view style="Select__RadioInner" />
               </view>
             </option>
             <view style="Select__Separator" />
-            <option style="Select__Option"
-                    value="1:3">
+            <option style="Select__Option" value="1:3">
               <text style="Select__Label">1: 3</text>
               <view style="Select__RadioOuter">
                 <view style="Select__RadioInner" />
@@ -193,19 +181,16 @@
             </option>
             <view style="Select__Separator" />
           </view>
-          <view hide="true"
-                id="section2">
+          <view hide="true" id="section2">
             <view style="Select__Separator" />
-            <option style="Select__Option"
-                    value="2:1">
+            <option style="Select__Option" value="2:1">
               <text style="Select__Label">2: 1</text>
               <view style="Select__RadioOuter">
                 <view style="Select__RadioInner" />
               </view>
             </option>
             <view style="Select__Separator" />
-            <option style="Select__Option"
-                    value="2:2">
+            <option style="Select__Option" value="2:2">
               <text style="Select__Label">2: 2</text>
               <view style="Select__RadioOuter">
                 <view style="Select__RadioInner" />
@@ -213,11 +198,9 @@
             </option>
             <view style="Select__Separator" />
           </view>
-          <view hide="true"
-                id="section3">
+          <view hide="true" id="section3">
             <view style="Select__Separator" />
-            <option style="Select__Option"
-                    value="3:3">
+            <option style="Select__Option" value="3:3">
               <text style="Select__Label">3: 1</text>
               <view style="Select__RadioOuter">
                 <view style="Select__RadioInner" />

--- a/examples/case_studies/index.xml
+++ b/examples/case_studies/index.xml
@@ -160,6 +160,15 @@
           <text style="Item__Label">Custom Android Back</text>
           <text style="Item__Chevron">&gt;</text>
         </item>
+        <item
+          href="/case_studies/cascader.xml"
+          key="cascader"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Cascader</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
       </list>
     </body>
   </screen>


### PR DESCRIPTION
Example of implementing a two-level menu using two `<select-single>` elements.

This first `<select-single>` triggers behavior on `select` and `deselect` to show subsets of `<option>` elements in the second `<select-single>`.

https://user-images.githubusercontent.com/1034502/119771524-b3619c80-be72-11eb-9505-3918f04f60e2.mov

