### PR TITLE
fix: Remove `ask-rating` from schema

### DIFF
--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -25,7 +25,6 @@
         <xs:enumeration value="hide" />
         <xs:enumeration value="toggle" />
         <xs:enumeration value="set-value" />
-        <xs:enumeration value="ask-rating" />
         <xs:enumeration value="alert" />
         <xs:enumeration value="copy-to-clipboard" />
       </xs:restriction>


### PR DESCRIPTION
This is an Instawork specific behavior, removing it from the core schema.