### PR TITLE
feat: improve `Accept` header

### DIFF
--- a/src/services/dom/index.test.js
+++ b/src/services/dom/index.test.js
@@ -52,7 +52,7 @@ describe('Parser', () => {
         const expectedOptions = {
           body: undefined,
           headers: {
-            Accept: 'application/xml',
+            Accept: 'application/xml, application/vnd.hyperview+xml',
             'X-Hyperview-Dimensions': '750w 1334h',
             'X-Hyperview-Version': version,
           },
@@ -92,7 +92,7 @@ describe('Parser', () => {
         expect(fetchMock).toHaveBeenCalledWith(expectedUrl, {
           body: undefined,
           headers: {
-            Accept: 'application/xml',
+            Accept: 'application/xml, application/vnd.hyperview+xml',
             'X-Hyperview-Dimensions': '750w 1334h',
             'X-Hyperview-Version': version,
           },
@@ -120,7 +120,7 @@ describe('Parser', () => {
         expect(fetchMock).toHaveBeenCalledWith(url, {
           body: data,
           headers: {
-            Accept: 'application/xml',
+            Accept: 'application/xml, application/vnd.hyperview+xml',
             'X-Hyperview-Dimensions': '750w 1334h',
             'X-Hyperview-Version': version,
           },

--- a/src/services/dom/parser.js
+++ b/src/services/dom/parser.js
@@ -20,11 +20,6 @@ import { getFirstTag } from './helpers';
 import { version } from 'hyperview/package.json';
 
 const { width, height } = Dimensions.get('window');
-const headers = {
-  [HTTP_HEADERS.ACCEPT]: CONTENT_TYPE.APPLICATION_XML,
-  [HTTP_HEADERS.X_HYPERVIEW_VERSION]: version,
-  [HTTP_HEADERS.X_HYPERVIEW_DIMENSIONS]: `${width}w ${height}h`,
-};
 
 const parser = new DOMParser({
   errorHandler: {
@@ -62,6 +57,7 @@ export class Parser {
     baseUrl: string,
     data: ?FormData,
     method: ?HttpMethod = HTTP_METHODS.GET,
+    acceptContentType: string = CONTENT_TYPE.APPLICATION_VND_HYPERVIEW_XML,
   ): Promise<Document> => {
     // For GET requests, we can't include a body so we encode the form data as a query
     // string in the URL.
@@ -73,7 +69,11 @@ export class Parser {
     const options = {
       // For non-GET requests, include the formdata as the body of the request.
       body: method === HTTP_METHODS.GET ? undefined : data,
-      headers,
+      headers: {
+        [HTTP_HEADERS.ACCEPT]: `${CONTENT_TYPE.APPLICATION_XML}, ${acceptContentType}`,
+        [HTTP_HEADERS.X_HYPERVIEW_VERSION]: version,
+        [HTTP_HEADERS.X_HYPERVIEW_DIMENSIONS]: `${width}w ${height}h`,
+      },
       method,
     };
 
@@ -128,7 +128,12 @@ export class Parser {
     data: ?FormData,
     method: ?HttpMethod = HTTP_METHODS.GET,
   ): Promise<Document> => {
-    const doc = await this.load(baseUrl, data, method);
+    const doc = await this.load(
+      baseUrl,
+      data,
+      method,
+      CONTENT_TYPE.APPLICATION_VND_HYPERVIEW_FRAGMENT_XML,
+    );
     const docElement = getFirstTag(doc, LOCAL_NAME.DOC);
     if (docElement) {
       throw new Errors.XMLRestrictedElementFound(LOCAL_NAME.DOC, baseUrl);

--- a/src/services/dom/types.js
+++ b/src/services/dom/types.js
@@ -23,6 +23,9 @@ export const HTTP_METHODS = {
 export type HttpMethod = $Values<typeof HTTP_METHODS>;
 
 export const CONTENT_TYPE = {
+  APPLICATION_VND_HYPERVIEW_FRAGMENT_XML:
+    'application/vnd.hyperview_fragment+xml',
+  APPLICATION_VND_HYPERVIEW_XML: 'application/vnd.hyperview+xml',
   APPLICATION_XML: 'application/xml',
   TEXT_HTML: 'text/html',
 };


### PR DESCRIPTION
Add additional content type in `Accept` header, to allow distinguishing full document vs fragment requests.