### PR TITLE
feat: Do not crash when text string not wrapped in <text>

### DIFF
--- a/src/services/render/index.js
+++ b/src/services/render/index.js
@@ -96,9 +96,20 @@ export const renderElement = (
   }
 
   if (element.nodeType === NODE_TYPE.TEXT_NODE) {
-    // Render non-empty text nodes
-    if (element.nodeValue && element.nodeValue.trim().length > 0) {
-      return element.nodeValue.trim().replace(/\s+/g, ' ');
+    // Render non-empty text nodes, when wrapped inside a <text> element
+    if (element.nodeValue) {
+      const trimmedValue = element.nodeValue.trim();
+      if (trimmedValue.length > 0) {
+        if (
+          element.parentNode &&
+          element.parentNode.localName === LOCAL_NAME.TEXT
+        ) {
+          return trimmedValue.replace(/\s+/g, ' ');
+        }
+        console.warn(
+          `Text string "${trimmedValue}" must be rendered within a <text> element`,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
Prior to rendering a text node, verify its parent component is a `<text>`, and log a warning instead of lefting the RN app crash.

| Before | After |
|--------|------|
| ![Simulator Screen Shot - iPhone 8 - 2022-02-04 at 20 55 23](https://user-images.githubusercontent.com/309515/152629237-da1f96de-9d27-4402-84c3-bbeebc9ba2c7.png) | ![Simulator Screen Shot - iPhone 8 - 2022-02-04 at 20 52 03](https://user-images.githubusercontent.com/309515/152629242-c8f70c6a-d7c7-48cf-a4db-d3d6b7dee6aa.png) |
 