### PR TITLE
fix(render): Set `key` prop when matching attribute is present

### DIFF
--- a/src/services/render/index.js
+++ b/src/services/render/index.js
@@ -67,12 +67,23 @@ export const renderElement = (
     ) {
       const Component =
         options.componentRegistry[element.namespaceURI][element.localName];
+
+      // Use object spreading instead of explicitly setting the key (to potentially undefined values)
+      // Explicitly setting the key causes collision when several components render with `undefined` value for `key`
+      // Object spreading will define the prop only when its value is truthy
+      const extraProps = {
+        key: element.getAttribute('key'),
+      };
+      if (!extraProps.key) {
+        delete extraProps.key;
+      }
       return (
         <Component
           element={element}
           onUpdate={onUpdate}
           options={options}
           stylesheets={stylesheets}
+          {...extraProps} // eslint-disable-line react/jsx-props-no-spreading
         />
       );
     }


### PR DESCRIPTION
Setting the `key` prop ensures the component will be re-instantiated on re-render, if the matching tree element key does not match. This change permits to control this React behavior from our XML templates.

Relates to https://app.asana.com/0/1173738217633521/1200975979949916/f and https://github.com/Instawork/instawork/pull/14057