### PR TITLE
feat: Preformatted text

### DIFF
--- a/docs/reference_text.md
+++ b/docs/reference_text.md
@@ -57,6 +57,8 @@ A `<view>` element can only appear anywhere within a `<screen>` element.
 - [`id`](#id)
 - [`hide`](#hide)
 - [`selectable`](#selectable)
+- [`adjustsFontSizeToFit`](#adjustsFontSizeToFit)
+- [`preformatted`](#preformatted)
 
 #### Behavior attributes
 
@@ -103,8 +105,17 @@ If `hide="true"`, the element will not be rendered on screen. If the element or 
 A boolean that allows users to select the content of `<text>` element.
 
 #### `adjustsFontSizeToFit`
-| Type    | Required | 
-| ------- | -------- | 
-| boolean | No       | 
+
+| Type    | Required |
+| ------- | -------- |
+| boolean | No       |
 
 If `adjustsFontSizeToFit="true"`, fonts will be scaled down automatically to fit given style constraints.
+
+#### `preformatted`
+
+| Type    | Required |
+| ------- | -------- |
+| boolean | No       |
+
+By default, `<text>` element stips out extraneous whitespaces and line breaks. This attribute prevents this behavior, so that all spaces and line-breaks are rendered.

--- a/examples/ui_elements/text.xml
+++ b/examples/ui_elements/text.xml
@@ -79,6 +79,14 @@
           style="Basic"
           adjustsFontSizeToFit="true"
         >Adjustable Font Size</text>
+        <text style="Basic" preformatted="true">
+          <![CDATA[
+          Preformatted
+          <hello>
+              <world />
+          </hello>
+          ]]>
+        </text>
       </view>
     </body>
   </screen>

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -854,6 +854,7 @@
       <xs:attribute name="id" type="hv:ID" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="selectable" type="xs:boolean" />
+      <xs:attribute name="preformatted" type="xs:boolean" />
       <xs:attribute name="value" type="xs:string" />
       <xs:attribute name="adjustsFontSizeToFit" type="xs:boolean" />
       <xs:attributeGroup ref="hv:behaviorAttributes" />

--- a/src/components/hv-text/index.js
+++ b/src/components/hv-text/index.js
@@ -40,7 +40,10 @@ export default class HvText extends PureComponent<HvComponentProps> {
         this.props.element,
         this.props.stylesheets,
         this.props.onUpdate,
-        this.props.options,
+        {
+          ...this.props.options,
+          preformatted: this.props.element.getAttribute('hide') === 'true',
+        },
       ),
     );
 

--- a/src/services/render/index.js
+++ b/src/services/render/index.js
@@ -105,7 +105,9 @@ export const renderElement = (
             element.parentNode?.localName === LOCAL_NAME.TEXT) ||
           element.parentNode?.namespaceURI !== Namespaces.HYPERVIEW
         ) {
-          return trimmedValue.replace(/\s+/g, ' ');
+          return options.preformatted
+            ? trimmedValue
+            : trimmedValue.replace(/\s+/g, ' ');
         }
         console.warn(
           `Text string "${trimmedValue}" must be rendered within a <text> element`,

--- a/src/types.js
+++ b/src/types.js
@@ -266,6 +266,7 @@ export type HvComponentOptions = {
   onEnd?: ?() => void,
   onSelect?: ?(value: ?DOMString) => void,
   onToggle?: ?(value: ?DOMString) => void,
+  preformatted?: ?boolean,
   pressed?: ?boolean,
   pressedSelected?: ?boolean,
   registerInputHandler?: (ref: ?ElementRef<*>) => void,


### PR DESCRIPTION
Add alias to `<text>` to allow rendering of preformatted text.

![Simulator Screen Shot - iPhone 13 Pro Max - 2022-03-23 at 18 45 02](https://user-images.githubusercontent.com/309515/159825337-d515f97c-da30-4a46-aeda-ac57eac9ad19.png)

TODO once approach is validated:
- [ ] Update docs

Relates to #62.