### PR TITLE
fix: Navigating on mobile-web

### DIFF
--- a/src/components/hv-option/index.js
+++ b/src/components/hv-option/index.js
@@ -134,7 +134,7 @@ export default class HvOption extends PureComponent<HvComponentProps, State> {
           // Used in select-multiple context.
           onToggle(value);
         }
-      }),
+      }, true),
       onPressIn: createEventHandler(() => this.setState({ pressed: true })),
       onPressOut: createEventHandler(() => this.setState({ pressed: false })),
       style: undefined,

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -51,10 +51,10 @@ import { createTestProps } from 'hyperview/src/services';
  */
 export const createEventHandler = (
   handler: () => void,
+  preventDefault: boolean = false,
 ): ((event: any) => void) => event => {
-  if (event) {
-    event.stopPropagation();
-    event.preventDefault();
+  if (preventDefault) {
+    event?.preventDefault();
   }
   handler();
 };


### PR DESCRIPTION
Rework change introduced in #453, that was meant to fix navigation on web but ended up causing issues on mobile web. The need with the fix was intended to work around the event propagation happening on `select-*` components, wherein selecting an option would lead to navigating to the linked `href` (instead of simply performing the selection). Calling `preventDefault` globally did not interfer with web click events, but prevent mobile web touch events from being received by their target element. The fix here makes calling the `preventDefault` optional, and removes the call to `stopPropagation` (which does not have a perceived effect on event handling in Hyperview/RN web). We explicitly set `preventDefault` on the `hv-option` component, where a press event is not meant to trigger a navigation.


https://user-images.githubusercontent.com/309515/193026393-71d7b787-acf5-4900-8ed4-7c07e495f6be.mov

