### PR TITLE
feat:Create select-all/unselect-all behavior actions

### DIFF
--- a/docs/reference_behavior_attributes.md
+++ b/docs/reference_behavior_attributes.md
@@ -342,9 +342,9 @@ The `verb` attribute defines the HTTP method used to request the content specifi
 
 ## action
 
-| Type                                                                                                                                                                                        | Required |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| **push** (default), new, back, close, navigate, deep-link, open-settings, replace, replace-inner, append, prepend, reload, dispatch-event, show, hide, toggle, set-value, copy-to-clipboard | No       |
+| Type                                                                                                                                                                                                                  | Required |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| **push** (default), new, back, close, navigate, deep-link, open-settings, replace, replace-inner, append, prepend, reload, dispatch-event, show, hide, toggle, set-value, copy-to-clipboard, select-all, unselect-all | No       |
 
 The `action` attribute defines what to do with the Hyperview XML resource described by the `href` attribute. The possible actions are divided into **navigation actions**, which load or navigate to a screen, and **update actions**, which update the elements on the current screen.
 
@@ -371,6 +371,8 @@ The update actions include:
 - [`toggle`](#toggle)
 - [`set-value`](#set-value)
 - [`copy-to-clipboard`](#copy-to-clipboard)
+- [`select-all`](#select-all)
+- [`unselect-all`](#unselect-all)
 
 ### `push`
 
@@ -594,6 +596,57 @@ The `copy-to-clipboard` action allows copying a value to the clipboard. The beha
 
 In this example, pressing "Copy to clipboard" will copy the value "Hello World!" to the clipboard.
 See [the repo](https://github.com/Instawork/hyperview/blob/master/examples/advanced_behaviors/copy_to_clipboard/index.xml) for examples.
+
+### `select-all`
+
+The `select-all` action allows selecting all the options of the target element.
+
+Note that the target element must be a [`<select-multiple>`](/docs/reference_selectmultiple) element.
+
+```xml
+<select-multiple id="id_sm">
+    <option value="1">
+      <text>1st option</text>
+    </option>
+    <option value="2">
+      <text>2nd option</text>
+    </option>
+    <option value="3" selected="true">
+      <text>3rd option</text>
+    </option>
+</select-multiple>
+<text style="link" action="select-all" target="id_sm">Select all</text>
+```
+
+In this example, pressing "Select all" will select "1st option" and "2nd option", in addition to the already selected "3rd option".
+See [the repo](https://github.com/Instawork/hyperview/blob/master/examples/behaviors/select_all/index.xml) for more examples.
+
+### `unselect-all`
+
+The `unselect-all` action allows unselecting all the options of the target element.
+
+Note that the target element must only be one of the following elements:
+
+- [`<select-single>`](/docs/reference_selectsingle)
+- [`<select-multiple>`](/docs/reference_selectmultiple)
+
+```xml
+<select-multiple id="id_sm">
+    <option value="1" selected="true">
+      <text>1st option</text>
+    </option>
+    <option value="2" selected="true">
+      <text>2nd option</text>
+    </option>
+    <option value="3">
+      <text>3rd option</text>
+    </option>
+</select-multiple>
+<text style="link" action="unselect-all" target="id_sm">Unselect all</text>
+```
+
+In this example, pressing "Unselect all" will unselect "1st option" and "2nd option", that were initially selected.
+See [the repo](https://github.com/Instawork/hyperview/blob/master/examples/behaviors/unselect_all/index.xml) for more examples.
 
 ## target
 

--- a/docs/reference_index.md
+++ b/docs/reference_index.md
@@ -41,7 +41,7 @@ Input elements in HXML allow users to set local state on a Hyperview screen. Thi
 - [`<text-field>`](/docs/reference_textfield): An element used to accept single-line text input.
 - [`<text-area>`](/docs/reference_textarea): An element used to accept multi-line text input.
 - [`<select-single>`](/docs/reference_selectsingle): An element that groups many `<option>` elements, and allows only one of the options to be selected at a time.
-- [`<select-single>`](/docs/reference_selectmultiple): An element that groups many `<option>` elements, and allows any number of options to be selected/deselected.
+- [`<select-multiple>`](/docs/reference_selectmultiple): An element that groups many `<option>` elements, and allows any number of options to be selected/deselected.
 - [`<option>`](/docs/reference_option): An element that groups many `<option>` elements, and allows any number of options to be selected/deselected.
 
 #### Style Elements

--- a/examples/behaviors/index.xml
+++ b/examples/behaviors/index.xml
@@ -130,6 +130,24 @@
             <text style="Item__Label">Toggle</text>
             <text style="Item__Chevron">&gt;</text>
           </item>
+          <item
+            href="/behaviors/select_all.xml"
+            key="select_all"
+            show-during-load="loadingScreen"
+            style="Item"
+          >
+            <text style="Item__Label">Select All</text>
+            <text style="Item__Chevron">&gt;</text>
+          </item>
+          <item
+            href="/behaviors/unselect_all.xml"
+            key="unselect_all"
+            show-during-load="loadingScreen"
+            style="Item"
+          >
+            <text style="Item__Label">Unselect All</text>
+            <text style="Item__Chevron">&gt;</text>
+          </item>
         </section>
         <section>
           <section-title style="List__Header">

--- a/examples/behaviors/select_all.xml
+++ b/examples/behaviors/select_all.xml
@@ -1,0 +1,248 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style
+        id="Header"
+        alignItems="center"
+        backgroundColor="white"
+        borderBottomColor="#eee"
+        borderBottomWidth="1"
+        flexDirection="row"
+        paddingLeft="24"
+        paddingRight="24"
+        paddingBottom="16"
+      />
+      <style
+        id="Header__Back"
+        color="blue"
+        fontSize="16"
+        fontWeight="600"
+        paddingRight="16"
+      />
+      <style id="Header__Title" color="black" fontSize="24" fontWeight="600" />
+      <style id="Body" backgroundColor="white" flex="1" />
+      <style
+        id="Description"
+        fontSize="16"
+        fontWeight="normal"
+        margin="24"
+        marginBottom="0"
+      />
+      <style
+        id="Item"
+        alignItems="center"
+        borderBottomColor="#eee"
+        borderBottomWidth="1"
+        flex="1"
+        flexDirection="row"
+        height="48"
+        justifyContent="space-between"
+        paddingLeft="24"
+        paddingRight="24"
+      />
+      <style id="Item__Label" fontSize="18" fontWeight="normal" />
+      <style id="Item__Chevron" fontSize="18" fontWeight="bold" />
+      <style
+        id="Button"
+        alignItems="center"
+        backgroundColor="#63CB76"
+        borderRadius="16"
+        flex="1"
+        flexDirection="column"
+        justifyContent="center"
+        margin="24"
+        padding="24"
+      />
+      <style id="Button__Label" color="white" fontSize="24" fontWeight="bold" />
+      <style
+        id="Container"
+        borderColor="#e1e1e1"
+        borderRadius="16"
+        borderWidth="2"
+        margin="24"
+        padding="24"
+      />
+      <style
+        id="Container__Label"
+        color="black"
+        fontSize="16"
+        fontWeight="normal"
+      />
+      <style id="Main" flex="1" />
+      <style id="Select" marginTop="24" />
+      <style
+        id="Select__Separator"
+        borderTopColor="#e1e3e3"
+        borderTopWidth="1"
+        marginLeft="24"
+        marginRight="24"
+      />
+      <style
+        id="Select__Option"
+        alignItems="center"
+        flex="1"
+        flexDirection="row"
+        justifyContent="space-between"
+        paddingBottom="16"
+        paddingLeft="24"
+        paddingRight="24"
+        paddingTop="16"
+      />
+      <style
+        id="Select__RadioOuter"
+        borderColor="#bdc4c4"
+        borderRadius="10"
+        borderWidth="1"
+        height="20"
+        width="20"
+      >
+        <modifier pressed="true">
+          <style borderColor="#8d9494" borderWidth="1" />
+        </modifier>
+        <modifier selected="true">
+          <style borderColor="#4778ff" borderWidth="2" />
+        </modifier>
+      </style>
+      <style
+        id="Select__RadioInner"
+        borderRadius="5"
+        height="10"
+        marginLeft="3"
+        marginTop="3"
+        opacity="0"
+        width="10"
+      >
+        <modifier selected="true">
+          <style backgroundColor="#4778ff" opacity="1" />
+        </modifier>
+      </style>
+      <style
+        id="Select__Label"
+        color="#4e4d4d"
+        fontSize="16"
+        fontWeight="normal"
+        lineHeight="18"
+      >
+        <modifier selected="true">
+          <style color="#312f2f" />
+        </modifier>
+        <modifier pressed="true">
+          <style color="#312f2f" />
+        </modifier>
+      </style>
+    </styles>
+    <body style="Body" safe-area="true">
+      <header style="Header">
+        <text action="back" href="#" style="Header__Back">Back</text>
+        <text style="Header__Title">Select All</text>
+      </header>
+      <view scroll="1" style="Main">
+        <text style="Description">
+          Tapping the button below will select all the options.
+        </text>
+        <select-multiple id="id_sm" name="sm" style="Select">
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option1">
+            <text style="Select__Label">Option 1</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option2">
+            <text style="Select__Label">Option 2</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option3" selected="true">
+            <text style="Select__Label">Option 3</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+        </select-multiple>
+        <view style="Button" target="id_sm" action="select-all">
+          <text style="Button__Label">Select All</text>
+        </view>
+        <text style="Description">
+          Select All can work with the delay attribute. In this example, the selection
+          will be delayed 1 second.
+        </text>
+        <select-multiple id="id_sm_delay" name="sm" style="Select">
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option1">
+            <text style="Select__Label">Option 1</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option2">
+            <text style="Select__Label">Option 2</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option3" selected="true">
+            <text style="Select__Label">Option 3</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+        </select-multiple>
+        <view
+          action="select-all"
+          style="Button"
+          target="id_sm_delay"
+          delay="1000"
+        >
+          <text style="Button__Label">Select All with Delay</text>
+        </view>
+        <text style="Description">
+          When selecting with delay, you can use indicators.
+        </text>
+        <select-multiple id="id_sm_indicator" name="sm" style="Select">
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option1">
+            <text style="Select__Label">Option 1</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option2">
+            <text style="Select__Label">Option 2</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option3" selected="true">
+            <text style="Select__Label">Option 3</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+        </select-multiple>
+        <view
+          action="select-all"
+          delay="1000"
+          show-during-load="show3-spinner"
+          style="Button"
+          target="id_sm_indicator"
+        >
+          <text style="Button__Label">Select All with Spinner</text>
+          <view id="show3-spinner" hide="true">
+            <spinner color="white" />
+          </view>
+        </view>
+      </view>
+    </body>
+  </screen>
+</doc>

--- a/examples/behaviors/unselect_all.xml
+++ b/examples/behaviors/unselect_all.xml
@@ -1,0 +1,284 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style
+        id="Header"
+        alignItems="center"
+        backgroundColor="white"
+        borderBottomColor="#eee"
+        borderBottomWidth="1"
+        flexDirection="row"
+        paddingLeft="24"
+        paddingRight="24"
+        paddingBottom="16"
+      />
+      <style
+        id="Header__Back"
+        color="blue"
+        fontSize="16"
+        fontWeight="600"
+        paddingRight="16"
+      />
+      <style id="Header__Title" color="black" fontSize="24" fontWeight="600" />
+      <style id="Body" backgroundColor="white" flex="1" />
+      <style
+        id="Description"
+        fontSize="16"
+        fontWeight="normal"
+        margin="24"
+        marginBottom="0"
+      />
+      <style
+        id="Item"
+        alignItems="center"
+        borderBottomColor="#eee"
+        borderBottomWidth="1"
+        flex="1"
+        flexDirection="row"
+        height="48"
+        justifyContent="space-between"
+        paddingLeft="24"
+        paddingRight="24"
+      />
+      <style id="Item__Label" fontSize="18" fontWeight="normal" />
+      <style id="Item__Chevron" fontSize="18" fontWeight="bold" />
+      <style
+        id="Button"
+        alignItems="center"
+        backgroundColor="#63CB76"
+        borderRadius="16"
+        flex="1"
+        flexDirection="column"
+        justifyContent="center"
+        margin="24"
+        padding="24"
+      />
+      <style id="Button__Label" color="white" fontSize="24" fontWeight="bold" />
+      <style
+        id="Container"
+        borderColor="#e1e1e1"
+        borderRadius="16"
+        borderWidth="2"
+        margin="24"
+        padding="24"
+      />
+      <style
+        id="Container__Label"
+        color="black"
+        fontSize="16"
+        fontWeight="normal"
+      />
+      <style id="Main" flex="1" />
+      <style id="Select" marginTop="24" />
+      <style
+        id="Select__Separator"
+        borderTopColor="#e1e3e3"
+        borderTopWidth="1"
+        marginLeft="24"
+        marginRight="24"
+      />
+      <style
+        id="Select__Option"
+        alignItems="center"
+        flex="1"
+        flexDirection="row"
+        justifyContent="space-between"
+        paddingBottom="16"
+        paddingLeft="24"
+        paddingRight="24"
+        paddingTop="16"
+      />
+      <style
+        id="Select__RadioOuter"
+        borderColor="#bdc4c4"
+        borderRadius="10"
+        borderWidth="1"
+        height="20"
+        width="20"
+      >
+        <modifier pressed="true">
+          <style borderColor="#8d9494" borderWidth="1" />
+        </modifier>
+        <modifier selected="true">
+          <style borderColor="#4778ff" borderWidth="2" />
+        </modifier>
+      </style>
+      <style
+        id="Select__RadioInner"
+        borderRadius="5"
+        height="10"
+        marginLeft="3"
+        marginTop="3"
+        opacity="0"
+        width="10"
+      >
+        <modifier selected="true">
+          <style backgroundColor="#4778ff" opacity="1" />
+        </modifier>
+      </style>
+      <style
+        id="Select__Label"
+        color="#4e4d4d"
+        fontSize="16"
+        fontWeight="normal"
+        lineHeight="18"
+      >
+        <modifier selected="true">
+          <style color="#312f2f" />
+        </modifier>
+        <modifier pressed="true">
+          <style color="#312f2f" />
+        </modifier>
+      </style>
+    </styles>
+    <body style="Body" safe-area="true">
+      <header style="Header">
+        <text action="back" href="#" style="Header__Back">Back</text>
+        <text style="Header__Title">Unselect All</text>
+      </header>
+      <view scroll="1" style="Main">
+        <text style="Description">
+          Tapping the button below will unselect all the options of a Multiple Select element.
+        </text>
+        <select-multiple id="id_sm" name="sm" style="Select">
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option1" selected="true">
+            <text style="Select__Label">Option 1</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option2" selected="true">
+            <text style="Select__Label">Option 2</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option3">
+            <text style="Select__Label">Option 3</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+        </select-multiple>
+        <view style="Button" target="id_sm" action="unselect-all">
+          <text style="Button__Label">Unselect All</text>
+        </view>
+        <text style="Description">
+          Unselect All can work with the delay attribute. In this example, the un-selection
+          will be delayed 1 second.
+        </text>
+        <select-multiple id="id_sm_delay" name="sm" style="Select">
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option1" selected="true">
+            <text style="Select__Label">Option 1</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option2" selected="true">
+            <text style="Select__Label">Option 2</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option3">
+            <text style="Select__Label">Option 3</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+        </select-multiple>
+        <view
+          action="unselect-all"
+          style="Button"
+          target="id_sm_delay"
+          delay="1000"
+        >
+          <text style="Button__Label">Unselect All with Delay</text>
+        </view>
+        <text style="Description">
+          When unselecting with delay, you can use indicators.
+        </text>
+        <select-multiple id="id_sm_indicator" name="sm" style="Select">
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option1" selected="true">
+            <text style="Select__Label">Option 1</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option2" selected="true">
+            <text style="Select__Label">Option 2</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option3">
+            <text style="Select__Label">Option 3</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+        </select-multiple>
+        <view
+          action="unselect-all"
+          delay="1000"
+          show-during-load="show3-spinner"
+          style="Button"
+          target="id_sm_indicator"
+        >
+          <text style="Button__Label">Unselect All with Spinner</text>
+          <view id="show3-spinner" hide="true">
+            <spinner color="white" />
+          </view>
+        </view>
+        <text style="Description">
+          Tapping the button below will unselect all the options of a Select Single element.
+        </text>
+        <select-single id="id_ss" name="ss" style="Select">
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option1" selected="true">
+            <text style="Select__Label">Option 1</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option2">
+            <text style="Select__Label">Option 2</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+          <option style="Select__Option" value="option3">
+            <text style="Select__Label">Option 3</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <option style="Select__Option" value="">
+            <text style="Select__Label">Option 4</text>
+            <view style="Select__RadioOuter">
+              <view style="Select__RadioInner" />
+            </view>
+          </option>
+          <view style="Select__Separator" />
+        </select-single>
+        <view style="Button" target="id_ss" action="unselect-all">
+          <text style="Button__Label">Unselect All</text>
+        </view>
+      </view>
+    </body>
+  </screen>
+</doc>

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -27,6 +27,8 @@
         <xs:enumeration value="set-value" />
         <xs:enumeration value="alert" />
         <xs:enumeration value="copy-to-clipboard" />
+        <xs:enumeration value="select-all" />
+        <xs:enumeration value="unselect-all" />
       </xs:restriction>
     </xs:simpleType>
   </xs:redefine>

--- a/src/behaviors/hv-select-all/index.js
+++ b/src/behaviors/hv-select-all/index.js
@@ -1,0 +1,80 @@
+// @flow
+
+import * as Behaviors from 'hyperview/src/services/behaviors';
+import * as Xml from 'hyperview/src/services/xml';
+import type {
+  DOMString,
+  Document,
+  Element,
+  HvComponentOnUpdate,
+  HvGetRoot,
+  HvUpdateRoot,
+} from 'hyperview/src/types';
+import { later, shallowCloneToRoot } from 'hyperview/src/services';
+import { ACTIONS } from 'hyperview/src/types';
+
+export default {
+  action: ACTIONS.SELECT_ALL,
+  callback: (
+    element: Element,
+    onUpdate: HvComponentOnUpdate,
+    getRoot: HvGetRoot,
+    updateRoot: HvUpdateRoot,
+  ) => {
+    const targetId: ?DOMString = element.getAttribute('target');
+    if (!targetId) {
+      console.warn('[behaviors/select-all]: missing "target" attribute');
+      return;
+    }
+
+    const delayAttr: string = element.getAttribute('delay') || '0';
+    const parsedDelay: number = parseInt(delayAttr, 10);
+    const delay: number = Number.isNaN(parsedDelay) ? 0 : parsedDelay;
+
+    const showIndicatorIds: Array<string> = Xml.splitAttributeList(
+      element.getAttribute('show-during-load') || '',
+    );
+    const hideIndicatorIds: Array<string> = Xml.splitAttributeList(
+      element.getAttribute('hide-during-load') || '',
+    );
+
+    const selectAll = () => {
+      const doc: Document = getRoot();
+      const targetElement: ?Element = doc.getElementById(targetId);
+      if (!targetElement) {
+        return;
+      }
+
+      targetElement.setAttribute('select-all', 'true');
+      let newRoot: Document = shallowCloneToRoot(targetElement);
+
+      // If using delay, we need to undo the indicators shown earlier.
+      if (delay > 0) {
+        newRoot = Behaviors.setIndicatorsAfterLoad(
+          showIndicatorIds,
+          hideIndicatorIds,
+          newRoot,
+        );
+      }
+      // Update the DOM with the new shown state and finished indicators.
+      updateRoot(newRoot);
+    };
+
+    if (delay === 0) {
+      // If there's no delay, select-all the target immediately without showing/hiding
+      // any indicators.
+      selectAll();
+    } else {
+      // If there's a delay, first trigger the indicators before the select-all.
+      const newRoot = Behaviors.setIndicatorsBeforeLoad(
+        showIndicatorIds,
+        hideIndicatorIds,
+        getRoot(),
+      );
+      // Update the DOM to reflect the new state of the indicators.
+      updateRoot(newRoot);
+      // Wait for the delay then select-all the target.
+      later(delay).then(selectAll).catch(selectAll);
+    }
+  },
+};

--- a/src/behaviors/hv-unselect-all/index.js
+++ b/src/behaviors/hv-unselect-all/index.js
@@ -1,0 +1,80 @@
+// @flow
+
+import * as Behaviors from 'hyperview/src/services/behaviors';
+import * as Xml from 'hyperview/src/services/xml';
+import type {
+  DOMString,
+  Document,
+  Element,
+  HvComponentOnUpdate,
+  HvGetRoot,
+  HvUpdateRoot,
+} from 'hyperview/src/types';
+import { later, shallowCloneToRoot } from 'hyperview/src/services';
+import { ACTIONS } from 'hyperview/src/types';
+
+export default {
+  action: ACTIONS.UNSELECT_ALL,
+  callback: (
+    element: Element,
+    onUpdate: HvComponentOnUpdate,
+    getRoot: HvGetRoot,
+    updateRoot: HvUpdateRoot,
+  ) => {
+    const targetId: ?DOMString = element.getAttribute('target');
+    if (!targetId) {
+      console.warn('[behaviors/unselect-all]: missing "target" attribute');
+      return;
+    }
+
+    const delayAttr: string = element.getAttribute('delay') || '0';
+    const parsedDelay: number = parseInt(delayAttr, 10);
+    const delay: number = Number.isNaN(parsedDelay) ? 0 : parsedDelay;
+
+    const showIndicatorIds: Array<string> = Xml.splitAttributeList(
+      element.getAttribute('show-during-load') || '',
+    );
+    const hideIndicatorIds: Array<string> = Xml.splitAttributeList(
+      element.getAttribute('hide-during-load') || '',
+    );
+
+    const unselectAll = () => {
+      const doc: Document = getRoot();
+      const targetElement: ?Element = doc.getElementById(targetId);
+      if (!targetElement) {
+        return;
+      }
+
+      targetElement.setAttribute('unselect-all', 'true');
+      let newRoot: Document = shallowCloneToRoot(targetElement);
+
+      // If using delay, we need to undo the indicators shown earlier.
+      if (delay > 0) {
+        newRoot = Behaviors.setIndicatorsAfterLoad(
+          showIndicatorIds,
+          hideIndicatorIds,
+          newRoot,
+        );
+      }
+      // Update the DOM with the new shown state and finished indicators.
+      updateRoot(newRoot);
+    };
+
+    if (delay === 0) {
+      // If there's no delay, unselect-all the target immediately without showing/hiding
+      // any indicators.
+      unselectAll();
+    } else {
+      // If there's a delay, first trigger the indicators before the unselect-all.
+      const newRoot = Behaviors.setIndicatorsBeforeLoad(
+        showIndicatorIds,
+        hideIndicatorIds,
+        getRoot(),
+      );
+      // Update the DOM to reflect the new state of the indicators.
+      updateRoot(newRoot);
+      // Wait for the delay then unselect-all the target.
+      later(delay).then(unselectAll).catch(unselectAll);
+    }
+  },
+};

--- a/src/behaviors/index.js
+++ b/src/behaviors/index.js
@@ -13,20 +13,24 @@ import HvAlert from 'hyperview/src/behaviors/hv-alert';
 import HvCopyToClipboard from 'hyperview/src/behaviors/hv-copy-to-clipboard';
 import HvHide from 'hyperview/src/behaviors/hv-hide';
 import HvOpenSettings from 'hyperview/src/behaviors/hv-open-settings';
+import HvSelectAll from 'hyperview/src/behaviors/hv-select-all';
 import HvSetValue from 'hyperview/src/behaviors/hv-set-value';
 import HvShare from 'hyperview/src/behaviors/hv-share';
 import HvShow from 'hyperview/src/behaviors/hv-show';
 import HvToggle from 'hyperview/src/behaviors/hv-toggle';
+import HvUnselectAll from 'hyperview/src/behaviors/hv-unselect-all';
 
 const HYPERVIEW_BEHAVIORS = [
   HvAlert,
   HvCopyToClipboard,
   HvHide,
   HvOpenSettings,
+  HvSelectAll,
   HvSetValue,
   HvShare,
   HvShow,
   HvToggle,
+  HvUnselectAll,
 ];
 
 export const getRegistry = (behaviors: HvBehavior[] = []): BehaviorRegistry =>

--- a/src/components/hv-select-multiple/index.js
+++ b/src/components/hv-select-multiple/index.js
@@ -53,6 +53,19 @@ export default class HvSelectMultiple extends PureComponent<HvComponentProps> {
     this.onToggle = this.onToggle.bind(this);
   }
 
+  componentDidUpdate() {
+    // NOTE: we need to remove the attribute before
+    // (un)selecting all, since (un)selecting all will update the component.
+    if (this.props.element.hasAttribute('select-all')) {
+      this.props.element.removeAttribute('select-all');
+      this.applyToAllOptions(true);
+    }
+    if (this.props.element.hasAttribute('unselect-all')) {
+      this.props.element.removeAttribute('unselect-all');
+      this.applyToAllOptions(false);
+    }
+  }
+
   /**
    * Callback passed to children. Option components invoke this callback when toggles.
    * Will update the XML DOM to toggle the option with the given value.
@@ -71,6 +84,21 @@ export default class HvSelectMultiple extends PureComponent<HvComponentProps> {
           const selected = option.getAttribute('selected') === 'true';
           option.setAttribute('selected', selected ? 'false' : 'true');
         }
+      }
+    }
+    this.props.onUpdate('#', 'swap', this.props.element, { newElement });
+  };
+
+  applyToAllOptions = (selected: boolean) => {
+    const newElement = this.props.element.cloneNode(true);
+    const options = newElement.getElementsByTagNameNS(
+      Namespaces.HYPERVIEW,
+      'option',
+    );
+    for (let i = 0; i < options.length; i += 1) {
+      const option = options.item(i);
+      if (option) {
+        option.setAttribute('selected', selected ? 'true' : 'false');
       }
     }
     this.props.onUpdate('#', 'swap', this.props.element, { newElement });

--- a/src/components/hv-select-single/index.js
+++ b/src/components/hv-select-single/index.js
@@ -53,12 +53,16 @@ export default class HvSelectSingle extends PureComponent<HvComponentProps> {
   }
 
   componentDidUpdate() {
+    // NOTE(adam): we need to remove the attribute before
+    // selection, since selection will update the component.
     if (this.props.element.hasAttribute('value')) {
-      // NOTE(adam): we need to remove the attribute before
-      // selection, since selection will update the component.
       const newValue = this.props.element.getAttribute('value');
       this.props.element.removeAttribute('value');
       this.onSelect(newValue);
+    }
+    if (this.props.element.hasAttribute('unselect-all')) {
+      this.props.element.removeAttribute('unselect-all');
+      this.onSelect(null);
     }
   }
 

--- a/src/types.js
+++ b/src/types.js
@@ -365,7 +365,9 @@ export const ACTIONS = {
   RELOAD: 'reload',
   REPLACE: 'replace',
   REPLACE_INNER: 'replace-inner',
+  SELECT_ALL: 'select-all',
   SWAP: 'swap',
+  UNSELECT_ALL: 'unselect-all',
 };
 
 export const NAV_ACTIONS = {


### PR DESCRIPTION
Create `"select-all"` and `"unselect-all"` behavior actions.

https://user-images.githubusercontent.com/91907891/174645840-738bc378-fcfa-4fca-844f-e6576357a141.mp4

https://user-images.githubusercontent.com/91907891/174645831-6efcfd84-c78a-460c-b213-4b24588f0125.mp4

*NB*: while `"select-all"` is only supported by [`<select-multiple>`](https://hyperview.org/docs/reference_selectmultiple), `"unselect-all"` is supported by both [`<select-multiple>`](https://hyperview.org/docs/reference_selectmultiple) and [`<select-single>`](https://hyperview.org/docs/reference_selectsingle).
