### PR TITLE
fix: warning about `<items>` not registered

### DIFF
--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -35,6 +35,7 @@ export default class HvView extends PureComponent<HvComponentProps> {
     LOCAL_NAME.FORM,
     LOCAL_NAME.HEADER,
     LOCAL_NAME.ITEM,
+    LOCAL_NAME.ITEMS,
     LOCAL_NAME.SECTION_TITLE,
   ];
 

--- a/src/services/components/index.test.js
+++ b/src/services/components/index.test.js
@@ -33,6 +33,7 @@ const defaultRegistryContent = {
   header: HvView,
   image: HvImage,
   item: HvView,
+  items: HvView,
   list: HvList,
   option: HvOption,
   'picker-field': HvPickerField,


### PR DESCRIPTION
Lists can use the `<items>` element to wrap several items when paginating. This tag does not get rendered and is only used so that generated responses are valid XML. Because it is not registered as a component, it triggers a warning when inserted into the DOM. Add it as an alias for the `view` element to get rid of the warning.

![Simulator Screen Shot - iPhone 8 - 2022-01-22 at 08 28 50](https://user-images.githubusercontent.com/309515/150647289-edbeafe0-55c2-4ee1-b560-c3ef728a1601.png)

