### PR TITLE
fix(schema): Allow `<section>` to be a child of `<items>`

### DIFF
--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -837,6 +837,7 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:item" />
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:section" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
`<items>` is an alias of `<view>` that allows returning list partials. 