### PR TITLE
fix: Implement native only components for web

### DIFF
--- a/src/core/components/date-time-picker/index.web.js
+++ b/src/core/components/date-time-picker/index.web.js
@@ -1,0 +1,16 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// Currently not implemented, should be addressed in
+// https://github.com/Instawork/hyperview/issues/454
+export default () => {
+  alert('Not implemented!'); // eslint-disable-line no-alert
+  return '';
+};

--- a/src/core/components/keyboard-aware-scroll-view/index.web.js
+++ b/src/core/components/keyboard-aware-scroll-view/index.web.js
@@ -1,0 +1,18 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React from 'react';
+import { View } from 'react-native';
+
+// Simple passthrough on web. We might want to detect
+// the device type in the future, to support keyboard
+// avoiding when the web page is rendered on device
+// equiped with a virtual keyboard
+export default (props: any) => <View {...props} />;

--- a/src/core/components/web-view/index.web.js
+++ b/src/core/components/web-view/index.web.js
@@ -1,0 +1,34 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Dimensions } from 'react-native';
+import React from 'react';
+
+// Currently partially implemented, should be brought to parity
+// with mobile in https://github.com/Instawork/hyperview/issues/455
+export default (props: any) => {
+  const windowDimensions = Dimensions.get('window');
+  const windowHeight = windowDimensions.height;
+  const windowWidth = windowDimensions.width;
+  if (props.source.uri) {
+    return (
+      <iframe
+        height={windowHeight}
+        src={props.source.uri}
+        title="-"
+        width={windowWidth}
+      />
+    );
+  }
+  if (props.source.html) {
+    return props.source.html;
+  }
+  return '';
+};


### PR DESCRIPTION
Implement variants of `date-time-picker`, `keyboard-aware-scroll-view` and `web-view` for Hyperview web.