### PR TITLE
fix(copy-to-clipboard): Make attribute name specific to usage

### DIFF
--- a/docs/reference_behavior_attributes.md
+++ b/docs/reference_behavior_attributes.md
@@ -585,11 +585,15 @@ See [the repo](https://github.com/Instawork/hyperview/blob/master/examples/advan
 
 ### `copy-to-clipboard`
 
-The `copy-to-clipboard` action allows copying a value to the clipboard. The behavior attributes must include a [`value`] attribute specifying the value to be copied.
+The `copy-to-clipboard` action allows copying a value to the clipboard. The behavior attributes must include a [`copy-to-clipboard-value`] attribute specifying the value to be copied.
 
 ```xml
 <view>
-  <behavior trigger="press" action="copy-to-clipboard" value="Hello World!" />
+  <behavior
+    trigger="press"
+    action="copy-to-clipboard"
+    copy-to-clipboard-value="Hello World!"
+  />
   <text style="link">Copy to clipboard</text>
 </view>
 ```

--- a/examples/advanced_behaviors/copy_to_clipboard/index.xml
+++ b/examples/advanced_behaviors/copy_to_clipboard/index.xml
@@ -54,7 +54,7 @@
         <view
           action="copy-to-clipboard"
           trigger="press"
-          value="Hello World"
+          copy-to-clipboard-value="Hello World"
           style="Button"
         >
           <text style="Button__Label">Copy to clipboard</text>

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -376,6 +376,7 @@
     </xs:attribute>
     <xs:attribute name="event-name" type="hv:eventName" />
     <xs:attribute name="new-value" type="xs:string" />
+    <xs:attribute name="copy-to-clipboard-value" type="xs:string" />
     <xs:attributeGroup ref="alert:alertAttributes" />
   </xs:attributeGroup>
 

--- a/src/behaviors/hv-copy-to-clipboard/index.js
+++ b/src/behaviors/hv-copy-to-clipboard/index.js
@@ -14,9 +14,12 @@ import type { Element } from 'hyperview/src/types';
 export default {
   action: 'copy-to-clipboard',
   callback: (element: Element) => {
-    const value: ?string = element.getAttribute('value');
+    const attributeName = 'copy-to-clipboard-value';
+    const value: ?string = element.getAttribute(attributeName);
     if (!value) {
-      console.warn('[behaviors/copy-to-clipboard]: missing "value" attribute');
+      console.warn(
+        `[behaviors/copy-to-clipboard]: missing "${attributeName}" attribute`,
+      );
       return;
     }
     Clipboard.setString(value);


### PR DESCRIPTION
`value` is an attribute that is currently used by many other elements, sometimes with different meanings/types (i.e. `hv-switch` defines it as a complex type). Because this overlaps with non-behavior attributes, it clashes when we try to validate the markup.
Rename the attribute to be specific to the behavior, and add the attribute to schema.

Relates to #195