### PR TITLE
Fix paginated lists

### DIFF
--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -61,17 +61,32 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
   };
 
   getItems = () => {
+    const isOwnedBySelf = item => {
+      if (item.parentNode === this.props.element) {
+        return true;
+      }
+      if (
+        item.parentNode.tagName === LOCAL_NAME.ITEMS &&
+        item.parentNode.namespaceURI === Namespaces.HYPERVIEW &&
+        item.parentNode.parentNode === this.props.element
+      ) {
+        return true;
+      }
+      if (
+        item.parentNode.tagName === LOCAL_NAME.LIST &&
+        item.parentNode.namespaceURI === Namespaces.HYPERVIEW &&
+        item.parentNode.parentNode !== this.props.element
+      ) {
+        return false;
+      }
+      return isOwnedBySelf(item.parentNode);
+    };
+
     return Array.from(
       this.props.element
         // $FlowFixMe: this.props.element is an Element, not a Node
         .getElementsByTagNameNS(Namespaces.HYPERVIEW, LOCAL_NAME.ITEM),
-    ).filter(
-      item =>
-        item.parentNode === this.props.element ||
-        (item.parentNode.tagName === LOCAL_NAME.ITEMS &&
-          item.parentNode.namespaceURI === Namespaces.HYPERVIEW &&
-          item.parentNode.parentNode === this.props.element),
-    );
+    ).filter(isOwnedBySelf);
   };
 
   render() {

--- a/src/components/hv-list/index.test.js
+++ b/src/components/hv-list/index.test.js
@@ -123,11 +123,11 @@ describe('HvList', () => {
                     <item id="1-foo"/>
                     <item id="1-bar"/>
                     <item id="1-baz"/>
-                  </items>
-                  <items>
-                    <item id="2-foo"/>
-                    <item id="2-bar"/>
-                    <item id="2-baz"/>
+                    <items>
+                      <item id="2-foo"/>
+                      <item id="2-bar"/>
+                      <item id="2-baz"/>
+                    </items>
                   </items>
                   <item id="baz"/>
                 </list>


### PR DESCRIPTION
Follow up for #312.
One scenario with paginated lists was not accounted correctly. A paginated list could typically look like this:
```xml
<list>
  <item>1</item>
  <item>2</item>
  <items>
    <item>3</item>
    <item>4</item>
    <items>
      <item>5</item>
      <item>6</item>
      <items>
        ...
      </items>
    </items>
  </items>
</list>
```
Previous implementation did not account for recursive nesting aspect of `<items>`, and would only retrieve the items under the `<items>` directly nested under the main `<list>`.

This fixes it by recursively checking that the parent list is the same as our current element.