### PR TITLE
Proposal: Allow overriding of `Loading` / `LoadError` / `RefreshControl` components

### DIFF
--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -11,9 +11,9 @@
 import * as Dom from 'hyperview/src/services/dom';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
+import { FlatList, RefreshControl } from 'react-native';
 import React, { PureComponent } from 'react';
 import { DOMParser } from 'xmldom-instawork';
-import { FlatList } from 'react-native';
 import type { HvComponentProps } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import type { State } from './types';
@@ -24,6 +24,8 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
   static localName = LOCAL_NAME.LIST;
 
   static localNameAliases = [];
+
+  static RefreshComponent = RefreshControl;
 
   parser: DOMParser = new DOMParser();
 
@@ -119,11 +121,14 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
 
     let refreshProps = {};
     if (this.props.element.getAttribute('trigger') === 'refresh') {
+      const { RefreshComponent } = this.constructor;
       refreshProps = {
-        onRefresh: () => {
-          this.refresh();
-        },
-        refreshing: this.state.refreshing,
+        refreshControl: (
+          <RefreshComponent
+            onRefresh={this.refresh}
+            refreshing={this.state.refreshing}
+          />
+        ),
       };
     }
 

--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -11,10 +11,10 @@
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
 import React, { PureComponent } from 'react';
+import { RefreshControl, SectionList } from 'react-native';
 import { DOMParser } from 'xmldom-instawork';
 import type { HvComponentProps } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
-import { SectionList } from 'react-native';
 import type { State } from './types';
 
 export default class HvSectionList extends PureComponent<
@@ -26,6 +26,8 @@ export default class HvSectionList extends PureComponent<
   static localName = LOCAL_NAME.SECTION_LIST;
 
   static localNameAliases = [];
+
+  static RefreshComponent = RefreshControl;
 
   parser: DOMParser = new DOMParser();
 
@@ -115,9 +117,14 @@ export default class HvSectionList extends PureComponent<
 
     let refreshProps = {};
     if (this.props.element.getAttribute('trigger') === 'refresh') {
+      const { RefreshComponent } = this.constructor;
       refreshProps = {
-        onRefresh: () => this.refresh(),
-        refreshing: this.state.refreshing,
+        refreshControl: (
+          <RefreshComponent
+            onRefresh={this.refresh}
+            refreshing={this.state.refreshing}
+          />
+        ),
       };
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,10 @@ export default class HyperScreen extends React.Component {
 
   static renderElement = Render.renderElement;
 
+  static LoadErrorComponent = LoadError;
+
+  static LoadingComponent = Loading;
+
   constructor(props) {
     super(props);
 
@@ -227,16 +231,20 @@ export default class HyperScreen extends React.Component {
    */
   render() {
     if (this.state.error) {
-      const errorScreen = this.props.errorScreen || LoadError;
-      return React.createElement(errorScreen, {
-        error: this.state.error,
-        onPressReload: () => this.reload(),  // Make sure reload() is called without any args
-        onPressViewDetails: (uri) => this.props.openModal({url: uri}),
-      });
+      // Backward support for deprectated prop `errorScreen`
+      const LoadErrorComponent = this.props.errorScreen || this.constructor.LoadErrorComponent;
+      return (
+        <LoadErrorComponent
+          error={this.state.error}
+          onPressReload={() => this.reload()}  // Make sure reload() is called without any args
+          onPressViewDetails={(uri) => this.props.openModal({url: uri})}
+        />
+      );
     }
     if (!this.state.doc) {
+      const { LoadingComponent } = this.constructor;
       return (
-        <Loading />
+        <LoadingComponent />
       );
     }
     const [body] = Array.from(this.state.doc.getElementsByTagNameNS(Namespaces.HYPERVIEW, 'body'));


### PR DESCRIPTION
Original intent is to allow customization of the pull to refresh UI - right now, it's not explicit at what point the user needs to pull in order to trigger the refresh. We could improve UX by indicating "pull some more" and "release now", or adding any custom animation.

This PR makes components used for rendering loading, load error and refresh states overridable by setting them as static properties of their parent components. The parent component can then be extended and used in place of the original component. It is aimed as a proposal to replace current limited support for custom error screen that uses `errorScreen` property.

I chose the approach of static properties / extensible classes over props, because the props from the root Hyperview component are not accessible to `HvList` and `HvSectionList` instances.

**Usage:**
For `Loading` / `LoadError`, it is as simple as extending the base `Hyperview` component, and redefining the static properties, then make sure to render the extended component instead of the original one.
i.e.

*before*
```js
import Hyperview from 'hyperview';

...

<Hyperview ... />
```

*after*
```js
import HyperviewCore from 'hyperview';
import Loading from './Loading';
import LoadError from './LoadError';

class Hyperview extends HyperviewCore {
  static LoadingComponent = Loading
  static LoadErrorComponent = LoadError;
}

...

<Hyperview ... />
```

For `RefreshControl`, this is done by extending the HvList / HvSectionList, and redefining the static property `RefreshComponent`, then re-register extended components (which will replace the default core component).
i.e.

```js
import { HvList as HvListCore, HvSectionList as HvSectionListCore } from 'hyperview';
import Refresh from './Refresh';

class HvList extends HvListCore {
  static RefreshComponent = Refresh;
}

class HvSectionList extends HvSectionListCore {
  static RefreshComponent = Refresh;
}

Hyperview.registerComponents([
  HvList,
  HvSectionList,
]);
```

TODO:
- [ ] Add support for replacing the default refresh control used in scroll views - this might need to be done by replacing the current `addHref` helper by an actual React component, that can also be overridden as a static property of `Hyperview`
- [ ] Update demo app to showcase overrides usage

Resolves https://github.com/Instawork/hyperview/issues/286