### PR TITLE
fix(core-schema): update switch element to allow behaviors as children

### DIFF
--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -944,6 +944,11 @@
 
   <xs:element name="switch">
     <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="hv:behavior"/>
+        </xs:choice>
+      </xs:sequence>
       <xs:attribute name="name" use="required" type="xs:string" />
       <xs:attribute name="value">
         <xs:simpleType>

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -946,7 +946,7 @@
     <xs:complexType>
       <xs:sequence>
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element ref="hv:behavior"/>
+          <xs:element ref="hv:behavior" />
         </xs:choice>
       </xs:sequence>
       <xs:attribute name="name" use="required" type="xs:string" />


### PR DESCRIPTION
- Switch element schema does not allow any children as per current schema. It is useful to have behavior tags inside switch element to trigger a behavior if the switch value is changed.
- This change allows elements of type `behavior` to be inside `switch` element.