### PR TITLE
Fix picker-field cancel on iOS

### DIFF
--- a/src/components/hv-picker-field/index.js
+++ b/src/components/hv-picker-field/index.js
@@ -172,7 +172,10 @@ export default class HvPickerField extends PureComponent<
     const props = {
       onValueChange: (value: any) => {
         this.setState({ pickerValue: value });
-        this.props.element.setAttribute('value', value || '');
+        if (Platform.OS === 'android') {
+          // On Android, the value should be propagated immediately.
+          this.props.element.setAttribute('value', value || '');
+        }
       },
       selectedValue: this.state.pickerValue,
       style,


### PR DESCRIPTION
There's a history of issues with `<picker-field>` due to different implementations on iOS vs Android:
- https://github.com/Instawork/hyperview/pull/173
- https://github.com/Instawork/hyperview/pull/208
- https://github.com/Instawork/hyperview/pull/224

On Android, changes to values from the picker should apply immediately, there is no "Cancel".
On iOS, changes should not apply immediately because we've implemented our own modal.

Previous attempts to fix the issue have not been platform-aware. By checking the platform, we can use the right approach to fix issues on both platforms.