### PR TITLE
chore: Remove deprecated use of react-native `Picker`

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@react-native-community/datetimepicker": "4.0.0",
+    "@react-native-picker/picker": "2.2.1",
     "@react-navigation/native": "^6.0.8",
     "@react-navigation/stack": "^6.1.1",
     "expo": "~44.0.0",

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -1414,6 +1414,11 @@
   dependencies:
     invariant "^2.2.4"
 
+"@react-native-picker/picker@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.2.1.tgz#32b9f540d8e88a73d8856f73cca88251cecb9614"
+  integrity sha512-EC7yv22QLHlTfnbC1ez9IUdXTOh1W31x96Oir0PfskSGFFJMWWdLTg4VrcE2DsGLzbfjjkBk123c173vf2a5MQ==
+
 "@react-native/assets@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@react-native/assets/-/assets-1.0.0.tgz#c6f9bf63d274bafc8e970628de24986b30a55c8e"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "peerDependencies": {
     "@react-native-community/datetimepicker": ">= 3.0.3",
+    "@react-native-picker/picker": ">= 2.2.1",
     "react": ">= 16.13.1",
     "react-native": ">= 0.63.3",
     "react-native-keyboard-aware-scrollview": ">= 2.1.0",
@@ -64,6 +65,7 @@
     "@babel/runtime": "7.13.7",
     "@prettier/plugin-xml": "0.13.0",
     "@react-native-community/datetimepicker": "3.0.3",
+    "@react-native-picker/picker": "2.2.1",
     "@storybook/addon-actions": "4.1.18",
     "@storybook/addon-storyshots": "4.1.18",
     "@storybook/react-native": "4.1.18",

--- a/src/components/hv-picker-field/index.js
+++ b/src/components/hv-picker-field/index.js
@@ -18,7 +18,6 @@ import type {
 } from 'hyperview/src/types';
 import {
   Modal,
-  Picker,
   Platform,
   Text,
   TouchableWithoutFeedback,
@@ -32,6 +31,7 @@ import {
   getNameValueFormInputValues,
 } from 'hyperview/src/services';
 import { LOCAL_NAME } from 'hyperview/src/types';
+import { Picker } from '@react-native-picker/picker';
 import type { Node as ReactNode } from 'react';
 import type { State } from './types';
 import styles from './styles';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1788,6 +1788,11 @@
   dependencies:
     invariant "^2.2.4"
 
+"@react-native-picker/picker@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.2.1.tgz#32b9f540d8e88a73d8856f73cca88251cecb9614"
+  integrity sha512-EC7yv22QLHlTfnbC1ez9IUdXTOh1W31x96Oir0PfskSGFFJMWWdLTg4VrcE2DsGLzbfjjkBk123c173vf2a5MQ==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"


### PR DESCRIPTION
Replace with `@react-native-picker/picker` library.

| iOS | Android |
|---|---|
|  ![Simulator Screen Shot - iPhone 13 - 2022-03-15 at 16 24 57](https://user-images.githubusercontent.com/309515/158492147-f012cf35-bc50-4aa5-b7b6-65fd0ab6c7b9.png) | <img width="559" alt="Screen Shot 2022-03-15 at 5 08 26 PM" src="https://user-images.githubusercontent.com/309515/158492098-68c44a6c-facd-46a6-81da-2d3e8ae7bd45.png"> |

