### PR TITLE
`<list>` fix: Prevent rendering items from nested `<list>`

### DIFF
--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -17,6 +17,7 @@ import { FlatList } from 'react-native';
 import type { HvComponentProps } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import type { State } from './types';
+import { getAncestorByTagName } from 'hyperview/src/services';
 
 export default class HvList extends PureComponent<HvComponentProps, State> {
   static namespaceURI = Namespaces.HYPERVIEW;
@@ -71,11 +72,20 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
     const showScrollIndicator =
       this.props.element.getAttribute('shows-scroll-indicator') !== 'false';
 
-    const listProps = {
-      data: this.props.element.getElementsByTagNameNS(
+    const data = Array.from(
+      // $FlowFixMe: this.props.element is an `Element`, not a `Node`
+      this.props.element.getElementsByTagNameNS(
         Namespaces.HYPERVIEW,
-        'item',
+        LOCAL_NAME.ITEM,
       ),
+      // Prevent items from nested lists to be included during render
+    ).filter(
+      item =>
+        getAncestorByTagName(item, LOCAL_NAME.LIST) === this.props.element,
+    );
+
+    const listProps = {
+      data,
       horizontal,
       keyExtractor: item => item.getAttribute('key'),
       renderItem: ({ item }) =>

--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -60,6 +60,20 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
       });
   };
 
+  getItems = () => {
+    return Array.from(
+      this.props.element
+        // $FlowFixMe: this.props.element is an Element, not a Node
+        .getElementsByTagNameNS(Namespaces.HYPERVIEW, LOCAL_NAME.ITEM),
+    ).filter(
+      item =>
+        item.parentNode === this.props.element ||
+        (item.parentNode.tagName === LOCAL_NAME.ITEMS &&
+          item.parentNode.namespaceURI === Namespaces.HYPERVIEW &&
+          item.parentNode.parentNode === this.props.element),
+    );
+  };
+
   render() {
     const styleAttr = this.props.element.getAttribute('style');
     const style = styleAttr
@@ -71,20 +85,8 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
     const showScrollIndicator =
       this.props.element.getAttribute('shows-scroll-indicator') !== 'false';
 
-    const data = Array.from(
-      this.props.element
-        // $FlowFixMe: this.props.element is an Element, not a Node
-        .getElementsByTagNameNS(Namespaces.HYPERVIEW, LOCAL_NAME.ITEM),
-    ).filter(
-      item =>
-        item.parentNode === this.props.element ||
-        (item.parentNode.tagName === LOCAL_NAME.ITEMS &&
-          item.parentNode.namespaceURI === Namespaces.HYPERVIEW &&
-          item.parentNode.parentNode === this.props.element),
-    );
-
     const listProps = {
-      data,
+      data: this.getItems(),
       horizontal,
       keyExtractor: item => item && item.getAttribute('key'),
       renderItem: ({ item }) =>

--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -71,21 +71,17 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
     const showScrollIndicator =
       this.props.element.getAttribute('shows-scroll-indicator') !== 'false';
 
-    const itemsContainer =
-      this.props.element.firstChild &&
-      this.props.element.firstChild.tagName === LOCAL_NAME.ITEMS &&
-      this.props.element.firstChild.namespaceURI === Namespaces.HYPERVIEW
-        ? this.props.element.firstChild
-        : this.props.element;
-
-    const data = itemsContainer.childNodes
-      ? Array.from(itemsContainer.childNodes).filter(
-          item =>
-            item &&
-            item.tagName === LOCAL_NAME.ITEM &&
-            item.namespaceURI === Namespaces.HYPERVIEW,
-        )
-      : [];
+    const data = Array.from(
+      this.props.element
+        // $FlowFixMe: this.props.element is an Element, not a Node
+        .getElementsByTagNameNS(Namespaces.HYPERVIEW, LOCAL_NAME.ITEM),
+    ).filter(
+      item =>
+        item.parentNode === this.props.element ||
+        (item.parentNode.tagName === LOCAL_NAME.ITEMS &&
+          item.parentNode.namespaceURI === Namespaces.HYPERVIEW &&
+          item.parentNode.parentNode === this.props.element),
+    );
 
     const listProps = {
       data,

--- a/src/components/hv-list/index.test.js
+++ b/src/components/hv-list/index.test.js
@@ -1,0 +1,281 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { getDummyHvProps, getElements } from 'hyperview/test/helpers';
+import HvList from 'hyperview/src/components/hv-list';
+import { LOCAL_NAME } from 'hyperview/src/types';
+
+describe('HvList', () => {
+  describe('getItems', () => {
+    let items;
+    describe('simple list', () => {
+      beforeEach(() => {
+        const elements = getElements(
+          `
+            <doc xmlns="https://hyperview.org/hyperview">
+              <screen>
+                <body>
+                  <list>
+                    <item id="foo"/>
+                    <item id="bar"/>
+                    <item id="baz"/>
+                  </list>
+                </body>
+              </screen>
+            </doc>
+          `,
+          LOCAL_NAME.LIST,
+        );
+        const list = new HvList({
+          ...getDummyHvProps(),
+          element: elements[0],
+        });
+        items = list.getItems();
+      });
+      it('returns expected items count', async () => {
+        expect(items.length).toEqual(3);
+      });
+      it('returns expected items order', async () => {
+        expect(items[0].getAttribute('id')).toEqual('foo');
+        expect(items[1].getAttribute('id')).toEqual('bar');
+        expect(items[2].getAttribute('id')).toEqual('baz');
+      });
+    });
+    describe('nested lists', () => {
+      let elements;
+      beforeAll(() => {
+        elements = getElements(
+          `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <list>
+                  <item id="foo">
+                    <list>
+                      <item id="foo-foo"/>
+                      <item id="foo-bar"/>
+                    </list>
+                  </item>
+                  <item id="bar"/>
+                  <item id="baz"/>
+                </list>
+              </body>
+            </screen>
+          </doc>
+        `,
+          LOCAL_NAME.LIST,
+        );
+      });
+      describe('list 1', () => {
+        beforeAll(() => {
+          const list = new HvList({
+            ...getDummyHvProps(),
+            element: elements[0],
+          });
+          items = list.getItems();
+        });
+        it('returns expected items count', async () => {
+          expect(items.length).toEqual(3);
+        });
+        it('returns expected items order', async () => {
+          expect(items[0].getAttribute('id')).toEqual('foo');
+          expect(items[1].getAttribute('id')).toEqual('bar');
+          expect(items[2].getAttribute('id')).toEqual('baz');
+        });
+      });
+
+      describe('list 2', () => {
+        beforeAll(() => {
+          const list = new HvList({
+            ...getDummyHvProps(),
+            element: elements[1],
+          });
+          items = list.getItems();
+        });
+        it('returns expected items count', async () => {
+          expect(items.length).toEqual(2);
+        });
+        it('returns expected items order', async () => {
+          expect(items[0].getAttribute('id')).toEqual('foo-foo');
+          expect(items[1].getAttribute('id')).toEqual('foo-bar');
+        });
+      });
+    });
+    describe('paginated lists', () => {
+      let elements;
+      beforeAll(() => {
+        elements = getElements(
+          `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <list>
+                  <item id="foo"/>
+                  <item id="bar"/>
+                  <items>
+                    <item id="1-foo"/>
+                    <item id="1-bar"/>
+                    <item id="1-baz"/>
+                  </items>
+                  <items>
+                    <item id="2-foo"/>
+                    <item id="2-bar"/>
+                    <item id="2-baz"/>
+                  </items>
+                  <item id="baz"/>
+                </list>
+              </body>
+            </screen>
+          </doc>
+        `,
+          LOCAL_NAME.LIST,
+        );
+        const list = new HvList({
+          ...getDummyHvProps(),
+          element: elements[0],
+        });
+        items = list.getItems();
+      });
+      it('returns expected items count', async () => {
+        expect(items.length).toEqual(9);
+      });
+      it('returns expected items order', async () => {
+        expect(items[0].getAttribute('id')).toEqual('foo');
+        expect(items[1].getAttribute('id')).toEqual('bar');
+        expect(items[2].getAttribute('id')).toEqual('1-foo');
+        expect(items[3].getAttribute('id')).toEqual('1-bar');
+        expect(items[4].getAttribute('id')).toEqual('1-baz');
+        expect(items[5].getAttribute('id')).toEqual('2-foo');
+        expect(items[6].getAttribute('id')).toEqual('2-bar');
+        expect(items[7].getAttribute('id')).toEqual('2-baz');
+        expect(items[8].getAttribute('id')).toEqual('baz');
+      });
+    });
+    describe('paginated and nested lists', () => {
+      let elements;
+      beforeAll(() => {
+        elements = getElements(
+          `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <list>
+                  <item id="foo"/>
+                  <item id="bar">
+                    <list>
+                      <item id="bar-foo"/>
+                      <item id="bar-bar"/>
+                      <items>
+                        <item id="bar-1-foo"/>
+                        <item id="bar-1-bar"/>
+                        <item id="bar-1-baz"/>
+                      </items>
+                      <item id="bar-baz"/>
+                    </list>
+                  </item>
+                  <items>
+                    <item id="1-foo"/>
+                    <item id="1-bar"/>
+                    <item id="1-baz">
+                      <list>
+                        <item id="1-baz-foo"/>
+                        <item id="1-baz-bar"/>
+                        <items>
+                          <item id="1-baz-1-foo"/>
+                          <item id="1-baz-1-bar"/>
+                        </items>
+                        <item id="1-baz-baz"/>
+                      </list>
+                    </item>
+                  </items>
+                  <items>
+                    <item id="2-foo"/>
+                    <item id="2-bar"/>
+                    <item id="2-baz"/>
+                  </items>
+                  <item id="baz"/>
+                </list>
+              </body>
+            </screen>
+          </doc>
+        `,
+          LOCAL_NAME.LIST,
+        );
+        const list = new HvList({
+          ...getDummyHvProps(),
+          element: elements[0],
+        });
+        items = list.getItems();
+      });
+      describe('list 1', () => {
+        beforeAll(() => {
+          const list = new HvList({
+            ...getDummyHvProps(),
+            element: elements[0],
+          });
+          items = list.getItems();
+        });
+        it('returns expected items count', async () => {
+          expect(items.length).toEqual(9);
+        });
+        it('returns expected items order', async () => {
+          expect(items[0].getAttribute('id')).toEqual('foo');
+          expect(items[1].getAttribute('id')).toEqual('bar');
+          expect(items[2].getAttribute('id')).toEqual('1-foo');
+          expect(items[3].getAttribute('id')).toEqual('1-bar');
+          expect(items[4].getAttribute('id')).toEqual('1-baz');
+          expect(items[5].getAttribute('id')).toEqual('2-foo');
+          expect(items[6].getAttribute('id')).toEqual('2-bar');
+          expect(items[7].getAttribute('id')).toEqual('2-baz');
+          expect(items[8].getAttribute('id')).toEqual('baz');
+        });
+      });
+      describe('list 2', () => {
+        beforeAll(() => {
+          const list = new HvList({
+            ...getDummyHvProps(),
+            element: elements[1],
+          });
+          items = list.getItems();
+        });
+        it('returns expected items count', async () => {
+          expect(items.length).toEqual(6);
+        });
+        it('returns expected items order', async () => {
+          expect(items[0].getAttribute('id')).toEqual('bar-foo');
+          expect(items[1].getAttribute('id')).toEqual('bar-bar');
+          expect(items[2].getAttribute('id')).toEqual('bar-1-foo');
+          expect(items[3].getAttribute('id')).toEqual('bar-1-bar');
+          expect(items[4].getAttribute('id')).toEqual('bar-1-baz');
+          expect(items[5].getAttribute('id')).toEqual('bar-baz');
+        });
+      });
+      describe('list 3', () => {
+        beforeAll(() => {
+          const list = new HvList({
+            ...getDummyHvProps(),
+            element: elements[2],
+          });
+          items = list.getItems();
+        });
+        it('returns expected items count', async () => {
+          expect(items.length).toEqual(5);
+        });
+        it('returns expected items order', async () => {
+          expect(items[0].getAttribute('id')).toEqual('1-baz-foo');
+          expect(items[1].getAttribute('id')).toEqual('1-baz-bar');
+          expect(items[2].getAttribute('id')).toEqual('1-baz-1-foo');
+          expect(items[3].getAttribute('id')).toEqual('1-baz-1-bar');
+          expect(items[4].getAttribute('id')).toEqual('1-baz-baz');
+        });
+      });
+    });
+  });
+});

--- a/src/types.js
+++ b/src/types.js
@@ -22,6 +22,7 @@ export const LOCAL_NAME = {
   HEADER: 'header',
   IMAGE: 'image',
   ITEM: 'item',
+  ITEMS: 'items',
   LIST: 'list',
   MODIFIER: 'modifier',
   OPTION: 'option',

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,36 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import * as Namespaces from 'hyperview/src/services/namespaces';
+import type { Element, LocalName } from 'hyperview/src/types';
+import { DOMParser } from 'xmldom-instawork';
+
+const parser = new DOMParser();
+
+export const getElements = (
+  xml: string,
+  localName: LocalName,
+  namespaceURI: string = Namespaces.HYPERVIEW,
+): Element[] => {
+  const document = parser.parseFromString(xml);
+  return Array.from(document.getElementsByTagNameNS(namespaceURI, localName));
+};
+
+export const getDummyHvProps = () => ({
+  onUpdate: () => {},
+  options: {},
+  stylesheets: {
+    focused: [],
+    pressed: [],
+    pressedSelected: [],
+    regular: [],
+    selected: [],
+  },
+});


### PR DESCRIPTION
Render list items that are direct children of the `<list>` element, or nested under a `<items>` children node.