### PR TITLE
Add support for "change" trigger on text-area and text-field

### DIFF
--- a/docs/reference_behavior_attributes.md
+++ b/docs/reference_behavior_attributes.md
@@ -27,9 +27,9 @@ The rest of the document describes in-depth how these attributes work together.
 
 ## trigger
 
-| Type                                                                                                              | Required |
-| ----------------------------------------------------------------------------------------------------------------- | -------- |
-| **press** (default), longPress, pressIn, pressOut, visible, refresh, load, select, deselect, focus, blur, on-event | No       |
+| Type                                                                                                                       | Required |
+| -------------------------------------------------------------------------------------------------------------------------- | -------- |
+| **press** (default), longPress, pressIn, pressOut, visible, refresh, load, select, deselect, focus, blur, change, on-event | No       |
 
 ### `press`
 
@@ -135,6 +135,15 @@ These elements support the `focus` trigger:
 Triggers when the element loses focus. Only works on focusable elements.
 
 These elements support the `blur` trigger:
+
+- [`<text-field>`](/docs/reference_textfield)
+- [`<text-area>`](/docs/reference_textarea)
+
+### `change`
+
+Triggers when the element value changes. Only works on editable elements.
+
+These elements support the `change` trigger:
 
 - [`<text-field>`](/docs/reference_textfield)
 - [`<text-area>`](/docs/reference_textarea)

--- a/docs/reference_behavior_attributes.md
+++ b/docs/reference_behavior_attributes.md
@@ -143,7 +143,8 @@ These elements support the `blur` trigger:
 
 Triggers when the element value changes. Only works on editable elements.
 
-> **NOTE**: Elements with a `mask` do trigger the behavior for not allowed characters as well.
+> **NOTE**: when using the `change` trigger on a `<text-field>` that include the `mask` attribute, the behavior will be triggered even if the mask prevents the pressed key from being set.
+
 
 These elements support the `change` trigger:
 

--- a/docs/reference_behavior_attributes.md
+++ b/docs/reference_behavior_attributes.md
@@ -143,6 +143,8 @@ These elements support the `blur` trigger:
 
 Triggers when the element value changes. Only works on editable elements.
 
+> **NOTE**: Elements with a `mask` do trigger the behavior for not allowed characters as well.
+
 These elements support the `change` trigger:
 
 - [`<text-field>`](/docs/reference_textfield)

--- a/docs/reference_textarea.md
+++ b/docs/reference_textarea.md
@@ -40,8 +40,9 @@ A `<text-area>` element can appear anywhere within a `<form>` element.
 
 A `<text-area>` element accepts the standard [behavior attributes](/docs/reference_behavior_attributes), including the following triggers:
 
-- [focus](#focus)
-- [blur](#blur)
+- [blur](/docs/reference_behavior_attributes#blur)
+- [change](/docs/reference_behavior_attributes#change)
+- [focus](/docs/reference_behavior_attributes#focus)
 
 #### `name`
 

--- a/docs/reference_textarea.md
+++ b/docs/reference_textarea.md
@@ -8,10 +8,7 @@ The `<text-area>` element represents multi-line input fields. When pressed, the 
 
 ```xml
 <screen>
-  <text-area
-    name="feedback"
-    placeholder="Please leave your feedback"
-  />
+  <text-area name="feedback" placeholder="Please leave your feedback" />
 </screen>
 ```
 
@@ -96,8 +93,8 @@ If `hide="true"`, the element will not be rendered on screen. If the element or 
 
 ## `text-content-type` (iOS)
 
-| Type                                                                                                                                                                                                                                                                                                                                                                                            | Required |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| **none** (default), none, URL, addressCity, addressCityAndState, addressState, countryName, creditCardNumber, emailAddress, familyName, fullStreetAddress, givenName, jobTitle, location, middleName, name, namePrefix, nameSuffix, nickname, organizationName, postalCode, streetAddressLine1, streetAddressLine2, sublocality, telephoneNumber, username, password, newPassword, oneTimeCode  | No       |
+| Type                                                                                                                                                                                                                                                                                                                                                                                           | Required |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| **none** (default), none, URL, addressCity, addressCityAndState, addressState, countryName, creditCardNumber, emailAddress, familyName, fullStreetAddress, givenName, jobTitle, location, middleName, name, namePrefix, nameSuffix, nickname, organizationName, postalCode, streetAddressLine1, streetAddressLine2, sublocality, telephoneNumber, username, password, newPassword, oneTimeCode | No       |
 
 The `text-content-type` autofills available fields (for example, for iOS 12+ `oneTimeCode` can be used to indicate that a field can be autofilled by a code arriving in an SMS).

--- a/docs/reference_textfield.md
+++ b/docs/reference_textfield.md
@@ -43,8 +43,9 @@ A `<text-field>` element can appear anywhere within a `<form>` element.
 
 A `<text-field>` element accepts the standard [behavior attributes](/docs/reference_behavior_attributes), including the following triggers:
 
-- [focus](#focus)
-- [blur](#blur)
+- [blur](/docs/reference_behavior_attributes#blur)
+- [change](/docs/reference_behavior_attributes#change)
+- [focus](/docs/reference_behavior_attributes#focus)
 
 #### `name`
 

--- a/docs/reference_textfield.md
+++ b/docs/reference_textfield.md
@@ -8,11 +8,7 @@ The `<text-field>` element represents a single-line input field. When pressed, t
 
 ```xml
 <form>
-  <text-field
-    name="name"
-    placeholder="Your name"
-    value="Bart"
-  />
+  <text-field name="name" placeholder="Your name" value="Bart" />
   <text-field
     name="phone"
     placeholder="Your phone number"
@@ -150,8 +146,8 @@ If `secure-text="true"`, the input in the text field will be obscured. Appropria
 
 ## `text-content-type` (iOS)
 
-| Type                                                                                                                                                                                                                                                                                                                                                                                            | Required |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| **none** (default), none, URL, addressCity, addressCityAndState, addressState, countryName, creditCardNumber, emailAddress, familyName, fullStreetAddress, givenName, jobTitle, location, middleName, name, namePrefix, nameSuffix, nickname, organizationName, postalCode, streetAddressLine1, streetAddressLine2, sublocality, telephoneNumber, username, password, newPassword, oneTimeCode  | No       |
+| Type                                                                                                                                                                                                                                                                                                                                                                                           | Required |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| **none** (default), none, URL, addressCity, addressCityAndState, addressState, countryName, creditCardNumber, emailAddress, familyName, fullStreetAddress, givenName, jobTitle, location, middleName, name, namePrefix, nameSuffix, nickname, organizationName, postalCode, streetAddressLine1, streetAddressLine2, sublocality, telephoneNumber, username, password, newPassword, oneTimeCode | No       |
 
 The `text-content-type` autofills available fields (for example, for iOS 12+ `oneTimeCode` can be used to indicate that a field can be autofilled by a code arriving in an SMS).

--- a/examples/behaviors/blur.xml
+++ b/examples/behaviors/blur.xml
@@ -80,7 +80,7 @@
       <view scroll="true" style="Main">
         <text style="Description">
           When a text field loses focus, the content in the container
-          will re replaced.
+          will be replaced.
         </text>
         <view id="container1" style="Container" />
         <view style="FormGroup">
@@ -111,7 +111,7 @@
         </view>
         <text style="Description">
           When a text area loses focus, the content in the container
-          will re replaced.
+          will be replaced.
         </text>
         <view style="FormGroup">
           <text style="Label">Input area 1</text>

--- a/examples/behaviors/change.xml
+++ b/examples/behaviors/change.xml
@@ -1,0 +1,196 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style
+        id="Header"
+        alignItems="center"
+        backgroundColor="white"
+        borderBottomColor="#eee"
+        borderBottomWidth="1"
+        flexDirection="row"
+        paddingLeft="24"
+        paddingRight="24"
+        paddingBottom="16"
+      />
+      <style
+        id="Header__Back"
+        color="blue"
+        fontSize="16"
+        fontWeight="600"
+        paddingRight="16"
+      />
+      <style id="Header__Title" color="black" fontSize="24" fontWeight="600" />
+      <style id="Body" backgroundColor="white" flex="1" />
+      <style id="Main" flex="1" />
+      <style
+        id="Description"
+        fontSize="16"
+        fontWeight="normal"
+        margin="24"
+        marginBottom="0"
+      />
+      <style
+        id="Container"
+        borderColor="#e1e1e1"
+        borderRadius="16"
+        borderWidth="2"
+        margin="24"
+        padding="24"
+      />
+      <style
+        id="FormGroup"
+        flex="1"
+        marginLeft="24"
+        marginRight="24"
+        marginTop="24"
+      />
+      <style
+        id="Label"
+        borderColor="#4E4D4D"
+        fontSize="16"
+        fontWeight="bold"
+        lineHeight="24"
+        marginBottom="8"
+      />
+      <style
+        id="Input"
+        borderBottomColor="#E1E1E1"
+        borderBottomWidth="1"
+        borderColor="#4E4D4D"
+        flex="1"
+        fontSize="16"
+        fontWeight="normal"
+        paddingBottom="8"
+        paddingTop="8"
+      >
+        <modifier pressed="true">
+          <style borderBottomColor="green" />
+        </modifier>
+        <modifier focused="true">
+          <style borderBottomColor="#4778FF" />
+        </modifier>
+      </style>
+      <style id="Tip" color="#FF4847" fontSize="16" />
+    </styles>
+    <body style="Body" safe-area="true">
+      <header style="Header">
+        <text action="back" href="#" style="Header__Back">Back</text>
+        <text style="Header__Title">Change</text>
+      </header>
+      <view scroll="true" style="Main">
+        <text style="Description">
+          When a text field changes its value, the content in the container
+          will re replaced.
+        </text>
+        <view id="container1" style="Container" />
+        <view style="FormGroup">
+          <text style="Label">Input field 1</text>
+          <text-field
+            action="replace-inner"
+            href="#field1Changed"
+            name="text"
+            placeholder="First name"
+            placeholderTextColor="#8D9494"
+            style="Input"
+            target="container1"
+            trigger="change"
+          />
+        </view>
+        <view style="FormGroup">
+          <text style="Label">Input field 2</text>
+          <text-field
+            action="replace-inner"
+            href="#field2Changed"
+            name="text"
+            placeholder="Last name"
+            placeholderTextColor="#8D9494"
+            style="Input"
+            target="container1"
+            trigger="change"
+          />
+        </view>
+        <view style="FormGroup">
+          <text style="Label">Input field with auto-focus</text>
+          <text-field
+            action="replace-inner"
+            href="#fieldAutoFocusChanged"
+            name="text"
+            placeholder="Auto focused"
+            placeholderTextColor="#8D9494"
+            style="Input"
+            target="container1"
+            trigger="change"
+            auto-focus="true"
+          />
+        </view>
+        <view style="FormGroup">
+          <text style="Label">Input field with mask</text>
+          <text-field
+            action="replace-inner"
+            href="#fieldMaskChanged"
+            name="text"
+            placeholder="Phone number"
+            placeholderTextColor="#8D9494"
+            style="Input"
+            target="container1"
+            trigger="change"
+            mask="(999) 999-9999"
+          />
+        </view>
+        <view style="FormGroup">
+          <text style="Label">Input field with secure-text</text>
+          <text-field
+            action="replace-inner"
+            href="#fieldSecureTextChanged"
+            name="text"
+            placeholder="Password"
+            placeholderTextColor="#8D9494"
+            style="Input"
+            target="container1"
+            trigger="change"
+            secure-text="true"
+          />
+        </view>
+        <text style="Description">
+          When a text area loses focus, the content in the container
+          will re replaced.
+        </text>
+        <view style="FormGroup">
+          <text style="Label">Input area 1</text>
+          <text-area
+            action="replace-inner"
+            href="#area1Changed"
+            name="feedback"
+            placeholder="Please leave your feedback"
+            placeholderTextColor="#8D9494"
+            style="Input"
+            target="container1"
+            trigger="change"
+          />
+        </view>
+        <view style="FormGroup">
+          <text style="Label">Input area 2</text>
+          <text-area
+            action="replace-inner"
+            href="#area2Changed"
+            name="feedback"
+            placeholder="Please leave your feedback"
+            placeholderTextColor="#8D9494"
+            style="Input"
+            target="container1"
+            trigger="change"
+          />
+        </view>
+      </view>
+      <view hide="true">
+        <text id="field1Changed" style="Tip">Field 1 changed</text>
+        <text id="field2Changed" style="Tip">Field 2 changed</text>
+        <text id="fieldAutoFocusChanged" style="Tip">Field with auto-focus changed</text>
+        <text id="fieldMaskChanged" style="Tip">Field with mask changed</text>
+        <text id="fieldSecureTextChanged" style="Tip">Field with secure-text changed</text>
+        <text id="area1Changed" style="Tip">Area 1 changed</text>
+        <text id="area2Changed" style="Tip">Area 2 changed</text>
+      </view>
+    </body>
+  </screen>
+</doc>

--- a/examples/behaviors/change.xml
+++ b/examples/behaviors/change.xml
@@ -80,7 +80,7 @@
       <view scroll="true" style="Main">
         <text style="Description">
           When a text field changes its value, the content in the container
-          will re replaced.
+          will be replaced.
         </text>
         <view id="container1" style="Container" />
         <view style="FormGroup">
@@ -153,7 +153,7 @@
         </view>
         <text style="Description">
           When a text area loses focus, the content in the container
-          will re replaced.
+          will be replaced.
         </text>
         <view style="FormGroup">
           <text style="Label">Input area 1</text>

--- a/examples/behaviors/change.xml
+++ b/examples/behaviors/change.xml
@@ -185,9 +185,15 @@
       <view hide="true">
         <text id="field1Changed" style="Tip">Field 1 changed</text>
         <text id="field2Changed" style="Tip">Field 2 changed</text>
-        <text id="fieldAutoFocusChanged" style="Tip">Field with auto-focus changed</text>
+        <text
+          id="fieldAutoFocusChanged"
+          style="Tip"
+        >Field with auto-focus changed</text>
         <text id="fieldMaskChanged" style="Tip">Field with mask changed</text>
-        <text id="fieldSecureTextChanged" style="Tip">Field with secure-text changed</text>
+        <text
+          id="fieldSecureTextChanged"
+          style="Tip"
+        >Field with secure-text changed</text>
         <text id="area1Changed" style="Tip">Area 1 changed</text>
         <text id="area2Changed" style="Tip">Area 2 changed</text>
       </view>

--- a/examples/behaviors/index.xml
+++ b/examples/behaviors/index.xml
@@ -243,6 +243,15 @@
             <text style="Item__Label">Blur</text>
             <text style="Item__Chevron">&gt;</text>
           </item>
+          <item
+            href="/behaviors/change.xml"
+            key="change"
+            show-during-load="loadingScreen"
+            style="Item"
+          >
+            <text style="Item__Label">Change</text>
+            <text style="Item__Chevron">&gt;</text>
+          </item>
         </section>
         <section>
           <section-title style="List__Header">

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -121,6 +121,7 @@
       <xs:enumeration value="focus" />
       <xs:enumeration value="blur" />
       <xs:enumeration value="on-event" />
+      <xs:enumeration value="change" />
     </xs:restriction>
   </xs:simpleType>
 

--- a/src/components/hv-text-area/index.js
+++ b/src/components/hv-text-area/index.js
@@ -36,37 +36,23 @@ export default class HvTextArea extends PureComponent<HvComponentProps> {
   }
 
   triggerFocusBehaviors = (newElement: Element) => {
-    const behaviorElements = Dom.getBehaviorElements(this.props.element);
-    const focusBehaviors = behaviorElements.filter(
-      e => e.getAttribute('trigger') === 'focus',
-    );
-    focusBehaviors.forEach(behaviorElement => {
-      const href = behaviorElement.getAttribute('href');
-      const action = behaviorElement.getAttribute('action');
-      const verb = behaviorElement.getAttribute('verb');
-      const targetId = behaviorElement.getAttribute('target');
-      const showIndicatorIds = behaviorElement.getAttribute('show-during-load');
-      const hideIndicatorIds = behaviorElement.getAttribute('hide-during-load');
-      const delay = behaviorElement.getAttribute('delay');
-      const once = behaviorElement.getAttribute('once');
-      this.props.onUpdate(href, action, newElement, {
-        behaviorElement,
-        delay,
-        hideIndicatorIds,
-        once,
-        showIndicatorIds,
-        targetId,
-        verb,
-      });
-    });
+    this.triggerBehaviors(newElement, 'focus');
   };
 
   triggerBlurBehaviors = (newElement: Element) => {
+    this.triggerBehaviors(newElement, 'blur');
+  };
+
+  triggerChangeBehaviors = (newElement: Element) => {
+    this.triggerBehaviors(newElement, 'change');
+  };
+
+  triggerBehaviors = (newElement: Element, triggerName: string) => {
     const behaviorElements = Dom.getBehaviorElements(this.props.element);
-    const blurBehaviors = behaviorElements.filter(
-      e => e.getAttribute('trigger') === 'blur',
+    const matchingBehaviors = behaviorElements.filter(
+      e => e.getAttribute('trigger') === triggerName,
     );
-    blurBehaviors.forEach(behaviorElement => {
+    matchingBehaviors.forEach(behaviorElement => {
       const href = behaviorElement.getAttribute('href');
       const action = behaviorElement.getAttribute('action');
       const verb = behaviorElement.getAttribute('verb');
@@ -124,6 +110,7 @@ export default class HvTextArea extends PureComponent<HvComponentProps> {
         const newElement = this.props.element.cloneNode(true);
         newElement.setAttribute('value', value);
         this.props.onUpdate(null, 'swap', this.props.element, { newElement });
+        this.triggerChangeBehaviors(newElement);
       },
       onFocus: () => this.setFocus(true),
       ref: this.props.options.registerInputHandler,

--- a/src/components/hv-text-field/index.js
+++ b/src/components/hv-text-field/index.js
@@ -37,37 +37,23 @@ export default class HvTextField extends PureComponent<HvComponentProps> {
   }
 
   triggerFocusBehaviors = (newElement: Element) => {
-    const behaviorElements = Dom.getBehaviorElements(this.props.element);
-    const focusBehaviors = behaviorElements.filter(
-      e => e.getAttribute('trigger') === 'focus',
-    );
-    focusBehaviors.forEach(behaviorElement => {
-      const href = behaviorElement.getAttribute('href');
-      const action = behaviorElement.getAttribute('action');
-      const verb = behaviorElement.getAttribute('verb');
-      const targetId = behaviorElement.getAttribute('target');
-      const showIndicatorIds = behaviorElement.getAttribute('show-during-load');
-      const hideIndicatorIds = behaviorElement.getAttribute('hide-during-load');
-      const delay = behaviorElement.getAttribute('delay');
-      const once = behaviorElement.getAttribute('once');
-      this.props.onUpdate(href, action, newElement, {
-        behaviorElement,
-        delay,
-        hideIndicatorIds,
-        once,
-        showIndicatorIds,
-        targetId,
-        verb,
-      });
-    });
+    this.triggerBehaviors(newElement, 'focus');
   };
 
   triggerBlurBehaviors = (newElement: Element) => {
+    this.triggerBehaviors(newElement, 'blur');
+  };
+
+  triggerChangeBehaviors = (newElement: Element) => {
+    this.triggerBehaviors(newElement, 'change');
+  };
+
+  triggerBehaviors = (newElement: Element, triggerName: string) => {
     const behaviorElements = Dom.getBehaviorElements(this.props.element);
-    const blurBehaviors = behaviorElements.filter(
-      e => e.getAttribute('trigger') === 'blur',
+    const matchingBehaviors = behaviorElements.filter(
+      e => e.getAttribute('trigger') === triggerName,
     );
-    blurBehaviors.forEach(behaviorElement => {
+    matchingBehaviors.forEach(behaviorElement => {
       const href = behaviorElement.getAttribute('href');
       const action = behaviorElement.getAttribute('action');
       const verb = behaviorElement.getAttribute('verb');
@@ -146,6 +132,7 @@ export default class HvTextField extends PureComponent<HvComponentProps> {
         const newElement = this.props.element.cloneNode(true);
         newElement.setAttribute('value', formattedValue);
         this.props.onUpdate(null, 'swap', this.props.element, { newElement });
+        this.triggerChangeBehaviors(newElement);
       },
       onFocus: () => this.setFocus(true),
       ref: this.props.options.registerInputHandler,


### PR DESCRIPTION
In addition to the `blur` and `focus` triggers, add support for `change` so we can for instance, update a part of the UI when the user types in a text field or text area.

Partial implementation of https://github.com/Instawork/hyperview/issues/298 but doesn't handle the dirty/clean states.