### PR TITLE
fix(web): Add form data to URL

### DIFF
--- a/src/services/url/index.js
+++ b/src/services/url/index.js
@@ -8,7 +8,7 @@
  *
  */
 
-import type { FormDataGetParts } from 'hyperview/src/services/url/types';
+import type { FormData } from 'hyperview/src/services/url/types';
 import urlParse from 'url-parse';
 
 const QUERY_SEPARATOR = '?';
@@ -47,11 +47,27 @@ export const addParamsToUrl = (
  * Add FormData as query params to a url. Ignores files in the formdata.
  */
 export const addFormDataToUrl = (url: string, formData: ?FormData): string => {
-  if (!formData) {
-    return url;
+  if (formData) {
+    if (formData.getParts) {
+      const params = formData.getParts();
+      return addParamsToUrl(
+        url,
+        params.map(p => ({
+          name: p.fieldName,
+          value: p.string,
+        })),
+      );
+    }
+    if (formData.entries) {
+      const params = Array.from(formData.entries());
+      return addParamsToUrl(
+        url,
+        params.map(p => ({
+          name: p[0],
+          value: String(p[1]),
+        })),
+      );
+    }
   }
-
-  const parts = ((formData: any): FormDataGetParts).getParts();
-  const params = parts.map(p => ({ name: p.fieldName, value: p.string }));
-  return addParamsToUrl(url, params);
+  return url;
 };

--- a/src/services/url/types.js
+++ b/src/services/url/types.js
@@ -9,6 +9,12 @@
  */
 
 // Type needed to expose a method in FormData that default Flow types don't know about
-export type FormDataGetParts = {
-  getParts: () => Array<{ fieldName: string, string: string }>,
-};
+export type FormData = $ReadOnly<{
+  // React Native implementation of global FormData
+  // https://github.com/facebook/react-native/blob/d05a5d15512ab794ef80b31ef91090d5d88b3fcd/Libraries/Network/FormData.js#L73
+  getParts?: () => Array<{ fieldName: string, string: string }>,
+
+  // Web API
+  // https://developer.mozilla.org/en-US/docs/Web/API/FormData/entries
+  entries?: () => Iterator<[string, FormDataEntryValue]>,
+}>;


### PR DESCRIPTION
Web API does not expose the same methods allowing to retrieve the form data as React Native does. Update the implementation to be compatible with Web API.