### PR TITLE
fix: Prevent crashes on invalid markup

### DIFF
--- a/src/services/render/index.js
+++ b/src/services/render/index.js
@@ -20,11 +20,14 @@ import { LOCAL_NAME, NODE_TYPE } from 'hyperview/src/types';
 import React from 'react';
 
 export const renderElement = (
-  element: Element,
+  element: ?Element,
   stylesheets: StyleSheets,
   onUpdate: HvComponentOnUpdate,
   options: HvComponentOptions,
 ): ?React$Element<any> | ?string => {
+  if (!element) {
+    return null;
+  }
   if (element.nodeType === NODE_TYPE.ELEMENT_NODE) {
     // Hidden elements don't get rendered
     if (element.getAttribute('hide') === 'true') {


### PR DESCRIPTION
Note: this is a temporary work around to prevent crashes. Proper fix should be addressed in the form of refactors of faulty components.

This issue occurs as we have numerous places in the code base that expects an element to be returned, even when not present. e.g. with the following markup:
```xml
<section-list>
  <section>
    <item><text>Foo</text></item>
    <item><text>Bar</text></item>
  </section>
</section-list>
```
in the example above, we're missing the `<section-title>` element, but [this code](https://github.com/Instawork/hyperview/blob/master/src/components/hv-section-list/index.js#L105-L107) assumes it does. Upon trying to render it, the app crashes as we're trying to access properties on an `undefined` object. There's a variety of other places in the code that attempt to access elements without verifying it exist first, so this fix should help act as a "catch-all". Ideally, proper typing should help prevent these kind of bugs. For the time being, treating the element as an optional when rendering will avoid these crashes.

![Simulator Screen Shot - iPhone 14 Pro - 2022-11-02 at 08 54 11](https://user-images.githubusercontent.com/309515/199541335-73625447-4bc4-488f-8f38-c60709188499.png)

