### PR TITLE
docs: Add `avoid-keyboard` note

### DIFF
--- a/docs/reference_view.md
+++ b/docs/reference_view.md
@@ -146,6 +146,8 @@ If `hide="true"`, the element will not be rendered on screen. If the element or 
 
 An attribute to solve the common problem of views that need to move out of the way of the virtual keyboard. It can automatically adjust the position of its children based on the keyboard height. This is useful when you want keyboard avoiding behavior in non-scrollable views. It is applied only in iOS since Android has built-in support for avoiding keyboard.
 
+> For `avoid-keyboard` to work properly the direct parent element should have same screen height.
+
 #### `sticky`
 
 | Type                      | Required |


### PR DESCRIPTION
Add a quick note about `avoid-keyboard` . I found that the direct parent element should have the same screen height to work properly