### PR TITLE
feat(schema): add "resizeMode" support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hyperview changelog
 
+**Version 0.41.0**
+- feat(schema): add `resizeMode` enumeration type
+- feat(schema): add `resizeMode` attribute to `<image>` and `<style>` elements
+
 **Version 0.30.2**
 
 - fix!: `style`, `show-during-load`, and `hide-during-load` attributes are now split on any whitespace, not just spaces.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperview",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "main": "lib/index.js",
   "description": "React Native client for Hyperview XML",
   "homepage": "https://hyperview.org",

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -379,6 +379,16 @@
     <xs:list itemType="xs:NCName" />
   </xs:simpleType>
 
+  <xs:simpleType name="resizeMode">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="cover" />
+      <xs:enumeration value="contain" />
+      <xs:enumeration value="stretch" />
+      <xs:enumeration value="repeat" />
+      <xs:enumeration value="center" />
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:group name="baseChildren">
     <xs:sequence>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
@@ -757,6 +767,8 @@
       <xs:attribute name="width" type="hv:pointsOrPercent" />
       <xs:attribute name="zIndex" type="xs:positiveInteger" />
 
+      <xs:attribute name="resizeMode" type="hv:resizeMode" />
+
     </xs:complexType>
   </xs:element>
 
@@ -814,6 +826,7 @@
       <xs:attribute name="style" type="hv:styleList" use="required" />
       <xs:attribute name="id" type="hv:ID" />
       <xs:attribute name="hide" type="xs:boolean" />
+      <xs:attribute name="resizeMode" type="hv:resizeMode" />
       <xs:attribute name="value" type="xs:string" />
       <xs:attributeGroup ref="hv:behaviorAttributes" />
     </xs:complexType>


### PR DESCRIPTION
# Summary
- add `resizeMode` enumeration type
- add `resizeMode` attribute to `<image>` and `<style>` elements

Verified locally via `be_valid_hyperview` expectation in a python unit test