### PR TITLE
fix: Ensure we always pass a valid http method to `fetch`

### DIFF
--- a/src/services/dom/parser.js
+++ b/src/services/dom/parser.js
@@ -56,9 +56,14 @@ export class Parser {
   load = async (
     baseUrl: string,
     data: ?FormData,
-    method: ?HttpMethod = HTTP_METHODS.GET,
+    httpMethod: ?HttpMethod,
     acceptContentType: string = CONTENT_TYPE.APPLICATION_VND_HYPERVIEW_XML,
   ): Promise<Document> => {
+    // HTTP method can either be POST when explicitly set
+    // Any other value and we'll default to GET
+    const method =
+      httpMethod === HTTP_METHODS.POST ? HTTP_METHODS.POST : HTTP_METHODS.GET;
+
     // For GET requests, we can't include a body so we encode the form data as a query
     // string in the URL.
     const url =


### PR DESCRIPTION
When the HTTP method is not explicitly set in the XML, the parser returns an empty string value for `verb`. While this works fine in React Native and defaults to `GET`, this fails on web. Since we can't rely on the default value for the `load` method (as empty string takes precedence), make the `method` param default to `undefined`, and instead set the default value in the body of the method.