### PR TITLE
Storybook render helper

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -17,7 +17,6 @@ node_modules/
 scripts/
 stories/
 storybook/
-test/
 tidy.cfg
 website/
 yarn-error.log

--- a/src/services/dom/helpers.js
+++ b/src/services/dom/helpers.js
@@ -9,7 +9,7 @@
  */
 
 import * as Namespaces from 'hyperview/src/services/namespaces';
-import type { Document, LocalName } from 'hyperview/src/types';
+import type { Document, LocalName, NamespaceURI } from 'hyperview/src/types';
 
 export const getBehaviorElements = (element: any) => {
   // $FlowFixMe
@@ -24,11 +24,12 @@ export const getBehaviorElements = (element: any) => {
   return behaviorElements;
 };
 
-export const getFirstTag = (document: Document, localName: LocalName) => {
-  const elements = document.getElementsByTagNameNS(
-    Namespaces.HYPERVIEW,
-    localName,
-  );
+export const getFirstTag = (
+  document: Document,
+  localName: LocalName,
+  namespace: NamespaceURI = Namespaces.HYPERVIEW,
+) => {
+  const elements = document.getElementsByTagNameNS(namespace, localName);
   if (elements && elements[0]) {
     return elements[0];
   }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -8,9 +8,14 @@
  *
  */
 
+import * as Components from 'hyperview/src/services/components';
+import * as Dom from 'hyperview/src/services/dom';
 import * as Namespaces from 'hyperview/src/services/namespaces';
-import type { Element, LocalName } from 'hyperview/src/types';
+import * as Stylesheets from 'hyperview/src/services/stylesheets';
+import type { Element, HvComponent, LocalName } from 'hyperview/src/types';
 import { DOMParser } from 'xmldom-instawork';
+import React from 'react';
+import { action } from '@storybook/addon-actions';
 
 const parser = new DOMParser();
 
@@ -34,3 +39,33 @@ export const getDummyHvProps = () => ({
     selected: [],
   },
 });
+
+export const render = (
+  Component: HvComponent,
+  template: string,
+  ComponentsRegistry: ?(HvComponent[]) = null,
+): ?HvComponent => {
+  const document = parser.parseFromString(template);
+  const element = Dom.getFirstTag(
+    document,
+    Component.localName,
+    Component.namespaceURI,
+  );
+  const stylesheets = Stylesheets.createStylesheets(document);
+  if (!element) {
+    return null;
+  }
+  return (
+    // $FlowFixMe: HvComponentStatics type mixin causes type inference issues
+    <Component
+      element={element}
+      onUpdate={action('action')}
+      options={{
+        componentRegistry: Components.getRegistry(
+          ComponentsRegistry || [Component],
+        ),
+      }}
+      stylesheets={stylesheets}
+    />
+  );
+};


### PR DESCRIPTION
Add renderer for stories from XML markup, and expose it to published NPM package. Supports defining optional dependent Hyperview components.

### Usage

**without dependent components:**
```js
import * as TestHelpers from 'hyperview/test/helpers';
import { storiesOf } from '@storybook/react-native';
import MyComponent from './MyComponent';

storiesOf('MyComponent', module)
  .add('Example story', () =>
    TestHelpers.render(
      MyComponent,
      '<my-component foo="bar" bar="baz" />',
    ),
  );
```

**with dependent components:**
```js
import * as TestHelpers from 'hyperview/test/helpers';
import { storiesOf } from '@storybook/react-native';
import MyComponent from './MyComponent';
import Foo from './Foo';
import Bar from './Bar';

storiesOf('MyComponent', module)
  .add('Example story', () =>
    TestHelpers.render(
      MyComponent,
      `
        <my-component foo="bar" bar="baz">
          <foo />
          <bar />
        </my-component>
      `,
      [MyComponent , Foo, Bar],
    ),
  );
```