### PR TITLE
Fix: undo hardcoded activity indicator color

### DIFF
--- a/src/components/hv-spinner/index.js
+++ b/src/components/hv-spinner/index.js
@@ -24,7 +24,7 @@ export default class HvSpinner extends PureComponent<HvComponentProps> {
   props: HvComponentProps;
 
   render() {
-    const color = this.props.element.getAttribute('color') || "#8d9494";
+    const color = this.props.element.getAttribute('color') || '#8d9494';
     return <ActivityIndicator color={color} />;
   }
 }

--- a/src/components/hv-spinner/index.js
+++ b/src/components/hv-spinner/index.js
@@ -24,7 +24,7 @@ export default class HvSpinner extends PureComponent<HvComponentProps> {
   props: HvComponentProps;
 
   render() {
-    const color = this.props.element.getAttribute('color') || undefined;
+    const color = this.props.element.getAttribute('color') || "#8d9494";
     return <ActivityIndicator color={color} />;
   }
 }

--- a/src/components/hv-web-view/index.js
+++ b/src/components/hv-web-view/index.js
@@ -42,7 +42,7 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
       this.props.stylesheets,
       this.props.options,
     );
-    const color = props['activity-indicator-color'];
+    const color = props['activity-indicator-color'] || "#8d9494";
     const injectedJavaScript = props['injected-java-script'];
     const source = { html: props.html, uri: props.url };
     return (

--- a/src/components/hv-web-view/index.js
+++ b/src/components/hv-web-view/index.js
@@ -42,7 +42,7 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
       this.props.stylesheets,
       this.props.options,
     );
-    const color = props['activity-indicator-color'] || "#8d9494";
+    const color = props['activity-indicator-color'] || '#8d9494';
     const injectedJavaScript = props['injected-java-script'];
     const source = { html: props.html, uri: props.url };
     return (

--- a/src/core/components/loading/index.js
+++ b/src/core/components/loading/index.js
@@ -19,7 +19,7 @@ export default class Loading extends PureComponent<Props> {
   render() {
     return (
       <View style={styles.container}>
-        <ActivityIndicator color="#8d9494" />
+        <ActivityIndicator />
       </View>
     );
   }


### PR DESCRIPTION
Undoing the change in https://github.com/Instawork/hyperview/pull/275 since we wrote a patch in the client app instead.
[Ref 1](https://github.com/Instawork/hyperview/pull/324#issuecomment-878450708)

Context:
React Native 0.63 does not have a default color for ActivityIndicator on Android. See [reference](https://github.com/facebook/react-native/pull/30057) for creating a patch on the client app.