### PR TITLE
Fix: Set default color in all activity indicators

### DIFF
--- a/src/components/hv-spinner/index.js
+++ b/src/components/hv-spinner/index.js
@@ -24,7 +24,7 @@ export default class HvSpinner extends PureComponent<HvComponentProps> {
   props: HvComponentProps;
 
   render() {
-    const color = this.props.element.getAttribute('color') || undefined;
+    const color = this.props.element.getAttribute('color') || "#8d9494";
     return <ActivityIndicator color={color} />;
   }
 }

--- a/src/components/hv-web-view/index.js
+++ b/src/components/hv-web-view/index.js
@@ -42,7 +42,7 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
       this.props.stylesheets,
       this.props.options,
     );
-    const color = props['activity-indicator-color'];
+    const color = props['activity-indicator-color'] || "#8d9494";
     const injectedJavaScript = props['injected-java-script'];
     const source = { html: props.html, uri: props.url };
     return (


### PR DESCRIPTION
Apply default color for other `ActivityIndicators`

Reference: 
https://github.com/Instawork/hyperview/pull/275
https://github.com/Instawork/instawork/pull/13363/files#r667629321