### PR TITLE
fix: Commit message on demo package update

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "generate": "babel-node ./scripts/generate",
     "preversion": "yarn test && yarn build",
     "prettify": "pretty-quick && prettier --write '**/*.xsd' '**/*.xml' '**/*.md'",
-    "postversion": "yarn publish --new-version $npm_package_version && cd demo && yarn add hyperview@$npm_package_version && git add package.json yarn.lock && git commit -m'chore(demo): update Hyperview to v$npm_package_version' && cd .. && git push --follow-tags",
+    "postversion": "yarn publish --new-version $npm_package_version && cd demo && yarn add hyperview@$npm_package_version && git add package.json yarn.lock && git commit -m\"chore(demo): update Hyperview to v$npm_package_version\" && cd .. && git push --follow-tags",
     "format-xml": "./scripts/format-xml.sh",
     "release:patch": "yarn version --patch",
     "release:minor": "yarn version --minor",


### PR DESCRIPTION
The single quotes seem to prevent npm to properly interpolate the `$npm_package_version` variable (see https://github.com/Instawork/hyperview/commit/2c183da67ea11564f1a70e27a6127ca8dd29ab85). Using escaped double quotes instead (tested locally).