### PR TITLE
fix: Incorrect `element` reference

### DIFF
--- a/examples/ui_elements/list/infinite_scroll.xml
+++ b/examples/ui_elements/list/infinite_scroll.xml
@@ -116,23 +116,26 @@
         <item key="19" style="Item">
           <text style="Item__Label">List 19</text>
         </item>
-        <item
-          action="append"
-          delay="1000"
-          href="/ui_elements/list/_infinite_scroll_page2.xml"
-          key="20"
-          once="true"
-          show-during-load="myIndicator"
-          style="Item"
-          target="myList"
-          trigger="visible"
-        >
+        <item key="20" style="Item">
           <text style="Item__Label">List 20</text>
         </item>
+        <item key="page-2-loader" style="Item">
+          <behavior
+            trigger="visible"
+            action="show"
+            target="list-loading-indicator"
+          />
+          <behavior
+            trigger="visible"
+            action="replace"
+            once="true"
+            href="/ui_elements/list/_infinite_scroll_page2.xml"
+          />
+          <view id="list-loading-indicator" hide="true" style="Spinner">
+            <spinner />
+          </view>
+        </item>
       </list>
-      <view id="myIndicator" hide="true" style="Spinner">
-        <spinner />
-      </view>
     </body>
   </screen>
 </doc>

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -136,11 +136,10 @@ export default class HyperRef extends PureComponent<Props, State> {
     });
     onEventBehaviors.forEach(behaviorElement => {
       const handler = this.createActionHandler(
-        this.props.element,
         behaviorElement,
         this.props.onUpdate,
       );
-      handler();
+      handler(this.props.element);
       if (__DEV__) {
         const listenerElement: Element = behaviorElement.cloneNode(false);
         const caughtEvent: string = behaviorElement.getAttribute('event-name');
@@ -154,7 +153,6 @@ export default class HyperRef extends PureComponent<Props, State> {
   };
 
   createActionHandler = (
-    element: Element,
     behaviorElement: Element,
     onUpdate: HvComponentOnUpdate,
   ) => {
@@ -162,13 +160,13 @@ export default class HyperRef extends PureComponent<Props, State> {
       behaviorElement.getAttribute(ATTRIBUTES.ACTION) || NAV_ACTIONS.PUSH;
 
     if (action === ACTIONS.RELOAD) {
-      return () => {
+      return (element: Element) => {
         const href = behaviorElement.getAttribute(ATTRIBUTES.HREF);
         onUpdate(href, action, element, {});
       };
     }
     if (Object.values(NAV_ACTIONS).indexOf(action) >= 0) {
-      return () => {
+      return (element: Element) => {
         const href = behaviorElement.getAttribute(ATTRIBUTES.HREF);
         const showIndicatorId = behaviorElement.getAttribute(
           ATTRIBUTES.SHOW_DURING_LOAD,
@@ -178,7 +176,7 @@ export default class HyperRef extends PureComponent<Props, State> {
       };
     }
     if (Object.values(UPDATE_ACTIONS).indexOf(action) >= 0) {
-      return () => {
+      return (element: Element) => {
         const href = behaviorElement.getAttribute(ATTRIBUTES.HREF);
         const verb = behaviorElement.getAttribute(ATTRIBUTES.VERB);
         const targetId = behaviorElement.getAttribute(ATTRIBUTES.TARGET);
@@ -202,7 +200,7 @@ export default class HyperRef extends PureComponent<Props, State> {
       };
     }
     // Custom behavior
-    return () =>
+    return (element: Element) =>
       onUpdate(null, action, element, { behaviorElement, custom: true });
   };
 
@@ -223,11 +221,10 @@ export default class HyperRef extends PureComponent<Props, State> {
     const loadBehaviors = this.getBehaviorElements(TRIGGERS.LOAD);
     loadBehaviors.forEach(behaviorElement => {
       const handler = this.createActionHandler(
-        this.props.element,
         behaviorElement,
         this.props.onUpdate,
       );
-      setTimeout(handler, 0);
+      setTimeout(() => handler(this.props.element), 0);
     });
   };
 
@@ -256,7 +253,6 @@ export default class HyperRef extends PureComponent<Props, State> {
         behaviorElement.getAttribute(ATTRIBUTES.TRIGGER) || TRIGGERS.PRESS;
       const triggerPropName = PRESS_TRIGGERS_PROP_NAMES[trigger];
       const handler = this.createActionHandler(
-        this.props.element,
         behaviorElement,
         this.props.onUpdate,
       );
@@ -264,11 +260,13 @@ export default class HyperRef extends PureComponent<Props, State> {
         const oldHandler = pressHandlers[triggerPropName];
         pressHandlers[triggerPropName] = createEventHandler(() => {
           oldHandler();
-          setTimeout(handler, time);
+          setTimeout(() => handler(this.props.element), time);
           time += 1;
         });
       } else {
-        pressHandlers[triggerPropName] = createEventHandler(handler);
+        pressHandlers[triggerPropName] = createEventHandler(() =>
+          handler(this.props.element),
+        );
       }
     });
 
@@ -358,13 +356,9 @@ export default class HyperRef extends PureComponent<Props, State> {
       return children;
     }
     const refreshHandlers = behaviors.map(behaviorElement =>
-      this.createActionHandler(
-        this.props.element,
-        behaviorElement,
-        this.props.onUpdate,
-      ),
+      this.createActionHandler(behaviorElement, this.props.onUpdate),
     );
-    const onRefresh = () => refreshHandlers.forEach(h => h());
+    const onRefresh = () => refreshHandlers.forEach(h => h(this.props.element));
 
     const refreshControl = React.createElement(RefreshControl, {
       onRefresh,
@@ -383,13 +377,11 @@ export default class HyperRef extends PureComponent<Props, State> {
       return children;
     }
     const visibleHandlers = behaviors.map(behaviorElement =>
-      this.createActionHandler(
-        this.props.element,
-        behaviorElement,
-        this.props.onUpdate,
-      ),
+      this.createActionHandler(behaviorElement, this.props.onUpdate),
     );
-    const onVisible = () => visibleHandlers.forEach(h => h());
+    const onVisible = () => {
+      visibleHandlers.forEach(h => h(this.props.element));
+    };
 
     return React.createElement(
       VisibilityDetectingView,


### PR DESCRIPTION
While working on changing how we render our loading state in lists (so that we would not render the loading state/animation until it's actually made visible), I discovered the following bug:

[Per spec](https://hyperview.org/docs/reference_behavior_attributes#update-actions), when `target` is not set, the target will be the source of the behavior, that is, the parent container. However, this did not work correctly, an the changes made to `examples/ui_elements/list/infinite_scroll.xml` include a repro case of the issue. The root cause is still a bit unclear, but most likely related to how we mutate the Hyperview DOM while preserving a separate copy in the React state.
I found that by changing the behavior handler creator to not receive the current DOM element, and instead pass the element to the generated handler itself, we circumvent a bug where an we would otherwise receive an old / invalid reference for the element. In particular, I found that the invalid reference would have `Text` element instances in place of `Element` element instances for actual DOM elements. It's still not clear to me where this invalid reference is coming from / how it ended up in such state.

| Before | After |
|-------|------|
| ![before](https://user-images.githubusercontent.com/309515/197870777-2a97e833-fea3-4aba-a519-c133c2e5816f.mp4) | ![after](https://user-images.githubusercontent.com/309515/197870789-7f50dbcb-c761-46ab-89ae-9f393dad9f78.mp4) |


Invalid element instances when debugging:
<img width="305" alt="Screen Shot 2022-10-25 at 1 09 21 PM" src="https://user-images.githubusercontent.com/309515/197872102-03af3b1b-a50f-411f-8f19-64a13128860b.png">
