### PR TITLE
feat: Render XML server errors

### DIFF
--- a/src/services/dom/parser.js
+++ b/src/services/dom/parser.js
@@ -79,7 +79,9 @@ export class Parser {
 
     const response: Response = await this.fetch(url, options);
     const responseText: string = await response.text();
-    const contentType: string = response.headers.get(HTTP_HEADERS.CONTENT_TYPE);
+    const contentType: string = response.headers?.get(
+      HTTP_HEADERS.CONTENT_TYPE,
+    );
     if (
       response.status >= 500 &&
       contentType !== CONTENT_TYPE.APPLICATION_XML

--- a/src/services/dom/parser.js
+++ b/src/services/dom/parser.js
@@ -79,8 +79,11 @@ export class Parser {
 
     const response: Response = await this.fetch(url, options);
     const responseText: string = await response.text();
-
-    if (response.status >= 500) {
+    const contentType: string = response.headers.get(HTTP_HEADERS.CONTENT_TYPE);
+    if (
+      response.status >= 500 &&
+      contentType !== CONTENT_TYPE.APPLICATION_XML
+    ) {
       throw new Errors.ServerError(
         url,
         responseText,


### PR DESCRIPTION
Before throwing a `Errors.ServerError`, which results in rendering a webview with the error content when in dev mode, or a generic error message, verify if the content-type is `application/xml`. When it is the case, render the XML document like any other screens.