### PR TITLE
fix: Nested text spaces

### DIFF
--- a/src/services/dom/helpers.js
+++ b/src/services/dom/helpers.js
@@ -15,6 +15,8 @@ import type {
   HvComponentOnUpdate,
   LocalName,
   NamespaceURI,
+  Node,
+  NodeType,
 } from 'hyperview/src/types';
 
 export const getBehaviorElements = (element: any) => {
@@ -75,4 +77,24 @@ export const triggerBehaviors = (
       verb,
     });
   });
+};
+
+/**
+ * N-ary Tree Preorder Traversal
+ */
+export const preorder = (
+  root: Node,
+  type: NodeType,
+  acc: Node[] = [],
+): Node[] => {
+  if (root.childNodes) {
+    Array.from(root.childNodes).forEach((node: ?Node) => {
+      if (node) {
+        preorder(node, type, acc);
+      }
+    });
+  } else if (root.nodeType === type) {
+    acc.push(root);
+  }
+  return acc;
 };

--- a/src/services/dom/helpers.test.js
+++ b/src/services/dom/helpers.test.js
@@ -1,0 +1,54 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { NODE_TYPE } from 'hyperview/src/types';
+import { parse } from 'hyperview/test/helpers';
+import { preorder } from './helpers';
+
+describe('preorder', () => {
+  test('1', () => {
+    const node: Document = parse(
+      `<text id="a">
+          <text id="b">
+            <text id="c">   </text>
+            <text id="d">   </text>
+            <text id="e">
+              Hello
+            </text>
+            <text id="f">
+              World
+            </text>
+          </text>
+          <text id="g">
+            of HyperView! 
+          </text>
+          <text id="h"> </text>
+        </text>`,
+    );
+    // $FlowFixMe: preorder expects a Node (which Document is a subtype of)
+    expect(preorder(node, NODE_TYPE.TEXT_NODE)).toEqual([
+      node.getElementById('a')?.firstChild, // ⏎◦◦◦◦◦◦◦◦◦◦◦◦
+      node.getElementById('b')?.firstChild, // ⏎◦◦◦◦◦◦◦◦◦◦◦◦◦◦
+      node.getElementById('c')?.firstChild, // ◦◦◦
+      node.getElementById('c')?.nextSibling, // ⏎◦◦◦◦◦◦◦◦◦◦◦◦◦◦
+      node.getElementById('d')?.firstChild, // ◦◦◦
+      node.getElementById('d')?.nextSibling, // ⏎◦◦◦◦◦◦◦◦◦◦◦◦◦◦
+      node.getElementById('e')?.firstChild, // Hello
+      node.getElementById('e')?.nextSibling, // ⏎◦◦◦◦◦◦◦◦◦◦◦◦◦◦
+      node.getElementById('f')?.firstChild, // World
+      node.getElementById('f')?.nextSibling, // ⏎◦◦◦◦◦◦◦◦◦◦◦◦
+      node.getElementById('g')?.previousSibling, // ⏎◦◦◦◦◦◦◦◦◦◦◦◦
+      node.getElementById('g')?.firstChild, // of Hyperview!
+      node.getElementById('g')?.nextSibling, // ⏎◦◦◦◦◦◦◦◦◦◦◦◦
+      node.getElementById('h')?.firstChild, // ◦
+      node.getElementById('a')?.lastChild, // ⏎◦◦◦◦◦◦◦◦◦◦
+    ]);
+  });
+});

--- a/src/services/inline-context/helpers.js
+++ b/src/services/inline-context/helpers.js
@@ -19,15 +19,22 @@ export const convertLineBreaksIntoSpaces = (input: string): string =>
   input.replace(/\n/g, SPACE);
 
 export const ignoreSpacesFollowingSpace = (input: string[]): string[] => {
-  return input.map((value: string, index: number, values: string[]): string => {
-    if (index > 0) {
-      const previousEntry = values[index - 1];
-      const lastChar = previousEntry[previousEntry.length - 1];
-      if (lastChar === SPACE || previousEntry === EMPTY) {
-        return value.replace(/\s+/g, SPACE).trimStart();
-      }
+  let lastValueEndedWithSpace = false;
+  return input.map((value: string): string => {
+    // Replace every consecutive spaces with a single space
+    let trimmed = value.replace(/\s+/g, SPACE);
+
+    // If last string ended with a space, remove leading spaces
+    if (lastValueEndedWithSpace) {
+      trimmed = trimmed.trimStart();
     }
-    return value.replace(/\s+/g, SPACE);
+
+    // Set flag for next iteration, only when the current string is not empty
+    if (trimmed.length > 0) {
+      lastValueEndedWithSpace = trimmed[trimmed.length - 1] === SPACE;
+    }
+
+    return trimmed;
   });
 };
 

--- a/src/services/inline-context/helpers.js
+++ b/src/services/inline-context/helpers.js
@@ -12,12 +12,25 @@ export const LINE_BREAK = '\n';
 export const EMPTY = '';
 export const SPACE = ' ';
 
+/**
+ * Removes any space that follows a line break
+ */
 export const ignoreSpacesAfterLineBreak = (input: string): string =>
   input.replace(/\n\s+/g, LINE_BREAK);
 
+/**
+ * Replaces any line break by a space
+ */
 export const convertLineBreaksIntoSpaces = (input: string): string =>
   input.replace(/\n/g, SPACE);
 
+/**
+ * Provided a list of strings as input, removes any spaces
+ * that immediately follows another space, across consecutive entries in the list
+ * i.e.
+ * input = [" ", " Hello ", " world ", " ", " "]
+ * output = [" ", "Hello ", "world ", "", ""]
+ */
 export const ignoreSpacesFollowingSpace = (input: string[]): string[] => {
   let lastValueEndedWithSpace = false;
   return input.map((value: string): string => {
@@ -38,6 +51,12 @@ export const ignoreSpacesFollowingSpace = (input: string[]): string[] => {
   });
 };
 
+/**
+ * Provided a list of strings as input, removes any leading and trailing spaces
+ * i.e.
+ * input = [" ", " Hello ", "world ", " ", " "]
+ * output = ["", "Hello ", "world", "", ""]
+ */
 export const trim = (input: string[]): string[] => {
   // Trim the start of the string
   let trimStartDone = false;

--- a/src/services/inline-context/helpers.js
+++ b/src/services/inline-context/helpers.js
@@ -1,0 +1,72 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export const LINE_BREAK = '\n';
+export const EMPTY = '';
+export const SPACE = ' ';
+
+export const ignoreSpacesAfterLineBreak = (input: string): string =>
+  input.replace(/\n\s+/g, LINE_BREAK);
+
+export const convertLineBreaksIntoSpaces = (input: string): string =>
+  input.replace(/\n/g, SPACE);
+
+export const ignoreSpacesFollowingSpace = (input: string[]): string[] => {
+  return input.map((value: string, index: number, values: string[]): string => {
+    if (index > 0) {
+      const previousEntry = values[index - 1];
+      const lastChar = previousEntry[previousEntry.length - 1];
+      if (lastChar === SPACE || previousEntry === EMPTY) {
+        return value.replace(/\s+/g, SPACE).trimStart();
+      }
+    }
+    return value.replace(/\s+/g, SPACE);
+  });
+};
+
+export const trim = (input: string[]): string[] => {
+  // Trim the start of the string
+  let trimStartDone = false;
+  const startTrimmed = [];
+  input.forEach((value: string) => {
+    let shouldTrim = false;
+    if (startTrimmed.length === 0) {
+      shouldTrim = true;
+    } else if (!trimStartDone) {
+      const previousEntry = startTrimmed[startTrimmed.length - 1];
+      if (previousEntry === EMPTY) {
+        shouldTrim = true;
+      } else {
+        trimStartDone = true;
+      }
+    }
+    startTrimmed.push(shouldTrim ? value.trimStart() : value);
+  });
+
+  // Trim the end of the string
+  let trimEndDone = false;
+  const endTrimmed = [];
+  startTrimmed.reverse().forEach((value: string) => {
+    let shouldTrim = false;
+    if (endTrimmed.length === 0) {
+      shouldTrim = true;
+    } else if (!trimEndDone) {
+      const previousEntry = endTrimmed[endTrimmed.length - 1];
+      if (previousEntry === EMPTY) {
+        shouldTrim = true;
+      } else {
+        trimEndDone = true;
+      }
+    }
+    endTrimmed.push(shouldTrim ? value.trimEnd() : value);
+  });
+
+  return endTrimmed.reverse();
+};

--- a/src/services/inline-context/helpers.test.js
+++ b/src/services/inline-context/helpers.test.js
@@ -76,6 +76,11 @@ describe('ignoreSpacesFollowingSpace', () => {
       ]),
     ).toEqual([' ', '', '', '', 'foo ', '', '', '', 'bar baz ', '', '', '']);
   });
+  test('5', () => {
+    expect(
+      ignoreSpacesFollowingSpace(['', '', ' ', ' foo  ', ' ', ' bar ', ' ']),
+    ).toEqual(['', '', ' ', 'foo ', '', 'bar ', '']);
+  });
 });
 
 describe('trim', () => {

--- a/src/services/inline-context/helpers.test.js
+++ b/src/services/inline-context/helpers.test.js
@@ -1,0 +1,100 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  convertLineBreaksIntoSpaces,
+  ignoreSpacesAfterLineBreak,
+  ignoreSpacesFollowingSpace,
+  trim,
+} from './helpers';
+
+describe('ignoreSpacesAfterLineBreak', () => {
+  test('1', () => {
+    expect(ignoreSpacesAfterLineBreak('\n ')).toEqual('\n');
+  });
+  test('2', () => {
+    expect(ignoreSpacesAfterLineBreak('\n   ')).toEqual('\n');
+  });
+  test('3', () => {
+    expect(ignoreSpacesAfterLineBreak(' \n   ')).toEqual(' \n');
+  });
+  test('4', () => {
+    expect(ignoreSpacesAfterLineBreak('  \n   ')).toEqual('  \n');
+  });
+});
+
+describe('convertLineBreaksIntoSpaces', () => {
+  test('1', () => {
+    expect(convertLineBreaksIntoSpaces('\n')).toEqual(' ');
+  });
+  test('2', () => {
+    expect(convertLineBreaksIntoSpaces('  \n\n  ')).toEqual('      ');
+  });
+  test('3', () => {
+    expect(convertLineBreaksIntoSpaces(' \n \n ')).toEqual('     ');
+  });
+});
+
+describe('ignoreSpacesFollowingSpace', () => {
+  test('1', () => {
+    expect(ignoreSpacesFollowingSpace([' ', ' ', ' '])).toEqual([' ', '', '']);
+  });
+  test('2', () => {
+    expect(ignoreSpacesFollowingSpace([' ', ' foo ', ' '])).toEqual([
+      ' ',
+      'foo ',
+      '',
+    ]);
+  });
+  test('3', () => {
+    expect(
+      ignoreSpacesFollowingSpace([' ', '  foo  ', ' bar   baz  ', ' ']),
+    ).toEqual([' ', 'foo ', 'bar baz ', '']);
+  });
+  test('4', () => {
+    expect(
+      ignoreSpacesFollowingSpace([
+        ' ',
+        '',
+        ' ',
+        '',
+        '  foo  ',
+        '',
+        ' ',
+        '',
+        '  bar   baz  ',
+        ' ',
+        '',
+        ' ',
+      ]),
+    ).toEqual([' ', '', '', '', 'foo ', '', '', '', 'bar baz ', '', '', '']);
+  });
+});
+
+describe('trim', () => {
+  test('1', () => {
+    expect(trim([' ', 'foo', ' '])).toEqual(['', 'foo', '']);
+  });
+  test('2', () => {
+    expect(trim([' ', '  foo  ', ' '])).toEqual(['', 'foo', '']);
+  });
+  test('3', () => {
+    expect(trim([' ', '', '  foo  ', '', ' '])).toEqual([
+      '',
+      '',
+      'foo',
+      '',
+      '',
+    ]);
+  });
+  test('4', () => {
+    expect(trim(['', 'foo', ''])).toEqual(['', 'foo', '']);
+  });
+});

--- a/src/services/inline-context/index.js
+++ b/src/services/inline-context/index.js
@@ -1,0 +1,89 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import * as Dom from 'hyperview/src/services/dom';
+import {
+  EMPTY,
+  convertLineBreaksIntoSpaces,
+  ignoreSpacesAfterLineBreak,
+  ignoreSpacesFollowingSpace,
+  trim,
+} from './helpers';
+import type { Element, Node } from 'hyperview/src/types';
+import { NODE_TYPE } from 'hyperview/src/types';
+
+/**
+ * Given the following markup:
+
+   <text id="a">⏎
+   ◦◦<text id="b">⏎
+   ◦◦◦◦<text id="d">⏎
+   ◦◦◦◦◦◦Hello⏎
+   ◦◦◦◦</text>⏎
+   ◦◦◦◦<text id="e">⏎
+   ◦◦◦◦◦◦World⏎
+   ◦◦◦◦</text>⏎
+   ◦◦</text>⏎
+   ◦◦<text id="c">⏎
+   ◦◦◦◦of HyperView!⏎
+   ◦◦</text>⏎
+   </text>
+   
+   And its associated tree representation:
+
+                                          [<text id="a">]
+      __________________________________________|_________________________________
+     /                        /                       \            \              \
+    /                        /                         \            \              \
+   /                        /                           \            \              \
+[⏎◦◦]              [<text id="b"/>]                      [⏎◦◦]    [<text id="c"/>]    [⏎]
+         _________________|__________________________                     |
+       /       |              |           |          \                    |
+      /        |              |           |           \                   |
+     /         |              |           |            \            [⏎◦◦◦◦of HyperView!⏎]
+[⏎◦◦◦◦]  [<text id="d"/>]  [⏎◦◦◦◦]  [<text id="e"/>]  [⏎◦◦]
+               |                            |
+               |                            |
+               |                            |
+         [⏎◦◦◦◦◦◦Hello⏎]              [⏎◦◦◦◦◦◦World⏎◦◦◦◦]
+
+  We're using using preorder traversal algorithm to retrieve leaf nodes, and put them in a list, such as:
+
+  ['⏎◦◦', '⏎◦◦◦◦', '⏎◦◦◦◦◦◦Hello⏎', '⏎◦◦◦◦', '⏎◦◦◦◦◦◦World⏎◦◦◦◦', '⏎◦◦', '⏎◦◦', '⏎◦◦◦◦of HyperView!⏎', '⏎']
+
+  For each node, we then apply the following rules:
+
+  1- All spaces immediately before and after a line break are ignored:
+    ['⏎', '⏎', '⏎Hello⏎', '⏎', '⏎World⏎', '⏎', '⏎', '⏎of HyperView!⏎', '⏎']
+
+  2- Line breaks are converted to spaces:
+    ['◦', '◦', '◦Hello◦', '◦', '◦World◦', '◦', '◦', '◦of HyperView!◦', '◦']
+
+  3- Any space immediately following another space is ignored
+    ['◦', '', 'Hello◦', '', 'World◦', '', '', 'of HyperView!◦', '']
+
+  4- Sequences of spaces at the beginning and end of a line are removed
+    ['', '', 'Hello◦', '', 'World◦', '', '', 'of HyperView!', '']
+
+  (inspired by: https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace#how_does_css_process_whitespace#explanation)
+ */
+export const formatter = (root: Element): [Node[], string[]] => {
+  const nodes = Dom.preorder(root, NODE_TYPE.TEXT_NODE);
+
+  const nodeValues: string[] = Array.from(nodes)
+    .map((node: Node): string =>
+      node && node.nodeValue
+        ? ignoreSpacesAfterLineBreak(node.nodeValue)
+        : EMPTY,
+    )
+    .map((nodeValue: string) => convertLineBreaksIntoSpaces(nodeValue));
+
+  return [nodes, trim(ignoreSpacesFollowingSpace(nodeValues))];
+};

--- a/src/services/inline-context/index.test.js
+++ b/src/services/inline-context/index.test.js
@@ -1,0 +1,74 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import * as InlineContext from 'hyperview/src/services/inline-context';
+import { parse } from 'hyperview/test/helpers';
+
+describe('inlineFormatter', () => {
+  test('1', () => {
+    const node: Document = parse(
+      `<text id="a">
+          <text id="b">
+            <text id="c">   </text>
+            <text id="d">   </text>
+            <text id="e">
+              Hello
+            </text>
+            <text id="f">
+              World
+            </text>
+          </text>
+          <text id="g">
+            of HyperView! 
+          </text>
+          <text id="h"> </text>
+        </text>`,
+    );
+    const expectedNodes = [
+      node.getElementById('a')?.firstChild, // ⏎◦◦◦◦◦◦◦◦◦◦◦◦
+      node.getElementById('b')?.firstChild, // ⏎◦◦◦◦◦◦◦◦◦◦◦◦◦◦
+      node.getElementById('c')?.firstChild, // ◦◦◦
+      node.getElementById('c')?.nextSibling, // ⏎◦◦◦◦◦◦◦◦◦◦◦◦◦◦
+      node.getElementById('d')?.firstChild, // ◦◦◦
+      node.getElementById('d')?.nextSibling, // ⏎◦◦◦◦◦◦◦◦◦◦◦◦◦◦
+      node.getElementById('e')?.firstChild, // Hello
+      node.getElementById('e')?.nextSibling, // ⏎◦◦◦◦◦◦◦◦◦◦◦◦◦◦
+      node.getElementById('f')?.firstChild, // World
+      node.getElementById('f')?.nextSibling, // ⏎◦◦◦◦◦◦◦◦◦◦◦◦
+      node.getElementById('g')?.previousSibling, // ⏎◦◦◦◦◦◦◦◦◦◦◦◦
+      node.getElementById('g')?.firstChild, // of Hyperview!
+      node.getElementById('g')?.nextSibling, // ⏎◦◦◦◦◦◦◦◦◦◦◦◦
+      node.getElementById('h')?.firstChild, // ◦
+      node.getElementById('a')?.lastChild, // ⏎◦◦◦◦◦◦◦◦◦◦
+    ];
+    const expectedValues = [
+      '',
+      '',
+      '',
+      '',
+      '',
+      '',
+      'Hello ',
+      '',
+      'World ',
+      '',
+      '',
+      'of HyperView!',
+      '',
+      '',
+      '',
+    ];
+    // $FlowFixMe: formatter expects a Node (which Document is a subtype of)
+    expect(InlineContext.formatter(node)).toEqual([
+      expectedNodes,
+      expectedValues,
+    ]);
+  });
+});

--- a/src/types.js
+++ b/src/types.js
@@ -276,6 +276,7 @@ export type HvComponentOptions = {
   showIndicatorIds?: ?DOMString,
   styleAttr?: ?DOMString,
   targetId?: ?DOMString,
+  inlineFormattingContext?: ?[Node[], string[]],
 };
 
 export type HvComponentOnUpdate = (


### PR DESCRIPTION
Create inline formatting context when rendering a `<text>` element. Traverse the element tree, create a list of text node leaves, ordered as they appear on screen, then apply logic to collide/trim spaces (explanation of logic [here](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace#how_does_css_process_whitespace#explanation)).

**Demo:**
| Before | After |
|-------|-------|
| ![Simulator Screen Shot - iPhone 13 mini - 2022-07-10 at 18 16 38](https://user-images.githubusercontent.com/309515/178171759-7c34823d-f12f-4166-8fa7-186d532fab2d.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-07-10 at 18 22 46](https://user-images.githubusercontent.com/309515/178171764-14870607-de2e-44cf-8512-edd72ddfeb58.png) |

**Note:** Unlike HTML, siblings `<text>` elements that are not nested under a parent text won't apply the inline formatting context, hence won't be separated by space.

For example, the following markup:

```xml
<text>Hello</text> <text>World</text>
```

will render:
```
HelloWorld
```

to properly observe spaces, the `<text>` elements should be nested under another `<text>`, such as:
```xml
<text><text>Hello</text> <text>World</text></text>
```

will render:
```
Hello World
```


**TODO:**
- [X] add more demo cases to cover more use cases - done in #449
- [X] screenshots
- [x] Testing in Instawork app

Rework of #444