### PR TITLE
feat(demo/web): Configure demo app to work on web

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,20 @@
 module.exports = function (eleventyConfig) {
+  eleventyConfig.setBrowserSyncConfig({
+    middleware: function (req, res, next) {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+      res.setHeader(
+        'Access-Control-Allow-Headers',
+        'x-hyperview-dimensions,x-hyperview-version,pragma,expires,cache-control',
+      );
+      if (req.method === 'OPTIONS') {
+        res.writeHead(200, {});
+        res.end();
+      } else {
+        next();
+      }
+    },
+  });
   // Pass through any XML files that haven't been ported yet.
   // Once everything is ported, we can remove this.
   eleventyConfig.addPassthroughCopy("examples/**/*.xml");

--- a/demo/App.js
+++ b/demo/App.js
@@ -6,7 +6,7 @@
  *
  */
 
-import 'react-native-gesture-handler';
+import './src/gesture-handler';
 import React from 'react';
 import Navigator from './src/Navigator';
 

--- a/demo/src/HyperviewScreen.js
+++ b/demo/src/HyperviewScreen.js
@@ -52,6 +52,7 @@ export default class HyperviewScreen extends PureComponent {
   fetchWrapper = (input, init = { headers: {} }) => {
     return fetch(input, {
       ...init,
+      mode: "cors",
       headers: {
         // Don't cache requests for the demo
         'Cache-Control': 'no-cache, no-store, must-revalidate',

--- a/demo/src/gesture-handler/index.js
+++ b/demo/src/gesture-handler/index.js
@@ -1,0 +1,1 @@
+import "react-native-gesture-handler";

--- a/scripts/sync/index.js
+++ b/scripts/sync/index.js
@@ -5,7 +5,7 @@ const chokidar = require('chokidar');
 const path = require('path');
 
 const PROJECT_DIR = path.join(__dirname, '../..');
-const SRC_DIRNAME = 'src';
+const SRC_DIRNAME = process.argv[3] || 'src';
 const SRC_DIR = path.join(PROJECT_DIR, SRC_DIRNAME);
 const DEST_PROJECT_REL_PATH = process.argv[2] || './demo';
 const HYPERVIEW_DIR = path.join(
@@ -17,7 +17,7 @@ const HYPERVIEW_SRC_DIR = path.join(HYPERVIEW_DIR, SRC_DIRNAME);
 
 const updatePackageJson = () => {
   console.log('Updating package.json…');
-  const cmd = `sed -i.bak 's/lib\\/index.js/src\\/index.js/g' ${HYPERVIEW_DIR}/package.json`;
+  const cmd = `sed -i.bak 's/lib\\/index.js/${SRC_DIRNAME}\\/index.js/g' ${HYPERVIEW_DIR}/package.json`;
   childProcess.execSync(cmd);
 };
 


### PR DESCRIPTION
- Wrap gesture-handler module dependency behind web-ready module.
- Pass `cors` option to fetch
- Configure eleventy to send correct CORS headers

**Testing instructions:**
```sh
cd hyperview/
rm -rf node_modules/ demo/node_modules/
watchman watch-del-all
rm -rf $TMPDIR/haste-map-* $TMPDIR/metro-cache
yarn
yarn sync demo lib
yarn test:xmlserver
```
in another terminal:
```sh
cd hyperview/demo
yarn start --clear --web
```

https://user-images.githubusercontent.com/309515/179417526-f568d63a-b899-49cb-8dcb-b88379a9a291.mov


