### PR TITLE
feat(header): support stale reason header and stale error trigger

### DIFF
--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -42,6 +42,7 @@ import type { Node } from 'react';
 import VisibilityDetectingView from 'hyperview/src/VisibilityDetectingView';
 import { XMLSerializer } from 'xmldom-instawork';
 import { createTestProps } from 'hyperview/src/services';
+import { X_RESPONSE_STALE_REASON } from '../../services/dom/types';
 
 /**
  * Wrapper to handle UI events
@@ -219,7 +220,10 @@ export default class HyperRef extends PureComponent<Props, State> {
 
   triggerLoadBehaviors = () => {
     let loadBehaviors = this.getBehaviorElements(TRIGGERS.LOAD);
-    if (this.props.options?.isStale) {
+    if (
+      this.props.options?.staleHeaderType ===
+      X_RESPONSE_STALE_REASON.STALE_IF_ERROR
+    ) {
       const loadStaleBehaviors = this.getBehaviorElements(
         TRIGGERS.LOAD_STALE_ERROR,
       );

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -218,7 +218,13 @@ export default class HyperRef extends PureComponent<Props, State> {
   };
 
   triggerLoadBehaviors = () => {
-    const loadBehaviors = this.getBehaviorElements(TRIGGERS.LOAD);
+    let loadBehaviors = this.getBehaviorElements(TRIGGERS.LOAD);
+    if (this.props.options?.isStale) {
+      const loadStaleBehaviors = this.getBehaviorElements(
+        TRIGGERS.LOAD_STALE_ERROR,
+      );
+      loadBehaviors = loadBehaviors.concat(loadStaleBehaviors);
+    }
     loadBehaviors.forEach(behaviorElement => {
       const handler = this.createActionHandler(
         behaviorElement,

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -41,8 +41,8 @@ import {
 import type { Node } from 'react';
 import VisibilityDetectingView from 'hyperview/src/VisibilityDetectingView';
 import { XMLSerializer } from 'xmldom-instawork';
+import { X_RESPONSE_STALE_REASON } from 'hyperview/src/services/dom/types';
 import { createTestProps } from 'hyperview/src/services';
-import { X_RESPONSE_STALE_REASON } from '../../services/dom/types';
 
 /**
  * Wrapper to handle UI events

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ export default class HyperScreen extends React.Component {
       error: false,
       styles: null,
       url: null,
+      isStale: false,
     };
 
     // <HACK>
@@ -195,13 +196,14 @@ export default class HyperScreen extends React.Component {
       }
 
       // eslint-disable-next-line react/no-access-state-in-setstate
-      const doc = await this.parser.loadDocument(this.state.url);
+      const { doc, isStale } = await this.parser.loadDocument(this.state.url);
       const stylesheets = Stylesheets.createStylesheets(doc);
       this.navigation.setRouteKey(this.state.url, routeKey);
       this.setState({
         doc,
         error: null,
         styles: stylesheets,
+        isStale: isStale,
       });
 
     } catch (err) {
@@ -238,7 +240,7 @@ export default class HyperScreen extends React.Component {
       return React.createElement(errorScreen, {
         error: this.state.error,
         onPressReload: () => this.reload(),  // Make sure reload() is called without any args
-        onPressViewDetails: (uri) => this.props.openModal({url: uri}),
+        onPressViewDetails: (uri) => this.props.openModal({ url: uri }),
       });
     }
     if (!this.state.doc) {
@@ -253,6 +255,7 @@ export default class HyperScreen extends React.Component {
       {
         componentRegistry: this.componentRegistry,
         screenUrl: this.state.url,
+        isStale: this.state.isStale,
       },
     );
 
@@ -297,7 +300,8 @@ export default class HyperScreen extends React.Component {
 
     try {
       const url = UrlService.getUrlFromHref(href, this.state.url, method);
-      const doc = await this.parser.loadElement(url, formData, method);
+      const { doc, isStale } = await this.parser.loadElement(url, formData, method);
+      this.setState({ isStale: isStale });
       return doc.documentElement;
     } catch (err) {
       this.setState({
@@ -403,7 +407,7 @@ export default class HyperScreen extends React.Component {
         }
         return;
       }
-        behaviorElement.setAttribute('ran-once', 'true');
+      behaviorElement.setAttribute('ran-once', 'true');
 
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ export default class HyperScreen extends React.Component {
     this.state = {
       doc: null,
       error: false,
-      isStale: false,
+      staleHeaderType: null,
       styles: null,
       url: null,
     };
@@ -196,13 +196,13 @@ export default class HyperScreen extends React.Component {
       }
 
       // eslint-disable-next-line react/no-access-state-in-setstate
-      const { doc, isStale } = await this.parser.loadDocument(this.state.url);
+      const { doc, staleHeaderType } = await this.parser.loadDocument(this.state.url);
       const stylesheets = Stylesheets.createStylesheets(doc);
       this.navigation.setRouteKey(this.state.url, routeKey);
       this.setState({
         doc,
         error: null,
-        isStale,
+        staleHeaderType,
         styles: stylesheets,
       });
 
@@ -254,7 +254,7 @@ export default class HyperScreen extends React.Component {
       this.onUpdate,
       {
         componentRegistry: this.componentRegistry,
-        isStale: this.state.isStale,
+        staleHeaderType: this.state.staleHeaderType,
         screenUrl: this.state.url,
       },
     );
@@ -300,8 +300,11 @@ export default class HyperScreen extends React.Component {
 
     try {
       const url = UrlService.getUrlFromHref(href, this.state.url, method);
-      const { doc, isStale } = await this.parser.loadElement(url, formData, method);
-      this.setState({ isStale });
+      const { doc, staleHeaderType } = await this.parser.loadElement(url, formData, method);
+      if (staleHeaderType) {
+        // We are doing this to ensure that we keep the screen stale until a `reload` happens
+        this.setState({ staleHeaderType });
+      }
       return doc.documentElement;
     } catch (err) {
       this.setState({

--- a/src/index.js
+++ b/src/index.js
@@ -254,8 +254,8 @@ export default class HyperScreen extends React.Component {
       this.onUpdate,
       {
         componentRegistry: this.componentRegistry,
-        staleHeaderType: this.state.staleHeaderType,
         screenUrl: this.state.url,
+        staleHeaderType: this.state.staleHeaderType,
       },
     );
 

--- a/src/index.js
+++ b/src/index.js
@@ -53,9 +53,9 @@ export default class HyperScreen extends React.Component {
     this.state = {
       doc: null,
       error: false,
+      isStale: false,
       styles: null,
       url: null,
-      isStale: false,
     };
 
     // <HACK>
@@ -202,8 +202,8 @@ export default class HyperScreen extends React.Component {
       this.setState({
         doc,
         error: null,
+        isStale,
         styles: stylesheets,
-        isStale: isStale,
       });
 
     } catch (err) {
@@ -254,8 +254,8 @@ export default class HyperScreen extends React.Component {
       this.onUpdate,
       {
         componentRegistry: this.componentRegistry,
-        screenUrl: this.state.url,
         isStale: this.state.isStale,
+        screenUrl: this.state.url,
       },
     );
 
@@ -301,7 +301,7 @@ export default class HyperScreen extends React.Component {
     try {
       const url = UrlService.getUrlFromHref(href, this.state.url, method);
       const { doc, isStale } = await this.parser.loadElement(url, formData, method);
-      this.setState({ isStale: isStale });
+      this.setState({ isStale });
       return doc.documentElement;
     } catch (err) {
       this.setState({

--- a/src/services/dom/index.test.js
+++ b/src/services/dom/index.test.js
@@ -28,7 +28,11 @@ const responseTextMock = jest.fn();
 const headers = new Map();
 headers.set(Dom.HTTP_HEADERS.X_RESPONSE_STALE_REASON, 'stale-if-error');
 // $FlowFixMe
-fetchMock.mockResolvedValue({ text: responseTextMock }).mockResolvedValueOnce({ text: responseTextMock, headers });
+fetchMock
+  .mockResolvedValue({
+    text: responseTextMock,
+  })
+  .mockResolvedValueOnce({ headers, text: responseTextMock });
 const beforeParseMock = jest.fn();
 const afterParseMock = jest.fn();
 const urlServiceAddFormDataToUrlMock = jest.spyOn(

--- a/src/services/dom/index.test.js
+++ b/src/services/dom/index.test.js
@@ -10,8 +10,8 @@
 
 import * as Dom from 'hyperview/src/services/dom';
 import * as UrlService from 'hyperview/src/services/url';
-import { version } from 'hyperview/package.json';
 import { X_RESPONSE_STALE_REASON } from './types';
+import { version } from 'hyperview/package.json';
 
 // Mock instawork-xmldom module
 const mockExpectedDocument = { foo: 'bar' };

--- a/src/services/dom/index.test.js
+++ b/src/services/dom/index.test.js
@@ -47,40 +47,6 @@ describe('Parser', () => {
   });
 
   describe('load', () => {
-    describe('offline GET', () => {
-      it('sets the right staleHeaderType', async () => {
-        const url = 'http://foo/bar';
-        const expectedOptions = {
-          body: undefined,
-          headers: {
-            Accept: 'application/xml, application/vnd.hyperview+xml',
-            'X-Hyperview-Dimensions': '750w 1334h',
-            'X-Hyperview-Version': version,
-          },
-          method: 'get',
-        };
-        const responseText = 'foobarbaz';
-        responseTextMock.mockResolvedValue(responseText);
-        const headers = new Map();
-        headers.set(
-          Dom.HTTP_HEADERS.X_RESPONSE_STALE_REASON,
-          X_RESPONSE_STALE_REASON.STALE_IF_ERROR,
-        );
-        // $FlowFixMe
-        fetchMock.mockResolvedValueOnce({ headers, text: responseTextMock });
-
-        const { doc, staleHeaderType } = await parser.load(url);
-
-        expect(urlServiceAddFormDataToUrlMock).toHaveBeenCalledTimes(0);
-        expect(mockParseFromString).toHaveBeenCalledWith(responseText);
-        expect(beforeParseMock).toHaveBeenCalledWith(url);
-        expect(afterParseMock).toHaveBeenCalledWith(url);
-        expect(fetchMock).toHaveBeenCalledWith(url, expectedOptions);
-        expect(doc).toEqual(mockExpectedDocument);
-        expect(staleHeaderType).toEqual(X_RESPONSE_STALE_REASON.STALE_IF_ERROR);
-      });
-    });
-
     describe('simple GET', () => {
       it('calls fetch with correct params', async () => {
         const url = 'http://foo/bar';
@@ -136,6 +102,40 @@ describe('Parser', () => {
         });
         expect(doc).toEqual(mockExpectedDocument);
         expect(staleHeaderType).toBeNull();
+      });
+    });
+
+    describe('offline GET', () => {
+      it('sets the right staleHeaderType', async () => {
+        const url = 'http://foo/bar';
+        const expectedOptions = {
+          body: undefined,
+          headers: {
+            Accept: 'application/xml, application/vnd.hyperview+xml',
+            'X-Hyperview-Dimensions': '750w 1334h',
+            'X-Hyperview-Version': version,
+          },
+          method: 'get',
+        };
+        const responseText = 'foobarbaz';
+        responseTextMock.mockResolvedValue(responseText);
+        const headers = new Map();
+        headers.set(
+          Dom.HTTP_HEADERS.X_RESPONSE_STALE_REASON,
+          X_RESPONSE_STALE_REASON.STALE_IF_ERROR,
+        );
+        // $FlowFixMe
+        fetchMock.mockResolvedValueOnce({ headers, text: responseTextMock });
+
+        const { doc, staleHeaderType } = await parser.load(url);
+
+        expect(urlServiceAddFormDataToUrlMock).toHaveBeenCalledTimes(0);
+        expect(mockParseFromString).toHaveBeenCalledWith(responseText);
+        expect(beforeParseMock).toHaveBeenCalledWith(url);
+        expect(afterParseMock).toHaveBeenCalledWith(url);
+        expect(fetchMock).toHaveBeenCalledWith(url, expectedOptions);
+        expect(doc).toEqual(mockExpectedDocument);
+        expect(staleHeaderType).toEqual(X_RESPONSE_STALE_REASON.STALE_IF_ERROR);
       });
     });
 

--- a/src/services/dom/index.test.js
+++ b/src/services/dom/index.test.js
@@ -28,11 +28,9 @@ const responseTextMock = jest.fn();
 const headers = new Map();
 headers.set(Dom.HTTP_HEADERS.X_RESPONSE_STALE_REASON, 'stale-if-error');
 // $FlowFixMe
-fetchMock
-  .mockResolvedValue({
-    text: responseTextMock,
-  })
-  .mockResolvedValueOnce({ headers, text: responseTextMock });
+fetchMock.mockResolvedValue({ text: responseTextMock });
+// $FlowFixMe
+fetchMock.mockResolvedValueOnce({ headers, text: responseTextMock });
 const beforeParseMock = jest.fn();
 const afterParseMock = jest.fn();
 const urlServiceAddFormDataToUrlMock = jest.spyOn(

--- a/src/services/dom/parser.js
+++ b/src/services/dom/parser.js
@@ -10,8 +10,18 @@
 
 import * as Errors from './errors';
 import * as UrlService from 'hyperview/src/services/url';
-import type { BeforeAfterParseHandler, Fetch, HttpMethod } from './types';
-import { CONTENT_TYPE, HTTP_HEADERS, HTTP_METHODS } from './types';
+import type {
+  BeforeAfterParseHandler,
+  Fetch,
+  HttpMethod,
+  XResponseStaleReason,
+} from './types';
+import {
+  CONTENT_TYPE,
+  HTTP_HEADERS,
+  HTTP_METHODS,
+  X_RESPONSE_STALE_REASON,
+} from './types';
 import { DOMParser } from 'xmldom-instawork';
 import { Dimensions } from 'react-native';
 import type { Document } from 'hyperview/src/types';
@@ -58,7 +68,7 @@ export class Parser {
     data: ?FormData,
     httpMethod: ?HttpMethod,
     acceptContentType: string = CONTENT_TYPE.APPLICATION_VND_HYPERVIEW_XML,
-  ): Promise<{ doc: Document, isStale: boolean }> => {
+  ): Promise<{ doc: Document, staleHeaderType: ?XResponseStaleReason }> => {
     // HTTP method can either be POST when explicitly set
     // Any other value and we'll default to GET
     const method =
@@ -87,12 +97,12 @@ export class Parser {
     const contentType: string = response.headers?.get(
       HTTP_HEADERS.CONTENT_TYPE,
     );
-    const staleHeader: string = response.headers?.get(
+    const staleHeaderType: XResponseStaleReason = response.headers?.get(
       HTTP_HEADERS.X_RESPONSE_STALE_REASON,
     );
     if (
       response.status >= 500 &&
-      !staleHeader &&
+      staleHeaderType !== X_RESPONSE_STALE_REASON.STALE_IF_ERROR &&
       contentType !== CONTENT_TYPE.APPLICATION_XML
     ) {
       throw new Errors.ServerError(
@@ -110,13 +120,13 @@ export class Parser {
     if (this.onAfterParse) {
       this.onAfterParse(url);
     }
-    return { doc, isStale: !!staleHeader };
+    return { doc, staleHeaderType: staleHeaderType ?? null };
   };
 
   loadDocument = async (
     baseUrl: string,
-  ): Promise<{ doc: Document, isStale: boolean }> => {
-    const { doc, isStale } = await this.load(baseUrl);
+  ): Promise<{ doc: Document, staleHeaderType: ?XResponseStaleReason }> => {
+    const { doc, staleHeaderType } = await this.load(baseUrl);
     const docElement = getFirstTag(doc, LOCAL_NAME.DOC);
     if (!docElement) {
       throw new Errors.XMLRequiredElementNotFound(LOCAL_NAME.DOC, baseUrl);
@@ -131,15 +141,15 @@ export class Parser {
     if (!bodyElement) {
       throw new Errors.XMLRequiredElementNotFound(LOCAL_NAME.BODY, baseUrl);
     }
-    return { doc, isStale };
+    return { doc, staleHeaderType };
   };
 
   loadElement = async (
     baseUrl: string,
     data: ?FormData,
     method: ?HttpMethod = HTTP_METHODS.GET,
-  ): Promise<{ doc: Document, isStale: boolean }> => {
-    const { doc, isStale } = await this.load(
+  ): Promise<{ doc: Document, staleHeaderType: ?XResponseStaleReason }> => {
+    const { doc, staleHeaderType } = await this.load(
       baseUrl,
       data,
       method,
@@ -159,6 +169,6 @@ export class Parser {
     if (bodyElement) {
       throw new Errors.XMLRestrictedElementFound(LOCAL_NAME.BODY, baseUrl);
     }
-    return { doc, isStale };
+    return { doc, staleHeaderType };
   };
 }

--- a/src/services/dom/parser.js
+++ b/src/services/dom/parser.js
@@ -120,7 +120,7 @@ export class Parser {
     if (this.onAfterParse) {
       this.onAfterParse(url);
     }
-    return { doc, staleHeaderType: staleHeaderType ?? null };
+    return { doc, staleHeaderType: staleHeaderType || null };
   };
 
   loadDocument = async (

--- a/src/services/dom/types.js
+++ b/src/services/dom/types.js
@@ -13,6 +13,7 @@ export const HTTP_HEADERS = {
   CONTENT_TYPE: 'Content-Type',
   X_HYPERVIEW_DIMENSIONS: 'X-Hyperview-Dimensions',
   X_HYPERVIEW_VERSION: 'X-Hyperview-Version',
+  X_RESPONSE_STALE_REASON: 'X-Response-Stale-Reason',
 };
 
 export const HTTP_METHODS = {

--- a/src/services/dom/types.js
+++ b/src/services/dom/types.js
@@ -31,6 +31,12 @@ export const CONTENT_TYPE = {
   TEXT_HTML: 'text/html',
 };
 
+export const X_RESPONSE_STALE_REASON = {
+  STALE_IF_ERROR: 'stale-if-error',
+};
+
+export type XResponseStaleReason = $Values<typeof X_RESPONSE_STALE_REASON>;
+
 export type Fetch = (
   url: string,
   options: { headers: { [string]: any } },

--- a/src/types.js
+++ b/src/types.js
@@ -262,6 +262,7 @@ export type HvComponentOptions = {
   delay?: ?DOMString,
   focused?: ?boolean,
   hideIndicatorIds?: ?DOMString,
+  isStale?: boolean,
   once?: ?DOMString,
   onEnd?: ?() => void,
   onSelect?: ?(value: ?DOMString) => void,
@@ -331,6 +332,7 @@ export type BehaviorRegistry = {
 export const TRIGGERS = Object.freeze({
   DESELECT: 'deselect',
   LOAD: 'load',
+  LOAD_STALE_ERROR: 'load-stale-error',
   LONG_PRESS: 'longPress',
   ON_EVENT: 'on-event',
   PRESS: 'press',

--- a/src/types.js
+++ b/src/types.js
@@ -10,6 +10,8 @@
 
 import type { ElementRef } from 'react';
 
+import type { XResponseStaleReason } from './services/dom/types';
+
 export type DOMString = string;
 export type NamespaceURI = string;
 
@@ -262,7 +264,7 @@ export type HvComponentOptions = {
   delay?: ?DOMString,
   focused?: ?boolean,
   hideIndicatorIds?: ?DOMString,
-  isStale?: boolean,
+  staleHeaderType?: XResponseStaleReason,
   once?: ?DOMString,
   onEnd?: ?() => void,
   onSelect?: ?(value: ?DOMString) => void,


### PR DESCRIPTION
### Summary
1. Add support for `X-Response-Stale-Reason` header, this header is set when content fetched is stale, typically served from a cache.
2. Implement new trigger `load-stale-error`, so that the UI can be modified when the content served is stale.