### PR TITLE
chore(doc):Fix invalid XML in examples

### DIFF
--- a/docs/reference_option.md
+++ b/docs/reference_option.md
@@ -20,7 +20,7 @@ The `<option>` element represents an input choice within a `<select-single>` or 
     <option value="3">
       <text>3rd grade</text>
     </option>
-  <select-single/>
+  </select-single>
 </form>
 ```
 

--- a/docs/reference_selectsingle.md
+++ b/docs/reference_selectsingle.md
@@ -20,7 +20,7 @@ The `<select-single>` element represents a user input widget that allows one opt
     <option value="3">
       <text>3rd grade</text>
     </option>
-  <select-single/>
+  </select-single>
 </form>
 ```
 


### PR DESCRIPTION
Fixing the XML `<select-single>` end tag from the examples at https://hyperview.org/docs/reference_selectsingle and https://hyperview.org/docs/reference_option