### PR TITLE
feat: Handle element error gracefully

### DIFF
--- a/src/core/components/load-element-error/index.js
+++ b/src/core/components/load-element-error/index.js
@@ -13,7 +13,6 @@ import { SafeAreaView, Text, View } from 'react-native';
 import type { Props } from './types';
 import styles from './styles';
 
-
 const LoadElementError = (props: Props) => {
   const getError = () => {
     if (!props.error) {
@@ -22,7 +21,10 @@ const LoadElementError = (props: Props) => {
     if (__DEV__) {
       return `${props.error.name}: ${props.error.message}`;
     }
-    if (props.error.name == 'TypeError' && props.error.message === 'Network request failed') {
+    if (
+      props.error.name == 'TypeError' &&
+      props.error.message === 'Network request failed'
+    ) {
       return 'You seem to be offline, check your connection';
     }
     return 'An error occured';

--- a/src/core/components/load-element-error/index.js
+++ b/src/core/components/load-element-error/index.js
@@ -1,0 +1,40 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React from 'react';
+import { SafeAreaView, Text, View } from 'react-native';
+import type { Props } from './types';
+import styles from './styles';
+
+
+const LoadElementError = (props: Props) => {
+  const getError = () => {
+    if (!props.error) {
+      return 'An error occured';
+    }
+    if (__DEV__) {
+      return `${props.error.name}: ${props.error.message}`;
+    }
+    if (props.error.name == 'TypeError' && props.error.message === 'Network request failed') {
+      return 'You seem to be offline, check your connection';
+    }
+    return 'An error occured';
+  };
+
+  return (
+    <SafeAreaView>
+      <View style={styles.container}>
+        <Text style={styles.title}>{getError()}</Text>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+export default LoadElementError;

--- a/src/core/components/load-element-error/index.js
+++ b/src/core/components/load-element-error/index.js
@@ -15,9 +15,6 @@ import styles from './styles';
 
 const LoadElementError = (props: Props) => {
   const getError = () => {
-    if (!props.error) {
-      return 'An error occured';
-    }
     if (__DEV__) {
       return `${props.error.name}: ${props.error.message}`;
     }

--- a/src/core/components/load-element-error/index.js
+++ b/src/core/components/load-element-error/index.js
@@ -8,9 +8,9 @@
  *
  */
 
-import React from 'react';
 import { SafeAreaView, Text, View } from 'react-native';
 import type { Props } from './types';
+import React from 'react';
 import styles from './styles';
 
 const LoadElementError = (props: Props) => {
@@ -19,7 +19,7 @@ const LoadElementError = (props: Props) => {
       return `${props.error.name}: ${props.error.message}`;
     }
     if (
-      props.error.name == 'TypeError' &&
+      props.error.name === 'TypeError' &&
       props.error.message === 'Network request failed'
     ) {
       return 'You seem to be offline, check your connection';

--- a/src/core/components/load-element-error/styles.js
+++ b/src/core/components/load-element-error/styles.js
@@ -1,0 +1,21 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    backgroundColor: '#fbb90e',
+  },
+  title: {
+    color: '#ffffff',
+    textAlign: 'center',
+  },
+});

--- a/src/core/components/load-element-error/types.js
+++ b/src/core/components/load-element-error/types.js
@@ -1,0 +1,13 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export type Props = {
+  error: ?Error,
+};

--- a/src/core/components/load-element-error/types.js
+++ b/src/core/components/load-element-error/types.js
@@ -8,6 +8,6 @@
  *
  */
 
-export type Props = {
+export type Props = {|
   error: Error,
-};
+|};

--- a/src/core/components/load-element-error/types.js
+++ b/src/core/components/load-element-error/types.js
@@ -9,5 +9,5 @@
  */
 
 export type Props = {
-  error: ?Error,
+  error: Error,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,8 @@ import { ACTIONS, NAV_ACTIONS, UPDATE_ACTIONS } from 'hyperview/src/types';
 // eslint-disable-next-line instawork/import-services
 import Navigation, { ANCHOR_ID_SEPARATOR } from 'hyperview/src/services/navigation';
 import { createProps, createStyleProp, getElementByTimeoutId, getFormData, later, removeTimeoutId, setTimeoutId, shallowCloneToRoot } from 'hyperview/src/services';
-import { Linking } from 'react-native';
+import { Linking, SafeAreaView } from 'react-native';
+import LoadElementError from './core/components/load-element-error';
 import LoadError from 'hyperview/src/core/components/load-error';
 import Loading from 'hyperview/src/core/components/loading';
 import React from 'react';
@@ -52,7 +53,8 @@ export default class HyperScreen extends React.Component {
     this.needsLoad = false;
     this.state = {
       doc: null,
-      error: false,
+      elementError: null,
+      error: null,
       staleHeaderType: null,
       styles: null,
       url: null,
@@ -112,11 +114,13 @@ export default class HyperScreen extends React.Component {
       this.setState({
         doc: preloadScreen,
         error: null,
+        elementError: null,
         styles: preloadStyles,
         url,
       });
     } else {
       this.setState({
+        elementError: null,
         error: null,
         url,
       });
@@ -201,6 +205,7 @@ export default class HyperScreen extends React.Component {
       this.navigation.setRouteKey(this.state.url, routeKey);
       this.setState({
         doc,
+        elementError: null,
         error: null,
         staleHeaderType,
         styles: stylesheets,
@@ -209,6 +214,7 @@ export default class HyperScreen extends React.Component {
     } catch (err) {
       this.setState({
         doc: null,
+        elementError: null,
         error: err,
         styles: null,
       });
@@ -226,6 +232,7 @@ export default class HyperScreen extends React.Component {
       : UrlService.getUrlFromHref(optHref, this.state.url); // eslint-disable-line react/no-access-state-in-setstate
     this.needsLoad = true;
     this.setState({
+      elementError: null,
       error: null,
       url,
     });
@@ -235,7 +242,7 @@ export default class HyperScreen extends React.Component {
    * Renders the XML doc into React components. Shows blank screen until the XML doc is available.
    */
   render() {
-    if (this.state.error && !this.state.doc) {
+    if (this.state.error) {
       const errorScreen = this.props.errorScreen || LoadError;
       return React.createElement(errorScreen, {
         error: this.state.error,
@@ -247,6 +254,7 @@ export default class HyperScreen extends React.Component {
       const loadingScreen = this.props.loadingScreen || Loading;
       return React.createElement(loadingScreen);
     }
+    const elementErrorComponent = this.state.elementError ? this.props.elementErrorTip || LoadError : null;
     const [body] = Array.from(this.state.doc.getElementsByTagNameNS(Namespaces.HYPERVIEW, 'body'));
     const screenElement = Render.renderElement(
       body,
@@ -263,6 +271,7 @@ export default class HyperScreen extends React.Component {
       <Contexts.DateFormatContext.Provider value={this.props.formatDate}>
         <Contexts.RefreshControlComponentContext.Provider value={this.props.refreshControl}>
           {screenElement}
+          {this.state.elementError ? (React.createElement(LoadElementError, { error: this.state.elementError })) : null}
         </Contexts.RefreshControlComponentContext.Provider>
       </Contexts.DateFormatContext.Provider>
     );
@@ -305,20 +314,12 @@ export default class HyperScreen extends React.Component {
         // We are doing this to ensure that we keep the screen stale until a `reload` happens
         this.setState({ staleHeaderType });
       }
+      if (this.state.elementError) {
+        this.setState({ elementError: null });
+      }
       return doc.documentElement;
     } catch (err) {
-      if (err.message === 'Network request failed') {
-        // Don't clear the doc and styles when offline
-        this.setState({
-          error: err,
-        });
-      } else {
-        this.setState({
-          doc: null,
-          error: err,
-          styles: null,
-        });
-      }
+      this.setState({ elementError: err });
     }
     return null;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -113,8 +113,8 @@ export default class HyperScreen extends React.Component {
     if (preloadScreen) {
       this.setState({
         doc: preloadScreen,
-        error: null,
         elementError: null,
+        error: null,
         styles: preloadStyles,
         url,
       });

--- a/src/index.js
+++ b/src/index.js
@@ -254,7 +254,7 @@ export default class HyperScreen extends React.Component {
       const loadingScreen = this.props.loadingScreen || Loading;
       return React.createElement(loadingScreen);
     }
-    const elementErrorComponent = this.state.elementError ? this.props.elementErrorTip || LoadError : null;
+    const elementErrorComponent = this.state.elementError ? this.props.elementErrorComponent || LoadElementError : null;
     const [body] = Array.from(this.state.doc.getElementsByTagNameNS(Namespaces.HYPERVIEW, 'body'));
     const screenElement = Render.renderElement(
       body,
@@ -271,7 +271,7 @@ export default class HyperScreen extends React.Component {
       <Contexts.DateFormatContext.Provider value={this.props.formatDate}>
         <Contexts.RefreshControlComponentContext.Provider value={this.props.refreshControl}>
           {screenElement}
-          {this.state.elementError ? (React.createElement(LoadElementError, { error: this.state.elementError })) : null}
+          {elementErrorComponent ? (React.createElement(elementErrorComponent, { error: this.state.elementError })) : null}
         </Contexts.RefreshControlComponentContext.Provider>
       </Contexts.DateFormatContext.Provider>
     );

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ import { ACTIONS, NAV_ACTIONS, UPDATE_ACTIONS } from 'hyperview/src/types';
 // eslint-disable-next-line instawork/import-services
 import Navigation, { ANCHOR_ID_SEPARATOR } from 'hyperview/src/services/navigation';
 import { createProps, createStyleProp, getElementByTimeoutId, getFormData, later, removeTimeoutId, setTimeoutId, shallowCloneToRoot } from 'hyperview/src/services';
-import { Linking, SafeAreaView } from 'react-native';
+import { Linking } from 'react-native';
 import LoadElementError from './core/components/load-element-error';
 import LoadError from 'hyperview/src/core/components/load-error';
 import Loading from 'hyperview/src/core/components/loading';

--- a/src/index.js
+++ b/src/index.js
@@ -235,7 +235,7 @@ export default class HyperScreen extends React.Component {
    * Renders the XML doc into React components. Shows blank screen until the XML doc is available.
    */
   render() {
-    if (this.state.error) {
+    if (this.state.error && !this.state.doc) {
       const errorScreen = this.props.errorScreen || LoadError;
       return React.createElement(errorScreen, {
         error: this.state.error,
@@ -307,11 +307,18 @@ export default class HyperScreen extends React.Component {
       }
       return doc.documentElement;
     } catch (err) {
-      this.setState({
-        doc: null,
-        error: err,
-        styles: null,
-      });
+      if (err.message === 'Network request failed') {
+        // Don't clear the doc and styles when offline
+        this.setState({
+          error: err,
+        });
+      } else {
+        this.setState({
+          doc: null,
+          error: err,
+          styles: null,
+        });
+      }
     }
     return null;
   }
@@ -431,7 +438,9 @@ export default class HyperScreen extends React.Component {
           targetElement = currentElement;
         }
 
-        newRoot = Behaviors.performUpdate(action, targetElement, newElement);
+        if (newElement) {
+          newRoot = Behaviors.performUpdate(action, targetElement, newElement);
+        }
         newRoot = Behaviors.setIndicatorsAfterLoad(showIndicatorIdList, hideIndicatorIdList, newRoot);
         // Re-render the modifications
         this.setState({


### PR DESCRIPTION
### Summary
When the document is already loaded on to the screen but the subsequent requests fail due to an error while scrolling, currently entire screen shows an error message, and we lose the previous content.
This PR aims to handle HTTP errors gracefully by showing a banner at the bottom indicating there was an error but still let the user browse the content which was already loaded.

### Videos
| Before | After |
| --- | --- |
| <video src="https://user-images.githubusercontent.com/28518512/217921739-5aed32a3-fd03-4d93-b1fc-8cfe406da5f5.mp4" /> | <video src="https://user-images.githubusercontent.com/28518512/217847216-56d2e123-e7f9-4933-89c0-d3b28cf345b9.mp4" /> |
