### PR TITLE
chore(schema): Allow `key` attribute

### DIFF
--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -287,6 +287,10 @@
     <xs:restriction base="xs:token" />
   </xs:simpleType>
 
+  <xs:simpleType name="KEY">
+    <xs:restriction base="xs:token" />
+  </xs:simpleType>
+
   <xs:simpleType name="IDREF">
     <xs:restriction base="hv:ID" />
   </xs:simpleType>
@@ -410,6 +414,7 @@
         <xs:element minOccurs="1" maxOccurs="1" ref="hv:body" />
       </xs:sequence>
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
     </xs:complexType>
   </xs:element>
 
@@ -699,6 +704,7 @@
     <xs:complexType>
       <xs:group ref="hv:viewChildren" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="style" type="hv:styleList" />
       <xs:attribute name="safe-area" type="xs:boolean" />
       <xs:attributeGroup ref="hv:scrollAttributes" />
@@ -711,6 +717,7 @@
       <xs:attribute name="safe-area" type="xs:boolean" />
       <xs:attribute name="style" type="hv:styleList" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
     </xs:complexType>
   </xs:element>
@@ -720,6 +727,7 @@
       <xs:group ref="hv:viewChildren" />
       <xs:attribute name="style" type="hv:styleList" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="avoid-keyboard" type="xs:boolean" />
       <xs:attribute name="safe-area" type="xs:boolean" />
@@ -738,6 +746,7 @@
       <xs:attribute name="source" use="required" type="xs:anyURI" />
       <xs:attribute name="style" type="hv:styleList" use="required" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="resizeMode" type="hv:resizeMode" />
       <xs:attribute name="value" type="xs:string" />
@@ -754,6 +763,7 @@
       <xs:attribute name="numberOfLines" type="xs:positiveInteger" />
       <xs:attribute name="style" type="hv:styleList" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="selectable" type="xs:boolean" />
       <xs:attribute name="preformatted" type="xs:boolean" />
@@ -782,6 +792,7 @@
       <xs:attribute name="itemHeight" type="xs:positiveInteger" />
       <xs:attribute name="style" type="hv:styleList" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="value" type="xs:string" />
       <xs:attributeGroup ref="hv:scrollAttributes" />
@@ -799,6 +810,7 @@
       </xs:sequence>
       <xs:attribute name="style" type="hv:styleList" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="value" type="xs:string" />
       <xs:attribute name="sticky-section-titles" type="xs:boolean" />
@@ -826,6 +838,7 @@
       <xs:group ref="hv:nonListViewChildren" />
       <xs:attribute name="style" type="hv:styleList" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="value" type="xs:string" />
       <xs:attributeGroup ref="hv:behaviorAttributes" />
@@ -844,9 +857,9 @@
   <xs:element name="item">
     <xs:complexType>
       <xs:group ref="hv:nonListViewChildren" />
-      <xs:attribute name="key" use="required" />
       <xs:attribute name="style" type="hv:styleList" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" use="required" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="value" type="xs:string" />
       <xs:attributeGroup ref="hv:behaviorAttributes" />
@@ -857,6 +870,7 @@
     <xs:complexType>
       <xs:attribute name="color" type="hv:color" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
     </xs:complexType>
   </xs:element>
@@ -866,6 +880,7 @@
       <xs:group ref="hv:viewChildren" />
       <xs:attribute name="style" type="hv:styleList" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attributeGroup ref="hv:scrollAttributes" />
     </xs:complexType>
@@ -894,6 +909,7 @@
       <xs:attribute name="modal-style" type="hv:styleList" />
       <xs:attribute name="modal-text-style" type="hv:styleList" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
     </xs:complexType>
   </xs:element>
@@ -914,6 +930,7 @@
       <xs:attribute name="modal-style" type="hv:styleList" />
       <xs:attribute name="modal-text-style" type="hv:styleList" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
     </xs:complexType>
   </xs:element>
@@ -937,6 +954,7 @@
         </xs:simpleType>
       </xs:attribute>
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="style" type="hv:styleList" />
       <xs:attributeGroup ref="hv:behaviorAttributes" />
@@ -962,6 +980,7 @@
       </xs:attribute>
       <xs:attribute name="mask" type="xs:string" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="style" type="hv:styleList" />
       <xs:attribute name="auto-focus" type="xs:boolean" />
@@ -993,6 +1012,7 @@
       <xs:attribute name="placeholder" type="xs:string" />
       <xs:attribute name="placeholderTextColor" type="hv:color" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="underlineColorAndroid" type="hv:color" />
       <xs:attribute name="style" />
@@ -1008,6 +1028,7 @@
       <xs:attribute name="allow-deselect" type="xs:boolean" />
       <xs:attribute name="name" use="required" type="xs:string" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="style" type="hv:styleList" />
     </xs:complexType>
@@ -1018,6 +1039,7 @@
       <xs:group ref="hv:viewChildren" />
       <xs:attribute name="name" use="required" type="xs:string" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="style" type="hv:styleList" />
     </xs:complexType>
@@ -1028,6 +1050,7 @@
       <xs:group ref="hv:baseChildren" />
       <xs:attributeGroup ref="hv:behaviorAttributes" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="style" type="hv:styleList" />
       <xs:attribute name="selected" type="xs:boolean" />
@@ -1042,6 +1065,7 @@
       <xs:attribute name="activity-indicator-color" type="hv:color" />
       <xs:attribute name="injected-java-script" type="xs:string" />
       <xs:attribute name="id" type="hv:ID" />
+      <xs:attribute name="key" type="hv:KEY" />
     </xs:complexType>
   </xs:element>
 


### PR DESCRIPTION
`key` attribute is used by React when rendering component in the context of loop. We need to allow it on every elements for XML validation to pass.