### PR TITLE
fix(examples): List layouts

### DIFF
--- a/examples/_includes/base.xml.njk
+++ b/examples/_includes/base.xml.njk
@@ -12,9 +12,7 @@
         {% endif %}
         <text style="Header__Title">{{ title }}</text>
       </header>
-      <view scroll="true" style="Main">
-        {% block content %}{% endblock %}
-      </view>
+      {% block container %}{% endblock %}
     </body>
   </screen>
   {% include 'loading_screen.xml.njk' %}

--- a/examples/_includes/directory_list.xml.njk
+++ b/examples/_includes/directory_list.xml.njk
@@ -1,13 +1,13 @@
 {# Standard template for showing a list of links to other screens. List is generated from a collection of screens with the given "list_tag" #}
-{% extends 'base.xml.njk' %}
 
-{% block styles %}
-
-{% endblock %}
-
-{% block content %}
-  <behavior trigger="refresh" action="reload" href="#" />
-  <list>
+<list
+  xmlns="https://hyperview.org/hyperview"
+  trigger="refresh"
+  action="replace"
+  target="directory-list"
+  id="directory-list"
+  href="{% block list_href %}{% endblock %}"
+>
   {% for screen in collections[list_tag] %}
     <item
       href="{{ screen.data.permalink }}"
@@ -21,5 +21,4 @@
       <text style="Item__Chevron">&gt;</text>
     </item>
   {% endfor %}
-  </list>
-{% endblock %}
+</list>

--- a/examples/_includes/directory_list.xml.njk
+++ b/examples/_includes/directory_list.xml.njk
@@ -6,7 +6,7 @@
   action="replace"
   target="directory-list"
   id="directory-list"
-  href="{% block list_href %}{% endblock %}"
+  href="{% if list_href %}{{ list_href }}{% else %}{{ permalink }}{% endif %}"
 >
   {% for screen in collections[list_tag] %}
     <item

--- a/examples/_includes/scrollview.xml.njk
+++ b/examples/_includes/scrollview.xml.njk
@@ -1,0 +1,7 @@
+{% extends 'base.xml.njk' %}
+
+{% block container %}
+  <view scroll="true" style="Main">
+    {% block content %}{% endblock %}
+  </view>
+{% endblock %}

--- a/examples/index.xml.njk
+++ b/examples/index.xml.njk
@@ -4,4 +4,8 @@ permalink: "index.xml"
 list_tag: "root"
 hide_back_button: true,
 ---
-{% extends 'directory_list.xml.njk' %}
+{% extends 'base.xml.njk' %}
+
+{% block container %}
+  {% include "./list.xml.njk" %}
+{% endblock %}

--- a/examples/index.xml.njk
+++ b/examples/index.xml.njk
@@ -2,7 +2,8 @@
 title: "Hyperview"
 permalink: "index.xml"
 list_tag: "root"
-hide_back_button: true,
+hide_back_button: true
+list_href: "list.xml"
 ---
 {% extends 'base.xml.njk' %}
 

--- a/examples/list.xml.njk
+++ b/examples/list.xml.njk
@@ -4,4 +4,3 @@ list_tag: "root"
 ---
 {% extends "directory_list.xml.njk" %}
 
-{% block list_href %}list.xml{% endblock %}

--- a/examples/list.xml.njk
+++ b/examples/list.xml.njk
@@ -1,0 +1,7 @@
+---
+permalink: "list.xml"
+list_tag: "root"
+---
+{% extends "directory_list.xml.njk" %}
+
+{% block list_href %}list.xml{% endblock %}

--- a/examples/navigation/back.xml.njk
+++ b/examples/navigation/back.xml.njk
@@ -3,7 +3,7 @@ title: "Back"
 permalink: "/navigation/back.xml"
 tags: navigation
 ---
-{% extends 'base.xml.njk' %}
+{% extends 'scrollview.xml.njk' %}
 
 {% block content %}
 <text style="Description">

--- a/examples/navigation/index.xml.njk
+++ b/examples/navigation/index.xml.njk
@@ -4,4 +4,8 @@ permalink: "/navigation/index.xml"
 tags: root
 list_tag: "navigation"
 ---
-{% extends 'directory_list.xml.njk' %}
+{% extends 'base.xml.njk' %}
+
+{% block container %}
+  {% include "./list.xml.njk" %}
+{% endblock %}

--- a/examples/navigation/index.xml.njk
+++ b/examples/navigation/index.xml.njk
@@ -3,6 +3,7 @@ title: "Navigation"
 permalink: "/navigation/index.xml"
 tags: root
 list_tag: "navigation"
+list_href: "/navigation/list.xml"
 ---
 {% extends 'base.xml.njk' %}
 

--- a/examples/navigation/list.xml.njk
+++ b/examples/navigation/list.xml.njk
@@ -3,5 +3,3 @@ permalink: "/navigation/list.xml"
 list_tag: "navigation"
 ---
 {% extends "directory_list.xml.njk" %}
-
-{% block list_href %}/navigation/list.xml{% endblock %}

--- a/examples/navigation/list.xml.njk
+++ b/examples/navigation/list.xml.njk
@@ -1,0 +1,7 @@
+---
+permalink: "/navigation/list.xml"
+list_tag: "navigation"
+---
+{% extends "directory_list.xml.njk" %}
+
+{% block list_href %}/navigation/list.xml{% endblock %}

--- a/examples/styling/button.xml.njk
+++ b/examples/styling/button.xml.njk
@@ -3,7 +3,7 @@ title: "Button"
 permalink: "/styling/button.xml"
 tags: styling
 ---
-{% extends 'base.xml.njk' %}
+{% extends 'scrollview.xml.njk' %}
 
 {% block content %}
 <text style="Description">Regular</text>

--- a/examples/styling/elevation.xml.njk
+++ b/examples/styling/elevation.xml.njk
@@ -3,7 +3,7 @@ title: "Elevation"
 permalink: "/styling/elevation.xml"
 tags: styling
 ---
-{% extends 'base.xml.njk' %}
+{% extends 'scrollview.xml.njk' %}
 
 {% block content %}
 <text style="Description">

--- a/examples/styling/flex.xml.njk
+++ b/examples/styling/flex.xml.njk
@@ -3,7 +3,7 @@ title: "Flex"
 permalink: "/styling/flex.xml"
 tags: styling
 ---
-{% extends 'base.xml.njk' %}
+{% extends 'scrollview.xml.njk' %}
 
 {% block styles %}
   <style

--- a/examples/styling/index.xml.njk
+++ b/examples/styling/index.xml.njk
@@ -4,4 +4,8 @@ permalink: "/styling/index.xml"
 tags: root
 list_tag: "styling"
 ---
-{% extends 'directory_list.xml.njk' %}
+{% extends 'base.xml.njk' %}
+
+{% block container %}
+  {% include "./list.xml.njk" %}
+{% endblock %}

--- a/examples/styling/index.xml.njk
+++ b/examples/styling/index.xml.njk
@@ -3,6 +3,7 @@ title: "Styling"
 permalink: "/styling/index.xml"
 tags: root
 list_tag: "styling"
+list_href: "/styling/list.xml"
 ---
 {% extends 'base.xml.njk' %}
 

--- a/examples/styling/list.xml.njk
+++ b/examples/styling/list.xml.njk
@@ -3,5 +3,3 @@ permalink: "/styling/list.xml"
 list_tag: "styling"
 ---
 {% extends "directory_list.xml.njk" %}
-
-{% block list_href %}/styling/list.xml{% endblock %}

--- a/examples/styling/list.xml.njk
+++ b/examples/styling/list.xml.njk
@@ -1,0 +1,7 @@
+---
+permalink: "/styling/list.xml"
+list_tag: "styling"
+---
+{% extends "directory_list.xml.njk" %}
+
+{% block list_href %}/styling/list.xml{% endblock %}

--- a/examples/styling/shadows.xml.njk
+++ b/examples/styling/shadows.xml.njk
@@ -3,7 +3,7 @@ title: "Shadows"
 permalink: "/styling/shadows.xml"
 tags: styling
 ---
-{% extends 'base.xml.njk' %}
+{% extends 'scrollview.xml.njk' %}
 
 {% block styles %}
   <style

--- a/examples/styling/text.xml.njk
+++ b/examples/styling/text.xml.njk
@@ -3,7 +3,7 @@ title: "Text"
 permalink: "/styling/text.xml"
 tags: styling
 ---
-{% extends 'base.xml.njk' %}
+{% extends 'scrollview.xml.njk' %}
 
 {% block styles %}
   <style


### PR DESCRIPTION
- Remove scrollview container from base layout, and create a separate scrollview layout. Create `container` block, and update related screens that need to extend it. (Solves RN warning about nested scrollable views)
- Update `directory_list.xml.njk` to not extend a base template and instead just render the list. Screens entry point now extend the default base template. In parallel, each screen that rely on a directory list now creates a separate `list.xml` template that extends `directory_list.xml.njk`. (Solves list pull to refresh mechanism)

https://user-images.githubusercontent.com/309515/179424708-80457e0c-18ab-4fa2-9fa8-813ba9188724.mp4


