### PR TITLE
Fix broken favicon image

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -37,7 +37,7 @@ const siteConfig = {
   /* path to images for header/footer */
   headerIcon: 'img/hv.svg',
   footerIcon: 'img/hv.svg',
-  favicon: 'img/hv.png',
+  favicon: 'img/hv.svg',
 
   /* Colors for website */
   colors: {


### PR DESCRIPTION
The current favicon [`img/hv.png`](https://hyperview.org/img/hv.png) does not exist, it should be [`img/hv.svg`](https://hyperview.org/img/hv.svg).