### PR TITLE
chore(web): Event handlers stop propagation/prevent defaults

### DIFF
--- a/src/components/hv-option/index.js
+++ b/src/components/hv-option/index.js
@@ -16,6 +16,7 @@ import { TouchableWithoutFeedback, View } from 'react-native';
 import type { HvComponentProps } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import type { State } from './types';
+import { createEventHandler } from 'hyperview/src/core/hyper-ref';
 import { createProps } from 'hyperview/src/services';
 
 /**
@@ -122,7 +123,7 @@ export default class HvOption extends PureComponent<HvComponentProps, State> {
     // Option renders as an outer TouchableWithoutFeedback view and inner view.
     // The outer view handles presses, the inner view handles styling.
     const outerProps = {
-      onPress: () => {
+      onPress: createEventHandler(() => {
         if (onSelect) {
           // Updates the DOM state, causing this element to re-render as selected.
           // Used in select-single context.
@@ -133,9 +134,9 @@ export default class HvOption extends PureComponent<HvComponentProps, State> {
           // Used in select-multiple context.
           onToggle(value);
         }
-      },
-      onPressIn: () => this.setState({ pressed: true }),
-      onPressOut: () => this.setState({ pressed: false }),
+      }),
+      onPressIn: createEventHandler(() => this.setState({ pressed: true })),
+      onPressOut: createEventHandler(() => this.setState({ pressed: false })),
       style: undefined,
     };
     if (props.style && props.style.flex) {

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -33,6 +33,16 @@ import VisibilityDetectingView from 'hyperview/src/VisibilityDetectingView';
 import { XMLSerializer } from 'xmldom-instawork';
 import { createTestProps } from 'hyperview/src/services';
 
+export const createEventHandler = (
+  handler: () => void,
+): ((event: any) => void) => event => {
+  if (event) {
+    event.stopPropagation();
+    event.preventDefault();
+  }
+  handler();
+};
+
 /**
  * Component that handles dispatching behaviors based on the appropriate
  * triggers.
@@ -228,46 +238,46 @@ export default class HyperRef extends PureComponent<Props, State> {
         );
         if (pressHandlers[triggerPropName]) {
           const oldHandler = pressHandlers[triggerPropName];
-          pressHandlers[triggerPropName] = () => {
+          pressHandlers[triggerPropName] = createEventHandler(() => {
             oldHandler();
             setTimeout(handler, time);
             time += 1;
-          };
+          });
         } else {
-          pressHandlers[triggerPropName] = handler;
+          pressHandlers[triggerPropName] = createEventHandler(handler);
         }
       });
 
       if (pressHandlers.onPressIn) {
         const oldHandler = pressHandlers.onPressIn;
-        pressHandlers.onPressIn = () => {
+        pressHandlers.onPressIn = createEventHandler(() => {
           this.setState({ pressed: true });
           oldHandler();
-        };
+        });
       } else {
-        pressHandlers.onPressIn = () => {
+        pressHandlers.onPressIn = createEventHandler(() => {
           this.setState({ pressed: true });
-        };
+        });
       }
 
       if (pressHandlers.onPressOut) {
         const oldHandler = pressHandlers.onPressOut;
-        pressHandlers.onPressOut = () => {
+        pressHandlers.onPressOut = createEventHandler(() => {
           this.setState({ pressed: false });
           oldHandler();
-        };
+        });
       } else {
-        pressHandlers.onPressOut = () => {
+        pressHandlers.onPressOut = createEventHandler(() => {
           this.setState({ pressed: false });
-        };
+        });
       }
 
       // Fix a conflict between onPressOut and onPress triggering at the same time.
       if (pressHandlers.onPressOut && pressHandlers.onPress) {
         const onPressHandler = pressHandlers.onPress;
-        pressHandlers.onPress = () => {
+        pressHandlers.onPress = createEventHandler(() => {
           setTimeout(onPressHandler, time);
-        };
+        });
       }
 
       renderedComponent = React.createElement(

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -33,6 +33,12 @@ import VisibilityDetectingView from 'hyperview/src/VisibilityDetectingView';
 import { XMLSerializer } from 'xmldom-instawork';
 import { createTestProps } from 'hyperview/src/services';
 
+/**
+ * Wrapper to handle UI events
+ * Stop propagation and prevent default client behavior
+ * This prevents clicks on various elements to trigger browser navigation
+ * when using Hyperview for web.
+ */
 export const createEventHandler = (
   handler: () => void,
 ): ((event: any) => void) => event => {


### PR DESCRIPTION
Wrap every press handler with helper that stop event propagation/prevent defaults. This does not affect UX on mobile, but allows for web interactions to perform as expected (so that the links added by behaviors are not "followed" by the browser).