### PR TITLE
fix: Bug with scrollbars on iOS 13+

### DIFF
--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -114,6 +114,12 @@ export default class HvView extends PureComponent<HvComponentProps> {
       props.showsHorizontalScrollIndicator = horizontal && showScrollIndicator;
       props.showsVerticalScrollIndicator = !horizontal && showScrollIndicator;
 
+      // Fix scrollbar rendering issue in iOS 13+
+      // https://github.com/facebook/react-native/issues/26610#issuecomment-539843444
+      if (Platform.OS === 'ios' && parseInt(Platform.Version, 10) >= 13) {
+        props.scrollIndicatorInsets = { right: 1 };
+      }
+
       if (horizontal) {
         props.horizontal = true;
       }

--- a/src/components/hv-view/types.js
+++ b/src/components/hv-view/types.js
@@ -26,5 +26,11 @@ export type InternalProps = {|
   style?: ?Array<StyleSheet>,
   testID?: ?string,
   children?: ?any,
+  scrollIndicatorInsets?: {
+    bottom?: number,
+    left?: number,
+    right?: number,
+    top?: number,
+  },
   stickyHeaderIndices?: ?(number[]),
 |};


### PR DESCRIPTION
Apply [suggested bug fix](https://github.com/facebook/react-native/issues/26610#issuecomment-539843444) for scrollbars sometimes not rendering pinned on the side of the view