### PR TITLE
feat: `immediate` load behavior

### DIFF
--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -381,6 +381,7 @@
     <xs:attribute name="event-name" type="hv:eventName" />
     <xs:attribute name="new-value" type="xs:string" />
     <xs:attribute name="copy-to-clipboard-value" type="xs:string" />
+    <xs:attribute name="immediate" type="xs:boolean" />
     <xs:attributeGroup ref="alert:alertAttributes" />
   </xs:attributeGroup>
 

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -234,7 +234,11 @@ export default class HyperRef extends PureComponent<Props, State> {
         behaviorElement,
         this.props.onUpdate,
       );
-      handler(this.props.element);
+      if (behaviorElement.getAttribute(ATTRIBUTES.IMMEDIATE) === 'true') {
+        handler(this.props.element);
+      } else {
+        setTimeout(() => handler(this.props.element), 0);
+      }
     });
   };
 

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -234,7 +234,7 @@ export default class HyperRef extends PureComponent<Props, State> {
         behaviorElement,
         this.props.onUpdate,
       );
-      setTimeout(() => handler(this.props.element), 0);
+      handler(this.props.element);
     });
   };
 

--- a/src/core/hyper-ref/types.js
+++ b/src/core/hyper-ref/types.js
@@ -35,6 +35,7 @@ export const ATTRIBUTES = {
   HIDE_DURING_LOAD: 'hide-during-load',
   HREF: 'href',
   HREF_STYLE: 'href-style',
+  IMMEDIATE: 'immediate',
   ONCE: 'once',
   SHOW_DURING_LOAD: 'show-during-load',
   TARGET: 'target',


### PR DESCRIPTION
`load` behavior are triggered by default on the next event loop. Apparent reason for this, is to wait until the first render occurred to trigger behavior that may try mutate existing elements.
While this works for most cases, there's some situation when we want to trigger custom behaviors before the render cycle occurred. This code change introduce a new boolean attribute `immediate`, which controls this.

The behaviors API need some work in general (i.e. "delay", "once" are not consistently supported for every triggers), so for the time being, we're keeping this new attribute as undocumented, as we're not certain how the behavior spec will evolve in the future.