### PR TITLE
fix: Inline links

### DIFF
--- a/examples/behaviors/_replace_link_fragment.xml
+++ b/examples/behaviors/_replace_link_fragment.xml
@@ -1,0 +1,4 @@
+<text
+  style="Description"
+  xmlns="https://hyperview.org/hyperview"
+>Replaced!</text>

--- a/examples/behaviors/long_press.xml
+++ b/examples/behaviors/long_press.xml
@@ -53,6 +53,7 @@
         padding="24"
       />
       <style id="Button__Label" color="white" fontSize="24" fontWeight="bold" />
+      <style id="Link" color="blue" />
       <style id="Main" flex="1" />
     </styles>
     <body style="Body" safe-area="true">
@@ -72,6 +73,15 @@
         >
           <text style="Button__Label">Press me</text>
         </view>
+        <text style="Description" id="link-to-replace">
+          Long-pressing on <text
+            action="replace"
+            href="/behaviors/_replace_link_fragment.xml"
+            trigger="longPress"
+            style="Link"
+            target="link-to-replace"
+          >this link</text> will replace the content.
+        </text>
       </view>
     </body>
   </screen>

--- a/examples/behaviors/press.xml
+++ b/examples/behaviors/press.xml
@@ -53,6 +53,7 @@
         padding="24"
       />
       <style id="Button__Label" color="white" fontSize="24" fontWeight="bold" />
+      <style id="Link" color="blue" />
       <style id="Main" flex="1" />
     </styles>
     <body style="Body" safe-area="true">
@@ -72,6 +73,15 @@
         >
           <text style="Button__Label">Press me</text>
         </view>
+        <text style="Description" id="link-to-replace">
+          Press on <text
+            action="replace"
+            href="/behaviors/_replace_link_fragment.xml"
+            trigger="press"
+            style="Link"
+            target="link-to-replace"
+          >this link</text> will replace the content.
+        </text>
       </view>
     </body>
   </screen>

--- a/examples/behaviors/press_in.xml
+++ b/examples/behaviors/press_in.xml
@@ -53,6 +53,7 @@
         padding="24"
       />
       <style id="Button__Label" color="white" fontSize="24" fontWeight="bold" />
+      <style id="Link" color="blue" />
       <style id="Main" flex="1" />
     </styles>
     <body style="Body" safe-area="true">
@@ -72,6 +73,15 @@
         >
           <text style="Button__Label">Press me</text>
         </view>
+        <text style="Description" id="link-to-replace">
+          Press-in <text
+            action="replace"
+            href="/behaviors/_replace_link_fragment.xml"
+            trigger="pressIn"
+            style="Link"
+            target="link-to-replace"
+          >this link</text> will replace the content.
+        </text>
       </view>
     </body>
   </screen>

--- a/examples/behaviors/press_out.xml
+++ b/examples/behaviors/press_out.xml
@@ -53,6 +53,7 @@
         padding="24"
       />
       <style id="Button__Label" color="white" fontSize="24" fontWeight="bold" />
+      <style id="Link" color="blue" />
       <style id="Main" flex="1" />
     </styles>
     <body style="Body" safe-area="true">
@@ -72,6 +73,15 @@
         >
           <text style="Button__Label">Press me</text>
         </view>
+        <text style="Description" id="link-to-replace">
+          Press-out <text
+            action="replace"
+            href="/behaviors/_replace_link_fragment.xml"
+            trigger="pressOut"
+            style="Link"
+            target="link-to-replace"
+          >this link</text> will replace the content.
+        </text>
       </view>
     </body>
   </screen>

--- a/examples/ui_elements/text/nested.xml
+++ b/examples/ui_elements/text/nested.xml
@@ -27,7 +27,11 @@
       <style id="Color" backgroundColor="#63CB76" color="white" />
       <style id="Big" fontSize="32" />
       <style id="Small" fontSize="16" />
-      <style id="Link" color="blue" textDecorationLine="underline" />
+      <style id="Link" color="blue">
+        <modifier pressed="true">
+          <style color="red" />
+        </modifier>
+      </style>
       <style id="Main" flex="1" />
     </styles>
     <body style="Body" safe-area="true">
@@ -60,6 +64,34 @@
         </text>
         <text style="Text Small">
           Tap <text style="Link" action="back">here</text> to go back
+        </text>
+        <text style="Text Small">
+           Velit voluptas et alias atque provident sapiente consequuntur deserunt.
+           <text style="Link" action="back">
+             Dolorem et non error dolorem voluptate amet accusantium.
+           </text>
+           Corporis rerum sed labore quae sed qui quis quasi.
+        </text>
+        <text style="Text Small">
+          Here's a <text
+            style="Link"
+            trigger="longPress"
+            action="back"
+          >link</text> that will navigate back when you long press
+        </text>
+        <text style="Text Small">
+          Here's a <text
+            style="Link"
+            trigger="pressIn"
+            action="back"
+          >link</text> that will navigate back when you press in
+        </text>
+        <text style="Text Small">
+          Here's a <text
+            style="Link"
+            trigger="pressOut"
+            action="back"
+          >link</text> that will navigate back when you press out
         </text>
       </view>
     </body>

--- a/examples/ui_elements/text/nested.xml
+++ b/examples/ui_elements/text/nested.xml
@@ -72,27 +72,6 @@
            </text>
            Corporis rerum sed labore quae sed qui quis quasi.
         </text>
-        <text style="Text Small">
-          Here's a <text
-            style="Link"
-            trigger="longPress"
-            action="back"
-          >link</text> that will navigate back when you long press
-        </text>
-        <text style="Text Small">
-          Here's a <text
-            style="Link"
-            trigger="pressIn"
-            action="back"
-          >link</text> that will navigate back when you press in
-        </text>
-        <text style="Text Small">
-          Here's a <text
-            style="Link"
-            trigger="pressOut"
-            action="back"
-          >link</text> that will navigate back when you press out
-        </text>
       </view>
     </body>
   </screen>


### PR DESCRIPTION
When rendering `hyper-ref` component within a text element, use `Text` component instead of `TouchableOpacity`.

Note: I tried using more modern `Pressable` component as a replacement of `TouchableOpacity`, but it did not allow keeping inline layout on nested `<text>`.

Solves #307

https://user-images.githubusercontent.com/309515/180471486-f5ba11fa-d502-4eed-8cb9-b1d59e0a5d9b.mp4

https://user-images.githubusercontent.com/309515/183530120-271e4c5d-dac2-4953-a000-f73dd5dd2f3d.mov


