### PR TITLE
feat(text): allow adjustsFontSizeToFit attribute on <text> elements 

### DIFF
--- a/docs/reference_text.md
+++ b/docs/reference_text.md
@@ -107,4 +107,4 @@ A boolean that allows users to select the content of `<text>` element.
 | ------- | -------- | 
 | boolean | No       | 
 
-If `adjustsFontSize="true"`, fonts will be scaled down automatically to fit given style constraints.
+If `adjustsFontSizeToFit="true"`, fonts will be scaled down automatically to fit given style constraints.

--- a/docs/reference_text.md
+++ b/docs/reference_text.md
@@ -101,3 +101,10 @@ If `hide="true"`, the element will not be rendered on screen. If the element or 
 | boolean | No       |
 
 A boolean that allows users to select the content of `<text>` element.
+
+#### `adjustsFontSizeToFit`
+| Type    | Required | 
+| ------- | -------- | 
+| boolean | No       | 
+
+If `adjustsFontSize="true"`, fonts will be scaled down automatically to fit given style constraints.

--- a/examples/ui_elements/text.xml
+++ b/examples/ui_elements/text.xml
@@ -75,7 +75,10 @@
 <![CDATA[Escaped with <![CDATA[]>: <hello><world>]]>
         </text>
         <text style="Basic" selectable="true">Select me!</text>
-        <text style="Basic" adjustsFontSizeToFit="true">Adjustable Font Size</text>
+        <text
+          style="Basic"
+          adjustsFontSizeToFit="true"
+        >Adjustable Font Size</text>
       </view>
     </body>
   </screen>

--- a/examples/ui_elements/text.xml
+++ b/examples/ui_elements/text.xml
@@ -75,6 +75,7 @@
 <![CDATA[Escaped with <![CDATA[]>: <hello><world>]]>
         </text>
         <text style="Basic" selectable="true">Select me!</text>
+        <text style="Basic" adjustsFontSizeToFit="true">Adjustable Font Size</text>
       </view>
     </body>
   </screen>

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -854,6 +854,7 @@
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="selectable" type="xs:boolean" />
       <xs:attribute name="value" type="xs:string" />
+      <xs:attribute name="adjustsFontSizeToFit" type="xs:boolean" />
       <xs:attributeGroup ref="hv:behaviorAttributes" />
     </xs:complexType>
   </xs:element>

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -105,7 +105,7 @@ export const createProps = (
   options: HvComponentOptions,
 ) => {
   const numericRules = ['numberOfLines'];
-  const booleanRules = ['multiline', 'selectable'];
+  const booleanRules = ['multiline', 'selectable', 'adjustsFontSizeToFit'];
 
   const props = {};
   if (!element.attributes) {


### PR DESCRIPTION
This will allow `<text>` elements to scale down automatically to fit given style constraints.