### PR TITLE
fix: set accessible to false in TouchableOpacity

### DIFF
--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -272,7 +272,7 @@ export default class HyperRef extends PureComponent<Props, State> {
 
       renderedComponent = React.createElement(
         TouchableOpacity,
-        { ...props, ...pressHandlers },
+        { ...props, ...pressHandlers, accessible: false },
         renderedComponent,
       );
     }


### PR DESCRIPTION
This change allow QA team to access nested elements via Appium, and then allow us to use this elements with their ids into automation scripts.

Setting accessible={false} is necessary for UI inspector to find child elements of TouchableOpacity, see: 
- https://github.com/facebook/react-native/issues/6560
- https://github.com/facebook/react-native/pull/6561