### PR TITLE
feat: Custom loading components

### DIFF
--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -8,12 +8,16 @@
  *
  */
 
+import * as Contexts from 'hyperview/src/contexts';
 import * as Dom from 'hyperview/src/services/dom';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
+import {
+  RefreshControl as DefaultRefreshControl,
+  FlatList,
+} from 'react-native';
 import React, { PureComponent } from 'react';
 import { DOMParser } from 'xmldom-instawork';
-import { FlatList } from 'react-native';
 import type { HvComponentProps } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import type { State } from './types';
@@ -24,6 +28,8 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
   static localName = LOCAL_NAME.LIST;
 
   static localNameAliases = [];
+
+  static contextType = Contexts.RefreshControlComponentContext;
 
   parser: DOMParser = new DOMParser();
 
@@ -89,6 +95,16 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
     ).filter(isOwnedBySelf);
   };
 
+  RefreshControl = () => {
+    const RefreshControl = this.context || DefaultRefreshControl;
+    return (
+      <RefreshControl
+        onRefresh={this.refresh}
+        refreshing={this.state.refreshing}
+      />
+    );
+  };
+
   render() {
     const styleAttr = this.props.element.getAttribute('style');
     const style = styleAttr
@@ -118,12 +134,10 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
     };
 
     let refreshProps = {};
+    const { RefreshControl } = this;
     if (this.props.element.getAttribute('trigger') === 'refresh') {
       refreshProps = {
-        onRefresh: () => {
-          this.refresh();
-        },
-        refreshing: this.state.refreshing,
+        refreshControl: <RefreshControl />,
       };
     }
 

--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -8,13 +8,17 @@
  *
  */
 
+import * as Contexts from 'hyperview/src/contexts';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
+import {
+  RefreshControl as DefaultRefreshControl,
+  SectionList,
+} from 'react-native';
 import React, { PureComponent } from 'react';
 import { DOMParser } from 'xmldom-instawork';
 import type { HvComponentProps } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
-import { SectionList } from 'react-native';
 import type { State } from './types';
 
 export default class HvSectionList extends PureComponent<
@@ -26,6 +30,8 @@ export default class HvSectionList extends PureComponent<
   static localName = LOCAL_NAME.SECTION_LIST;
 
   static localNameAliases = [];
+
+  static contextType = Contexts.RefreshControlComponentContext;
 
   parser: DOMParser = new DOMParser();
 
@@ -57,6 +63,16 @@ export default class HvSectionList extends PureComponent<
       showIndicatorIds,
       targetId,
     });
+  };
+
+  RefreshControl = () => {
+    const RefreshControl = this.context || DefaultRefreshControl;
+    return (
+      <RefreshControl
+        onRefresh={this.refresh}
+        refreshing={this.state.refreshing}
+      />
+    );
   };
 
   render() {
@@ -114,10 +130,10 @@ export default class HvSectionList extends PureComponent<
     };
 
     let refreshProps = {};
+    const { RefreshControl } = this;
     if (this.props.element.getAttribute('trigger') === 'refresh') {
       refreshProps = {
-        onRefresh: () => this.refresh(),
-        refreshing: this.state.refreshing,
+        refreshControl: <RefreshControl />,
       };
     }
 

--- a/src/contexts/index.js
+++ b/src/contexts/index.js
@@ -1,7 +1,5 @@
 // @flow
 
-import React from 'react';
-
 /**
  * Copyright (c) Garuda Labs, Inc.
  *
@@ -10,8 +8,15 @@ import React from 'react';
  *
  */
 
+import type { ComponentType } from 'react';
+import React from 'react';
+
 // Provides the date format function to use in date fields
 // in the screen. Default to ISO string format.
 export const DateFormatContext = React.createContext<
   (date: ?Date, format: ?string) => string,
 >(date => (date ? date.toISOString() : ''));
+
+export const RefreshControlComponentContext = React.createContext<
+  ComponentType<*>,
+>(component => component);

--- a/src/index.js
+++ b/src/index.js
@@ -242,9 +242,8 @@ export default class HyperScreen extends React.Component {
       });
     }
     if (!this.state.doc) {
-      return (
-        <Loading />
-      );
+      const loadingScreen = this.props.loadingScreen || Loading;
+      return React.createElement(loadingScreen);
     }
     const [body] = Array.from(this.state.doc.getElementsByTagNameNS(Namespaces.HYPERVIEW, 'body'));
     const screenElement = Render.renderElement(
@@ -259,7 +258,9 @@ export default class HyperScreen extends React.Component {
 
     return (
       <Contexts.DateFormatContext.Provider value={this.props.formatDate}>
-        {screenElement}
+        <Contexts.RefreshControlComponentContext.Provider value={this.props.refreshControl}>
+          {screenElement}
+        </Contexts.RefreshControlComponentContext.Provider>
       </Contexts.DateFormatContext.Provider>
     );
   }


### PR DESCRIPTION
Allow passing props to define loading, load error and list refresh control components.

Implementation notes:
- each component is passed as optional props of `HyperScreen`
- `refreshControl` prop is exposed to `HvList` and `HvSectionList` via a React context

Follow up for #330
Resolves #286