### PR TITLE
fix: Nested text spaces

### DIFF
--- a/src/services/dom/helpers.js
+++ b/src/services/dom/helpers.js
@@ -15,7 +15,9 @@ import type {
   HvComponentOnUpdate,
   LocalName,
   NamespaceURI,
+  Node,
 } from 'hyperview/src/types';
+import { LOCAL_NAME } from 'hyperview/src/types';
 
 export const getBehaviorElements = (element: any) => {
   // $FlowFixMe
@@ -76,3 +78,7 @@ export const triggerBehaviors = (
     });
   });
 };
+
+export const isWrappedByTextNode = (node: Node): boolean =>
+  node.parentNode?.namespaceURI === Namespaces.HYPERVIEW &&
+  node.parentNode?.localName === LOCAL_NAME.TEXT;


### PR DESCRIPTION
When `<text>` element are nested, collapse spaces instead of trimming them to ensure correct rendering.

| Before | After |
|-------|-------|
| ![Simulator Screen Shot - iPhone 13 mini - 2022-07-07 at 21 24 49](https://user-images.githubusercontent.com/309515/177918108-eb8eee86-993a-4fc7-a7fa-bdcdd665d340.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-07-07 at 21 38 55](https://user-images.githubusercontent.com/309515/177918128-f3779807-723b-4836-9f01-ea2bc93dcb74.png) |
