### PR TITLE
feat:Add set-value support to <select-multiple>

### DIFF
--- a/docs/reference_behavior_attributes.md
+++ b/docs/reference_behavior_attributes.md
@@ -568,9 +568,10 @@ Note that the target element must only be one of the following elements:
 - [`<picker-field>`](/docs/reference_pickerfield)
 - [`<date-field>`](/docs/reference_datefield)
 - [`<select-single>`](/docs/reference_selectsingle)
+- [`<select-multiple>`](/docs/reference_selectmultiple)
 - [`<switch>`](/docs/reference_switch)
 
-Notable, `<select-multiple>` is not currently supported. Also note that using `set-value` will ignore any validation or restrictions set by the input element, like masks or other requirements.
+Note that using `set-value` will ignore any validation or restrictions set by the input element, like masks or other requirements.
 
 ```xml
 <text-field id="id_tf" />

--- a/src/behaviors/hv-set-value/index.js
+++ b/src/behaviors/hv-set-value/index.js
@@ -1,7 +1,6 @@
 // @flow
 
 import * as Behaviors from 'hyperview/src/services/behaviors';
-import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Xml from 'hyperview/src/services/xml';
 import type {
   DOMString,
@@ -12,7 +11,6 @@ import type {
   HvUpdateRoot,
 } from 'hyperview/src/types';
 import { later, shallowCloneToRoot } from 'hyperview/src/services';
-import { LOCAL_NAME } from 'hyperview/src/types';
 
 export default {
   action: 'set-value',
@@ -50,18 +48,6 @@ export default {
 
       // Show the target
       targetElement.setAttribute('value', newValue);
-      // select the <option> matching the "newValue" and unselect the others
-      const options: NodeList<Element> = targetElement.getElementsByTagNameNS(
-        Namespaces.HYPERVIEW,
-        LOCAL_NAME.OPTION,
-      );
-      for (let i = 0; i < options.length; i += 1) {
-        const option = options.item(i);
-        option.setAttribute(
-          'selected',
-          option.getAttribute('value') === newValue,
-        );
-      }
       let newRoot: Document = shallowCloneToRoot(targetElement);
 
       // If using delay, we need to undo the indicators shown earlier.

--- a/src/behaviors/hv-set-value/index.js
+++ b/src/behaviors/hv-set-value/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as Behaviors from 'hyperview/src/services/behaviors';
+import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Xml from 'hyperview/src/services/xml';
 import type {
   DOMString,
@@ -11,6 +12,7 @@ import type {
   HvUpdateRoot,
 } from 'hyperview/src/types';
 import { later, shallowCloneToRoot } from 'hyperview/src/services';
+import { LOCAL_NAME } from 'hyperview/src/types';
 
 export default {
   action: 'set-value',
@@ -48,6 +50,18 @@ export default {
 
       // Show the target
       targetElement.setAttribute('value', newValue);
+      // select the <option> matching the "newValue" and unselect the others
+      const options = targetElement.getElementsByTagNameNS(
+        Namespaces.HYPERVIEW,
+        LOCAL_NAME.OPTION,
+      );
+      for (let i = 0; i < options.length; i += 1) {
+        const option = options.item(i);
+        option.setAttribute(
+          'selected',
+          option.getAttribute('value') === newValue,
+        );
+      }
       let newRoot: Document = shallowCloneToRoot(targetElement);
 
       // If using delay, we need to undo the indicators shown earlier.

--- a/src/behaviors/hv-set-value/index.js
+++ b/src/behaviors/hv-set-value/index.js
@@ -51,7 +51,7 @@ export default {
       // Show the target
       targetElement.setAttribute('value', newValue);
       // select the <option> matching the "newValue" and unselect the others
-      const options = targetElement.getElementsByTagNameNS(
+      const options: NodeList<Element> = targetElement.getElementsByTagNameNS(
         Namespaces.HYPERVIEW,
         LOCAL_NAME.OPTION,
       );

--- a/src/components/hv-select-multiple/index.js
+++ b/src/components/hv-select-multiple/index.js
@@ -53,11 +53,25 @@ export default class HvSelectMultiple extends PureComponent<HvComponentProps> {
     this.onToggle = this.onToggle.bind(this);
   }
 
+  componentDidUpdate() {
+    if (this.props.element.hasAttribute('value')) {
+      // NOTE: we need to remove the attribute before
+      // selection, since selection will update the component.
+      const newValue = this.props.element.getAttribute('value');
+      this.props.element.removeAttribute('value');
+      this.selectValue(newValue, true);
+    }
+  }
+
   /**
    * Callback passed to children. Option components invoke this callback when toggles.
    * Will update the XML DOM to toggle the option with the given value.
    */
   onToggle = (selectedValue: ?DOMString) => {
+    this.selectValue(selectedValue, false);
+  };
+
+  selectValue = (selectedValue: ?DOMString, unselectOthers: boolean) => {
     const newElement = this.props.element.cloneNode(true);
     const options = newElement.getElementsByTagNameNS(
       Namespaces.HYPERVIEW,
@@ -70,6 +84,8 @@ export default class HvSelectMultiple extends PureComponent<HvComponentProps> {
         if (value === selectedValue) {
           const selected = option.getAttribute('selected') === 'true';
           option.setAttribute('selected', selected ? 'false' : 'true');
+        } else if (unselectOthers) {
+          option.setAttribute('selected', 'false');
         }
       }
     }


### PR DESCRIPTION
Add support for [set-value behavior attribute](https://hyperview.org/docs/reference_behavior_attributes#set-value) to the [`<select-multiple>` element](https://hyperview.org/docs/reference_selectmultiple).