### PR TITLE
feat(scroll-view): add sticky attribute

### DIFF
--- a/docs/reference_view.md
+++ b/docs/reference_view.md
@@ -20,7 +20,11 @@ Some examples of views:
     <text>With Vertical Layout</text>
   </view>
 
-  <view style="Short FlexHorizontal" scroll="true" scroll-orientation="horizontal">
+  <view
+    style="Short FlexHorizontal"
+    scroll="true"
+    scroll-orientation="horizontal"
+  >
     <text>This</text>
     <text>view</text>
     <text>will</text>
@@ -122,3 +126,11 @@ If `hide="true"`, the element will not be rendered on screen. If the element or 
 | true, **false** (default) | No       |
 
 An attribute to solve the common problem of views that need to move out of the way of the virtual keyboard. It can automatically adjust the position of its children based on the keyboard height. This is useful when you want keyboard avoiding behavior in non-scrollable views. It is applied only in iOS since Android has built-in support for avoiding keyboard.
+
+#### `sticky`
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
+
+If `sticky="true"`, the element will remain fixed at the top of the screen when scrolling. This should be used in conjunction with an immediate parent view with `scroll="true"`and `scroll-orientation="vertical"`.

--- a/docs/reference_view.md
+++ b/docs/reference_view.md
@@ -133,4 +133,4 @@ An attribute to solve the common problem of views that need to move out of the w
 | ------------------------- | -------- |
 | **false** (default), true | No       |
 
-If `sticky="true"`, the element will remain fixed at the top of the screen when scrolling. This should be used in conjunction with an immediate parent view with `scroll="true"`and `scroll-orientation="vertical"`.
+If `sticky="true"`, the element will remain fixed at the top of the screen when scrolling. This should be used in conjunction with an immediate parent view with `scroll="true"` and `scroll-orientation="vertical"`.

--- a/examples/ui_elements/scroll_view.xml
+++ b/examples/ui_elements/scroll_view.xml
@@ -67,9 +67,18 @@
         borderRadius="16"
         height="40"
         margin="8"
+        alignItems="center"
+        justifyContent="center"
       />
       <style id="ScrollChild--Vertical" height="40" />
       <style id="ScrollChild--Horizontal" width="40" />
+      <style
+        id="Text"
+        color="#ffffff"
+        alignSelf="center"
+        textAlign="center"
+        fontSize="24"
+      />
     </styles>
     <body style="Body" safe-area="true">
       <header style="Header">
@@ -77,7 +86,7 @@
         <text style="Header__Title">Scroll Views</text>
       </header>
       <view>
-        <text style="Description">Vertical Scroll</text>
+      <text style="Description">Vertical Scroll</text>
         <view scroll="true" style="ScrollContainer ScrollContainer--Vertical">
           <view style="ScrollChild ScrollChild--Vertical" />
           <view style="ScrollChild ScrollChild--Vertical" />
@@ -85,6 +94,31 @@
           <view style="ScrollChild ScrollChild--Vertical" />
           <view style="ScrollChild ScrollChild--Vertical" />
           <view style="ScrollChild ScrollChild--Vertical" />
+        </view>
+        <text style="Description">Vertical Scroll with sticky header</text>
+        <view scroll="true" style="ScrollContainer ScrollContainer--Vertical">
+          <view id="view-0" style="ScrollChild ScrollChild--Vertical">
+            <text style="Text">Non Sticky</text>
+          </view>
+          <view
+            id="view-1"
+            sticky="true"
+            style="ScrollChild ScrollChild--Vertical"
+          >
+            <text style="Text">Sticky</text>
+          </view>
+          <view id="view-2" style="ScrollChild ScrollChild--Vertical">
+            <text style="Text">Non Sticky</text>
+          </view>
+          <view id="view-3" style="ScrollChild ScrollChild--Vertical">
+            <text style="Text">Non Sticky</text>
+          </view>
+          <view id="view-4" style="ScrollChild ScrollChild--Vertical">
+            <text style="Text">Non Sticky</text>
+          </view>
+          <view id="view-5" style="ScrollChild ScrollChild--Vertical">
+            <text style="Text">Non Sticky</text>
+          </view>
         </view>
         <text style="Description">Horizontal Scroll</text>
         <view

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "release:major": "yarn version --major",
     "storybook": "storybook start -p 7007",
     "test:flow": "flow",
+    "test:floww": "flow check-contents ./src/components/hv-view/index.js < ./src/components/hv-view/index.js",
     "test:generators": "yarn generate test && git diff --quiet HEAD",
     "test:lint": "eslint src && prettier --check '**/*.xsd' '**/*.xml'",
     "test:render": "npx patch-package && jest test/render.test.js --forceExit",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "release:major": "yarn version --major",
     "storybook": "storybook start -p 7007",
     "test:flow": "flow",
-    "test:floww": "flow check-contents ./src/components/hv-view/index.js < ./src/components/hv-view/index.js",
     "test:generators": "yarn generate test && git diff --quiet HEAD",
     "test:lint": "eslint src && prettier --check '**/*.xsd' '**/*.xml'",
     "test:render": "npx patch-package && jest test/render.test.js --forceExit",

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -822,6 +822,7 @@
       <xs:attribute name="avoid-keyboard" type="xs:boolean" />
       <xs:attribute name="safe-area" type="xs:boolean" />
       <xs:attribute name="value" type="xs:string" />
+      <xs:attribute name="sticky" type="xs:boolean" />
       <xs:attributeGroup ref="hv:behaviorAttributes" />
       <xs:attributeGroup ref="hv:scrollAttributes" />
     </xs:complexType>

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -52,9 +52,11 @@ export default class HvView extends PureComponent<HvComponentProps> {
   canRenderElement = (element: Element): boolean => {
     // ignore non rendering and hidden elements
     return (
-      this.props.options.componentRegistry &&
-      this.props.options.componentRegistry[element.namespaceURI] &&
-      this.props.options.componentRegistry[element.namespaceURI][
+      !!this.props.options.componentRegistry &&
+      !!element.namespaceURI &&
+      !!element.localName &&
+      !!this.props.options.componentRegistry[element.namespaceURI] &&
+      !!this.props.options.componentRegistry[element.namespaceURI][
         element.localName
       ] &&
       // $FlowFixMe

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -42,7 +42,7 @@ export default class HvView extends PureComponent<HvComponentProps> {
 
   getStickyElementIndices = (elements: Element[]): number[] => {
     return elements.reduce((acc, element, index) => {
-      if (element.getAttribute('sticky') === 'true') {
+      if (element?.getAttribute('sticky') === 'true') {
         acc.push(index);
       }
       return acc;
@@ -140,6 +140,7 @@ export default class HvView extends PureComponent<HvComponentProps> {
 
     if (scrollable && scrollDirection !== 'horizontal') {
       // add sticky indicies
+      // $FlowFixMe
       const elements = children.map(child => child.props.element);
       const stickyIndicies = this.getStickyElementIndices(elements);
       if (stickyIndicies.length) {

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -10,7 +10,7 @@
 
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
-import type { Attribute, Element, HvComponentProps } from 'hyperview/src/types';
+import type { Element, HvComponentProps } from 'hyperview/src/types';
 import {
   KeyboardAvoidingView,
   Platform,
@@ -40,13 +40,8 @@ export default class HvView extends PureComponent<HvComponentProps> {
 
   props: HvComponentProps;
 
-  isHiddenElement = (attributes: Attribute[]): boolean => {
-    for (let j = 0; j < attributes.length; j += 1) {
-      if (attributes[j].name === 'hide' && attributes[j].value === 'true') {
-        return true;
-      }
-    }
-    return false;
+  isHiddenElement = (element: Element): boolean => {
+    return element.getAttribute('hide') === 'true';
   };
 
   canRenderElement = (element: Element): boolean => {
@@ -59,8 +54,7 @@ export default class HvView extends PureComponent<HvComponentProps> {
       !!this.props.options.componentRegistry[element.namespaceURI][
         element.localName
       ] &&
-      // $FlowFixMe
-      !this.isHiddenElement(Array.from(element.attributes ?? []))
+      !this.isHiddenElement(element)
     );
   };
 
@@ -76,13 +70,9 @@ export default class HvView extends PureComponent<HvComponentProps> {
   getStickyElementIndices = (): number[] => {
     const elements = this.getElementsToRender();
     return elements.reduce((acc, element, index) => {
-      // $FlowFixMe
-      const attributes: Attribute[] = Array.from(element.attributes ?? []);
-      attributes.forEach(attribute => {
-        if (attribute.name === 'sticky' && attribute.value === 'true') {
-          acc.push(index);
-        }
-      });
+      if (element.getAttribute('sticky') === 'true') {
+        acc.push(index);
+      }
       return acc;
     }, []);
   };

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -10,6 +10,7 @@
 
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
+import type { Attribute, Element, HvComponentProps } from 'hyperview/src/types';
 import {
   KeyboardAvoidingView,
   Platform,
@@ -17,12 +18,10 @@ import {
   ScrollView,
   View,
 } from 'react-native';
+import { LOCAL_NAME, NODE_TYPE } from 'hyperview/src/types';
 import React, { PureComponent } from 'react';
-import type { Attribute, Element, HvComponentProps } from 'hyperview/src/types';
-import { NODE_TYPE } from 'hyperview/src/types';
 import type { InternalProps } from './types';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scrollview';
-import { LOCAL_NAME } from 'hyperview/src/types';
 import { addHref } from 'hyperview/src/core/hyper-ref';
 import { createProps } from 'hyperview/src/services';
 
@@ -42,7 +41,7 @@ export default class HvView extends PureComponent<HvComponentProps> {
   props: HvComponentProps;
 
   isHiddenElement = (attributes: Attribute[]): boolean => {
-    for (let j = 0; j < attributes.length; j++) {
+    for (let j = 0; j < attributes.length; j += 1) {
       if (attributes[j].name === 'hide' && attributes[j].value === 'true') {
         return true;
       }
@@ -76,7 +75,7 @@ export default class HvView extends PureComponent<HvComponentProps> {
     );
     return childNodes.reduce((acc, element) => {
       if (this.canRenderElement(element)) {
-        const attributes = element.attributes;
+        const { attributes } = element;
         // do not include hidden elements
         if (
           !attributes ||

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -142,7 +142,6 @@ export default class HvView extends PureComponent<HvComponentProps> {
       // add sticky indicies
       const elements = children.map(child => child.props.element);
       const stickyIndicies = this.getStickyElementIndices(elements);
-      console.log('stickyIndicies', stickyIndicies);
       if (stickyIndicies.length) {
         props.stickyHeaderIndices = stickyIndicies;
       }

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -40,15 +40,6 @@ export default class HvView extends PureComponent<HvComponentProps> {
 
   props: HvComponentProps;
 
-  getStickyElementIndices = (elements: Element[]): number[] => {
-    return elements.reduce((acc, element, index) => {
-      if (element?.getAttribute('sticky') === 'true') {
-        acc.push(index);
-      }
-      return acc;
-    }, []);
-  };
-
   render() {
     let viewOptions = this.props.options;
     const { skipHref } = viewOptions || {};
@@ -140,11 +131,16 @@ export default class HvView extends PureComponent<HvComponentProps> {
 
     if (scrollable && scrollDirection !== 'horizontal') {
       // add sticky indicies
-      // $FlowFixMe
-      const elements = children.map(child => child.props.element);
-      const stickyIndicies = this.getStickyElementIndices(elements);
-      if (stickyIndicies.length) {
-        props.stickyHeaderIndices = stickyIndicies;
+      const stickyIndices = children.reduce(
+        (acc, element, index) =>
+          typeof element !== 'string' &&
+          element.props?.element?.getAttribute('sticky') === 'true'
+            ? [...acc, index]
+            : acc,
+        [],
+      );
+      if (stickyIndices.length) {
+        props.stickyHeaderIndices = stickyIndices;
       }
     }
 

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -75,12 +75,12 @@ export default class HvView extends PureComponent<HvComponentProps> {
     );
     return childNodes.reduce((acc, element) => {
       if (this.canRenderElement(element)) {
-        const { attributes } = element;
         // do not include hidden elements
         if (
-          !attributes ||
+          !element.attributes ||
           // $FlowFixMe
-          (attributes && !this.isHiddenElement(Array.from(attributes)))
+          (element.attributes &&
+            !this.isHiddenElement(Array.from(element.attributes)))
         ) {
           acc.push(element);
         }

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -10,7 +10,6 @@
 
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
-import type { Element, HvComponentProps } from 'hyperview/src/types';
 import {
   KeyboardAvoidingView,
   Platform,
@@ -19,6 +18,7 @@ import {
   View,
 } from 'react-native';
 import React, { PureComponent } from 'react';
+import type { HvComponentProps } from 'hyperview/src/types';
 import type { InternalProps } from './types';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scrollview';
 import { LOCAL_NAME } from 'hyperview/src/types';

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -78,8 +78,8 @@ export default class HvView extends PureComponent<HvComponentProps> {
         // do not include hidden elements
         if (
           !element.attributes ||
-          // $FlowFixMe
           (element.attributes &&
+            // $FlowFixMe
             !this.isHiddenElement(Array.from(element.attributes)))
         ) {
           acc.push(element);

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -18,7 +18,8 @@ import {
   View,
 } from 'react-native';
 import React, { PureComponent } from 'react';
-import type { HvComponentProps, NODE_TYPE } from 'hyperview/src/types';
+import type { HvComponentProps } from 'hyperview/src/types';
+import { NODE_TYPE } from 'hyperview/src/types';
 import type { InternalProps } from './types';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scrollview';
 import { LOCAL_NAME } from 'hyperview/src/types';

--- a/src/components/hv-view/types.js
+++ b/src/components/hv-view/types.js
@@ -24,4 +24,5 @@ export type InternalProps = {|
   style?: ?Array<StyleSheet>,
   testID?: ?string,
   children?: ?any,
+  stickyHeaderIndices?: ?(number[]),
 |};


### PR DESCRIPTION
Add support for sticky header in scroll view, addresses #380.

### Single Sticky header

https://user-images.githubusercontent.com/28518512/152913944-aeda5741-4120-4cb5-aa2a-73168cd5eb90.mp4

### Multiple sticky headers

https://user-images.githubusercontent.com/28518512/152913998-9e4a6039-ce6c-4c1b-846f-83583402e836.mp4


Note: Flow wasn't happy with `Array.from(`, so had to fix ignore them, lmk if there is a better way to handle this.