### PR TITLE
refactor: `HyperRef` component

### DIFF
--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -26,6 +26,7 @@ import type {
   PressTrigger,
   StyleSheet,
   StyleSheets,
+  Trigger,
 } from 'hyperview/src/types';
 import type { PressHandlers, Props, State } from './types';
 import React, { PureComponent } from 'react';
@@ -177,11 +178,14 @@ export default class HyperRef extends PureComponent<Props, State> {
       onUpdate(null, action, element, { behaviorElement, custom: true });
   };
 
-  triggerLoadBehaviors = () => {
-    const loadBehaviors = this.behaviorElements.filter(
-      e => e.getAttribute(ATTRIBUTES.TRIGGER) === TRIGGERS.LOAD,
+  getBehaviorElements = (trigger: Trigger): Element[] => {
+    return this.behaviorElements.filter(
+      e => e.getAttribute(ATTRIBUTES.TRIGGER) === trigger,
     );
+  };
 
+  triggerLoadBehaviors = () => {
+    const loadBehaviors = this.getBehaviorElements(TRIGGERS.LOAD);
     loadBehaviors.forEach(behaviorElement => {
       const handler = this.createActionHandler(
         this.props.element,
@@ -321,19 +325,6 @@ export default class HyperRef extends PureComponent<Props, State> {
   };
 
   render() {
-    const pressBehaviors = this.behaviorElements.filter(
-      e =>
-        PRESS_TRIGGERS.indexOf(
-          e.getAttribute(ATTRIBUTES.TRIGGER) || TRIGGERS.PRESS,
-        ) >= 0,
-    );
-    const visibleBehaviors = this.behaviorElements.filter(
-      e => e.getAttribute(ATTRIBUTES.TRIGGER) === TRIGGERS.VISIBLE,
-    );
-    const refreshBehaviors = this.behaviorElements.filter(
-      e => e.getAttribute(ATTRIBUTES.TRIGGER) === TRIGGERS.REFRESH,
-    );
-
     // Render the component based on the XML element. Depending on the applied behaviors,
     // this component will be wrapped with others to provide the necessary interaction.
     let renderedComponent = Render.renderElement(
@@ -349,6 +340,12 @@ export default class HyperRef extends PureComponent<Props, State> {
       : null;
 
     // Wrap component in a pressable element
+    const pressBehaviors = this.behaviorElements.filter(
+      e =>
+        PRESS_TRIGGERS.indexOf(
+          e.getAttribute(ATTRIBUTES.TRIGGER) || TRIGGERS.PRESS,
+        ) >= 0,
+    );
     if (pressBehaviors.length > 0) {
       renderedComponent = this.wrapInTouchableView(
         pressBehaviors,
@@ -358,6 +355,7 @@ export default class HyperRef extends PureComponent<Props, State> {
     }
 
     // Wrap component in a scrollview with a refresh control to trigger refresh behaviors.
+    const refreshBehaviors = this.getBehaviorElements(TRIGGERS.REFRESH);
     if (refreshBehaviors.length > 0) {
       renderedComponent = this.wrapInScrollableView(
         refreshBehaviors,
@@ -367,6 +365,7 @@ export default class HyperRef extends PureComponent<Props, State> {
     }
 
     // Wrap component in a VisibilityDetectingView to trigger visibility behaviors.
+    const visibleBehaviors = this.getBehaviorElements(TRIGGERS.VISIBLE);
     if (visibleBehaviors.length > 0) {
       renderedComponent = this.wrapInVisibilityDetectingView(
         visibleBehaviors,

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -197,10 +197,19 @@ export default class HyperRef extends PureComponent<Props, State> {
   };
 
   wrapInTouchableView = (
-    behaviors: Element[],
     component: ?React$Element<*> | string,
     style: StyleSheet,
-  ): React$Element<*> => {
+  ): ?React$Element<*> | string => {
+    const behaviors = this.behaviorElements.filter(
+      e =>
+        PRESS_TRIGGERS.indexOf(
+          e.getAttribute(ATTRIBUTES.TRIGGER) || TRIGGERS.PRESS,
+        ) >= 0,
+    );
+    if (!behaviors.length) {
+      return component;
+    }
+
     // $FlowFixMe: cannot spread Test props because return type is inexact
     const props = {
       // Component will use touchable opacity to trigger href.
@@ -279,10 +288,13 @@ export default class HyperRef extends PureComponent<Props, State> {
   };
 
   wrapInScrollableView = (
-    behaviors: Element[],
     component: ?React$Element<*> | string,
     style: StyleSheet,
-  ): React$Element<*> => {
+  ): ?React$Element<*> | string => {
+    const behaviors = this.getBehaviorElements(TRIGGERS.REFRESH);
+    if (!behaviors.length) {
+      return component;
+    }
     const refreshHandlers = behaviors.map(behaviorElement =>
       this.createActionHandler(
         this.props.element,
@@ -304,10 +316,13 @@ export default class HyperRef extends PureComponent<Props, State> {
   };
 
   wrapInVisibilityDetectingView = (
-    behaviors: Element[],
     component: ?React$Element<*> | string,
     style: StyleSheet,
-  ): React$Element<*> => {
+  ): ?React$Element<*> | string => {
+    const behaviors = this.getBehaviorElements(TRIGGERS.VISIBLE);
+    if (!behaviors.length) {
+      return component;
+    }
     const visibleHandlers = behaviors.map(behaviorElement =>
       this.createActionHandler(
         this.props.element,
@@ -340,39 +355,16 @@ export default class HyperRef extends PureComponent<Props, State> {
       : null;
 
     // Wrap component in a pressable element
-    const pressBehaviors = this.behaviorElements.filter(
-      e =>
-        PRESS_TRIGGERS.indexOf(
-          e.getAttribute(ATTRIBUTES.TRIGGER) || TRIGGERS.PRESS,
-        ) >= 0,
-    );
-    if (pressBehaviors.length > 0) {
-      renderedComponent = this.wrapInTouchableView(
-        pressBehaviors,
-        renderedComponent,
-        hrefStyle,
-      );
-    }
+    renderedComponent = this.wrapInTouchableView(renderedComponent, hrefStyle);
 
     // Wrap component in a scrollview with a refresh control to trigger refresh behaviors.
-    const refreshBehaviors = this.getBehaviorElements(TRIGGERS.REFRESH);
-    if (refreshBehaviors.length > 0) {
-      renderedComponent = this.wrapInScrollableView(
-        refreshBehaviors,
-        renderedComponent,
-        hrefStyle,
-      );
-    }
+    renderedComponent = this.wrapInScrollableView(renderedComponent, hrefStyle);
 
     // Wrap component in a VisibilityDetectingView to trigger visibility behaviors.
-    const visibleBehaviors = this.getBehaviorElements(TRIGGERS.VISIBLE);
-    if (visibleBehaviors.length > 0) {
-      renderedComponent = this.wrapInVisibilityDetectingView(
-        visibleBehaviors,
-        renderedComponent,
-        hrefStyle,
-      );
-    }
+    renderedComponent = this.wrapInVisibilityDetectingView(
+      renderedComponent,
+      hrefStyle,
+    );
 
     return renderedComponent || null;
   }

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -68,6 +68,12 @@ export default class HyperRef extends PureComponent<Props, State> {
 
   style: ?StyleSheet;
 
+  constructor(props: Props, state: State) {
+    super(props, state);
+    this.updateBehaviorElements();
+    this.updateStyle();
+  }
+
   componentDidMount() {
     this.triggerLoadBehaviors();
 
@@ -79,16 +85,9 @@ export default class HyperRef extends PureComponent<Props, State> {
     if (prevProps.element === this.props.element) {
       return;
     }
-    // Retrieve and cache behavior elements when element is updated
-    this.behaviorElements = Dom.getBehaviorElements(this.props.element);
 
-    // Retrieve and cache style
-    const styleAttr = this.props.element.getAttribute(ATTRIBUTES.HREF_STYLE);
-    this.style = styleAttr
-      ? styleAttr.split(' ').map(s => this.props.stylesheets.regular[s])
-      : null;
-
-    // Then trigger load behaviors
+    this.updateBehaviorElements();
+    this.updateStyle();
     this.triggerLoadBehaviors();
   }
 
@@ -96,6 +95,19 @@ export default class HyperRef extends PureComponent<Props, State> {
     // Remove event listener for on-event triggers to avoid memory leaks
     Events.unsubscribe(this.onEventDispatch);
   }
+
+  updateBehaviorElements = () => {
+    // Retrieve and cache behavior elements when element is updated
+    this.behaviorElements = Dom.getBehaviorElements(this.props.element);
+  };
+
+  updateStyle = () => {
+    // Retrieve and cache style
+    const styleAttr = this.props.element.getAttribute(ATTRIBUTES.HREF_STYLE);
+    this.style = styleAttr
+      ? styleAttr.split(' ').map(s => this.props.stylesheets.regular[s])
+      : null;
+  };
 
   onEventDispatch = (eventName: string) => {
     const behaviorElements = Dom.getBehaviorElements(this.props.element);

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -62,6 +62,8 @@ export default class HyperRef extends PureComponent<Props, State> {
     refreshing: false,
   };
 
+  behaviorElements: Element[];
+
   componentDidMount() {
     this.triggerLoadBehaviors();
 
@@ -73,6 +75,10 @@ export default class HyperRef extends PureComponent<Props, State> {
     if (prevProps.element === this.props.element) {
       return;
     }
+    // Retrieve and cache behavior elements when element is updated
+    this.behaviorElements = Dom.getBehaviorElements(this.props.element);
+
+    // Then trigger load behaviors
     this.triggerLoadBehaviors();
   }
 
@@ -172,8 +178,7 @@ export default class HyperRef extends PureComponent<Props, State> {
   };
 
   triggerLoadBehaviors = () => {
-    const behaviorElements = Dom.getBehaviorElements(this.props.element);
-    const loadBehaviors = behaviorElements.filter(
+    const loadBehaviors = this.behaviorElements.filter(
       e => e.getAttribute(ATTRIBUTES.TRIGGER) === TRIGGERS.LOAD,
     );
 
@@ -316,17 +321,16 @@ export default class HyperRef extends PureComponent<Props, State> {
   };
 
   render() {
-    const behaviorElements = Dom.getBehaviorElements(this.props.element);
-    const pressBehaviors = behaviorElements.filter(
+    const pressBehaviors = this.behaviorElements.filter(
       e =>
         PRESS_TRIGGERS.indexOf(
           e.getAttribute(ATTRIBUTES.TRIGGER) || TRIGGERS.PRESS,
         ) >= 0,
     );
-    const visibleBehaviors = behaviorElements.filter(
+    const visibleBehaviors = this.behaviorElements.filter(
       e => e.getAttribute(ATTRIBUTES.TRIGGER) === TRIGGERS.VISIBLE,
     );
-    const refreshBehaviors = behaviorElements.filter(
+    const refreshBehaviors = this.behaviorElements.filter(
       e => e.getAttribute(ATTRIBUTES.TRIGGER) === TRIGGERS.REFRESH,
     );
 


### PR DESCRIPTION
Break up the `HyperRef.render` method into smaller, more manageable chunks.
Note to reviewers: it'll be easier to take a look first at individual commits to understand the thought process behind this refactor.

Verified that demo app continues to work as expected

https://user-images.githubusercontent.com/309515/180355495-92c85252-9cd4-4b87-9f0b-7a7674a28695.mp4


https://user-images.githubusercontent.com/309515/180359323-7310790a-a9dd-4411-b44e-d5c9238586eb.mp4


