### PR TITLE
fix(schema): Allow nested texts with behaviors in any order

### DIFF
--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -756,10 +756,10 @@
 
   <xs:element name="text">
     <xs:complexType mixed="true">
-      <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:text" />
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:behavior" />
-      </xs:sequence>
+      </xs:choice>
       <xs:attribute name="numberOfLines" type="xs:positiveInteger" />
       <xs:attribute name="style" type="hv:styleList" />
       <xs:attribute name="id" type="hv:ID" />


### PR DESCRIPTION
Prior to this change, `text` would have to be defined before `behavior`. This change allows the following markup to be valid:
```xml
<text>
  <behavior action="show" target="pressed" />
  <text id="press">
    Press
  </text>
  <behavior action="hide" target="press" />
  <text hide="true" id="pressed">Pressed!</text>
</text>
```