### PR TITLE
feat(hv-view): `content-container-style` attribute

### DIFF
--- a/docs/reference_view.md
+++ b/docs/reference_view.md
@@ -80,6 +80,14 @@ If true, the body will be rendered in the safe area of the mobile device (avoidi
 
 A space-separated list of styles to apply to the element. See [Styles](/docs/reference_style). Note that text style rules cannot be applied to a `<view>`.
 
+#### `content-container-style`
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
+
+A space-separated list of styles to apply to the content container element of a scroll view. See [Styles](/docs/reference_style). Note that text style rules cannot be applied to a `<view>`, and this attribute only has an effect when `scroll` is true.
+
 #### `scroll`
 
 | Type                      | Required |

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -491,6 +491,7 @@
       </xs:simpleType>
     </xs:attribute>
     <xs:attribute name="shows-scroll-indicator" type="xs:boolean" />
+    <xs:attribute name="content-container-style" type="hv:styleList" />
   </xs:attributeGroup>
 
   <xs:element name="doc">

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -18,12 +18,12 @@ import {
   View,
 } from 'react-native';
 import React, { PureComponent } from 'react';
+import { createProps, createStyleProp } from 'hyperview/src/services';
 import type { HvComponentProps } from 'hyperview/src/types';
 import type { InternalProps } from './types';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scrollview';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import { addHref } from 'hyperview/src/core/hyper-ref';
-import { createProps } from 'hyperview/src/services';
 
 export default class HvView extends PureComponent<HvComponentProps> {
   static namespaceURI = Namespaces.HYPERVIEW;
@@ -113,6 +113,18 @@ export default class HvView extends PureComponent<HvComponentProps> {
 
       props.showsHorizontalScrollIndicator = horizontal && showScrollIndicator;
       props.showsVerticalScrollIndicator = !horizontal && showScrollIndicator;
+
+      const contentContainerStyleAttr = 'content-container-style';
+      if (this.props.element.getAttribute('scroll-orientation')) {
+        props.contentContainerStyle = createStyleProp(
+          this.props.element,
+          this.props.stylesheets,
+          {
+            ...viewOptions,
+            styleAttr: contentContainerStyleAttr,
+          },
+        );
+      }
 
       if (horizontal) {
         props.horizontal = true;

--- a/src/components/hv-view/types.js
+++ b/src/components/hv-view/types.js
@@ -14,6 +14,7 @@ export type InternalProps = {|
   accessibilityLabel?: any,
   automaticallyAdjustContentInsets?: ?boolean,
   behavior?: 'position',
+  contentContainerStyle?: Array<StyleSheet>,
   extraScrollHeight?: ?number,
   keyboardOpeningTime?: ?number,
   keyboardShouldPersistTaps?: ?string,


### PR DESCRIPTION
Add support for `content-container-style` attribute, that allows setting the property [`contentContainerStyle`](https://reactnative.dev/docs/scrollview#contentcontainerstyle) of RN `ScrollView`