### PR TITLE
fix: Refresh control on Android

### DIFF
--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -95,16 +95,6 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
     ).filter(isOwnedBySelf);
   };
 
-  RefreshControl = () => {
-    const RefreshControl = this.context || DefaultRefreshControl;
-    return (
-      <RefreshControl
-        onRefresh={this.refresh}
-        refreshing={this.state.refreshing}
-      />
-    );
-  };
-
   render() {
     const styleAttr = this.props.element.getAttribute('style');
     const style = styleAttr
@@ -134,10 +124,15 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
     };
 
     let refreshProps = {};
-    const { RefreshControl } = this;
     if (this.props.element.getAttribute('trigger') === 'refresh') {
+      const RefreshControl = this.context || DefaultRefreshControl;
       refreshProps = {
-        refreshControl: <RefreshControl />,
+        refreshControl: (
+          <RefreshControl
+            onRefresh={this.refresh}
+            refreshing={this.state.refreshing}
+          />
+        ),
       };
     }
 

--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -65,16 +65,6 @@ export default class HvSectionList extends PureComponent<
     });
   };
 
-  RefreshControl = () => {
-    const RefreshControl = this.context || DefaultRefreshControl;
-    return (
-      <RefreshControl
-        onRefresh={this.refresh}
-        refreshing={this.state.refreshing}
-      />
-    );
-  };
-
   render() {
     const styleAttr = this.props.element.getAttribute('style');
     const style = styleAttr
@@ -130,10 +120,15 @@ export default class HvSectionList extends PureComponent<
     };
 
     let refreshProps = {};
-    const { RefreshControl } = this;
     if (this.props.element.getAttribute('trigger') === 'refresh') {
+      const RefreshControl = this.context || DefaultRefreshControl;
       refreshProps = {
-        refreshControl: <RefreshControl />,
+        refreshControl: (
+          <RefreshControl
+            onRefresh={this.refresh}
+            refreshing={this.state.refreshing}
+          />
+        ),
       };
     }
 


### PR DESCRIPTION
#412 introduced a bug with Android, where refresh control would not render correctly nor be properly removed once refreshing done. From my testing, it seems that nesting the `RefreshControl` under another component when setting `refreshControl` prop is causing this issue. Removing that extra nesting solves the issue.