### PR TITLE
fix: Custom loading screen

### DIFF
--- a/examples/_includes/loading_screen.xml.njk
+++ b/examples/_includes/loading_screen.xml.njk
@@ -21,10 +21,26 @@
     />
     <style id="Header__Title" color="black" fontSize="24" fontWeight="600" />
     <style id="Body" backgroundColor="white" flex="1" />
+    <style
+      id="LoadingText"
+      fontSize="14"
+      fontWeight="normal"
+      marginBottom="16"
+    />
+    <style
+      id="Loading"
+      alignItems="center"
+      flex="1"
+      justifyContent="center"
+    />
   </styles>
   <body style="Body" safe-area="true">
     <header style="Header">
       <text action="back" href="#" style="Header__Back">Back</text>
     </header>
+    <view style="Loading">
+      <text style="LoadingText">Loading…</text>
+      <spinner />
+    </view>
   </body>
 </screen>

--- a/src/index.js
+++ b/src/index.js
@@ -166,7 +166,7 @@ export default class HyperScreen extends React.Component {
     const { params } = this.getRoute(this.props);
     const { preloadScreen } = params;
     if (preloadScreen && this.navigation.getPreloadScreen(preloadScreen)) {
-      this.navigation.remove(preloadScreen);
+      this.navigation.removePreloadScreen(preloadScreen);
     }
     if (this.state.url) {
       this.navigation.removeRouteKey(this.state.url)

--- a/src/services/navigation/index.js
+++ b/src/services/navigation/index.js
@@ -20,6 +20,7 @@ const QUERY_SEPARATOR = '?';
 const getHrefKey = (href: string): string => href.split(QUERY_SEPARATOR)[0];
 
 const routeKeys: { [string]: string } = {};
+const preloadScreens: { [number]: Element } = {};
 
 export default class Navigation {
   url: string;
@@ -27,8 +28,6 @@ export default class Navigation {
   document: ?Document = null;
 
   navigation: NavigationProps;
-
-  preloadScreens: { [number]: Element } = {};
 
   constructor(url: string, navigation: NavigationProps) {
     this.url = url;
@@ -43,14 +42,14 @@ export default class Navigation {
     this.document = document;
   };
 
-  getPreloadScreen = (id: number): ?Element => this.preloadScreens[id];
+  getPreloadScreen = (id: number): ?Element => preloadScreens[id];
 
   setPreloadScreen = (id: number, element: Element): void => {
-    this.preloadScreens[id] = element;
+    preloadScreens[id] = element;
   };
 
   removePreloadScreen = (id: number): void => {
-    delete this.preloadScreens[id];
+    delete preloadScreens[id];
   };
 
   getRouteKey = (href: string): ?string => routeKeys[getHrefKey(href)];


### PR DESCRIPTION
Restore functionality of custom loading screens, which got broken in #69.

Implementation notes:
The dictionary that keeps track of loading screen was improperly moved to the `navigation` instance, which is re-created on each screen. Move this back to a global variable so new pushed screens can access it.

https://user-images.githubusercontent.com/309515/180581726-9c5ebd87-7f19-4321-98f3-ac68c363c3fb.mp4


