### PR TITLE
feat(section-list): remove 'section' requirement

### DIFF
--- a/docs/reference_index.md
+++ b/docs/reference_index.md
@@ -28,9 +28,9 @@ Display elements in HXML can be combined to define the layout of a screen.
 - [`<image>`](/docs/reference_image): Any image content on a screen.
 - [`<list>`](/docs/reference_list): Efficient layout of repeated items on a screen. Supports list-specific interactions like pull-to-refresh.
 - [`<section-list>`](/docs/reference_sectionlist): Efficient layout of sectioned (grouped) repeated items on a screen. Supports list-specific interactions like pull-to-refresh.
-- [`<section>`](/docs/reference_sectionlist): Groups `<item>` elements in a `<section-list>`.
-- [`<section-title>`](/docs/reference_sectiontitle): The header of a `<section>` in a `<section-list>`.
-- [`<item>`](/docs/reference_sectiontitle): An individual item in a `<list>` or `<section-list>`.
+- [`<section>`](/docs/reference_sectionlist): [Deprecated] Groups `<item>` and `<section-title>` elements in a `<section-list>`.
+- [`<section-title>`](/docs/reference_sectiontitle): The header of a group of `<item>` in a `<section-list>`.
+- [`<item>`](/docs/reference_item): An individual item in a `<list>` or `<section-list>`.
 - [`<spinner>`](/docs/reference_spinner): Activity indicator element.
 
 #### Input Elements

--- a/docs/reference_item.md
+++ b/docs/reference_item.md
@@ -4,7 +4,7 @@ title: <item>
 sidebar_label: <item>
 ---
 
-The `<item>` element represents an item in a `<list>` or `<section>`. The structure and attributes of an `<item>` match the `<view>` element.
+The `<item>` element represents an item in a `<list>` or `<section-list>`. The structure and attributes of an `<item>` match the `<view>` element.
 
 Here's a single item in a list:
 
@@ -26,21 +26,19 @@ Here's a single item in a section list:
 
 ```xml
 <section-list style="List">
-  <section>
-    <section-title style="Header">
-      <text>Section 1</text>
-    </section-title>
+  <section-title style="Header">
+    <text>Section 1</text>
+  </section-title>
 
-    <item key="a" style="Item">
-      <view style="Left">
-        <image source="avatar.png" style="Avatar">
-      </view>
-      <view style="Right">
-        <text>Line 1</text>
-        <text>Line 2</text>
-      </view>
-    </item>
-  </section>
+  <item key="a" style="Item">
+    <view style="Left">
+      <image source="avatar.png" style="Avatar">
+    </view>
+    <view style="Right">
+      <text>Line 1</text>
+      <text>Line 2</text>
+    </view>
+  </item>
 </section-list>
 ```
 
@@ -48,7 +46,7 @@ Note that the `key` attribute is required and must be unique among items in the 
 
 ## Structure
 
-An `<item>` element can only apear as a direct child of a `<list>` or `<section>` element. It can contain any non-list element as a child.
+An `<item>` element can only apear as a direct child of a `<list>` or `<section-list>` element. It can contain any non-list element as a child.
 
 ## Attributes
 

--- a/docs/reference_items.md
+++ b/docs/reference_items.md
@@ -26,9 +26,9 @@ The `<items>` element represents a group of items in a list. This group does not
 
 ## Structure
 
-An `<items>` element will only render `<item>` children elements. Other elements will be ignored during rendering.
+An `<items>` element will only render `<item>` and `<section-title>` children elements. Other elements will be ignored during rendering.
 
-An `<items>` element only appears as a direct child of a `<list>` and `<section>`.
+An `<items>` element only appears as a direct child of a `<list>` or as a collection of `<section-title>` and `<item>` elements.
 
 ## Attributes
 

--- a/docs/reference_section.md
+++ b/docs/reference_section.md
@@ -4,6 +4,13 @@ title: <section>
 sidebar_label: <section>
 ---
 
+---
+
+**NOTE - DEPRECATED**
+`<section>` is no longer required and has been marked deprecated; `<section-title>` and `<item>` elements may now be direct children of `<section-list>`.
+
+---
+
 The `<section>` element represents a group of items in a `<section-list>`. A section contains a title and items. The section itself does not have any visible style, it just serves as a grouping within the section list.
 
 ```xml

--- a/docs/reference_sectionlist.md
+++ b/docs/reference_sectionlist.md
@@ -8,31 +8,27 @@ The `<section-list>` element represents a sectioned list of items. Each section 
 
 ```xml
 <section-list style="List">
-  <section>
-    <section-title style="Header">
-      <text>Section 1</text>
-    </section-title>
+  <section-title style="Header">
+    <text>Section 1</text>
+  </section-title>
 
-    <item key="a" style="Item">
-      <text>Item 1</text>
-    </item>
-  </section>
+  <item key="a" style="Item">
+    <text>Item 1</text>
+  </item>
 
-  <section>
-    <section-title style="Header">
-      <text>Section 1</text>
-    </section-title>
+  <section-title style="Header">
+    <text>Section 1</text>
+  </section-title>
 
-    <item key="b" style="Item">
-      <text>Section 2</text>
-    </item>
-  </section>
+  <item key="b" style="Item">
+    <text>Section 2</text>
+  </item>
 </section-list>
 ```
 
 ## Structure
 
-A `<section-list>` element will only render `<section>` children elements. Other elements will be ignored during rendering.
+A `<section-list>` element will only render `<section-title>` and `<item>` children elements. Other elements will be ignored during rendering.
 
 ## Attributes
 

--- a/docs/reference_sectiontitle.md
+++ b/docs/reference_sectiontitle.md
@@ -4,35 +4,33 @@ title: <section-title>
 sidebar_label: <section-title>
 ---
 
-The `<section-title>` element represents the title of a section group within a `<sectinon-list>`. It renders as a sticky element that stays at the top of the list while the user scrolls through items in that section.
+The `<section-title>` element represents the title of a group of `<item>` within a `<section-list>`. It renders as an optionally sticky element that stays at the top of the list while the user scrolls through items in that section.
 
 ```xml
 <section-list style="List">
-  <section>
-    <section-title style="Header">
-      <text>Section 1</text>
-    </section-title>
+  <!-- Section 1 -->
+  <section-title style="Header">
+    <text>Section 1</text>
+  </section-title>
 
-    <item key="a" style="Item">
-      <text>Item 1</text>
-    </item>
-  </section>
+  <item key="a" style="Item">
+    <text>Item 1</text>
+  </item>
 
-  <section>
-    <section-title style="Header">
-      <text>Section 1</text>
-    </section-title>
+  <!-- Section 2 -->
+  <section-title style="Header">
+    <text>Section 1</text>
+  </section-title>
 
-    <item key="b" style="Item">
-      <text>Section 2</text>
-    </item>
-  </section>
+  <item key="b" style="Item">
+    <text>Section 2</text>
+  </item>
 </section-list>
 ```
 
 ## Structure
 
-A `<section-title>` element can only appear as a direct child of a `<section>` element.
+A `<section-title>` element can only appear as a direct child of a `<section-list>` or `<items>` element.
 
 ## Attributes
 

--- a/examples/behaviors/index.xml.njk
+++ b/examples/behaviors/index.xml.njk
@@ -68,370 +68,363 @@ tags: root
         <text style="Header__Title">Behaviors</text>
       </header>
       <section-list>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Actions</text>
-          </section-title>
-          <item
-            href="/behaviors/replace.xml"
-            key="replace"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Replace</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/replace_inner.xml"
-            key="replace_inner"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Replace Inner</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/append.xml"
-            key="append"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Append</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/prepend.xml"
-            key="prepend"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Prepend</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/hide.xml"
-            key="hide"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Hide</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/show.xml"
-            key="show"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Show</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/toggle.xml"
-            key="toggle"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Toggle</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/select_all.xml"
-            key="select_all"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Select All</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/unselect_all.xml"
-            key="unselect_all"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Unselect All</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Triggers</text>
-          </section-title>
-          <item
-            href="/behaviors/press.xml"
-            key="press"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Press</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/long_press.xml"
-            key="long_press"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Long press</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/press_in.xml"
-            key="press_in"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Press In</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/press_out.xml"
-            key="press_out"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Press Out</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/visible.xml"
-            key="visible"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Visible</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/visible_once.xml"
-            key="visible_once"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Visible Once</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/refresh.xml"
-            key="refresh"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Refresh</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/load.xml"
-            key="load"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Load</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/select.xml"
-            key="select"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Select</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/deselect.xml"
-            key="deselect"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Deselect</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/focus.xml"
-            key="focus"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Focus</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/blur.xml"
-            key="blur"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Blur</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/change.xml"
-            key="change"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Change</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Target</text>
-          </section-title>
-          <item
-            href="/behaviors/target_sibling.xml"
-            key="target_sibling"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Sibling</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/target_child.xml"
-            key="target_child"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Child</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/target_parent.xml"
-            key="target_parent"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Parent</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/target_parent_element.xml"
-            key="target_parent_element"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Parent Element</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/target_sibling_append.xml"
-            key="target_sibling_append"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Sibling Append</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Indicators</text>
-          </section-title>
-          <item
-            href="/behaviors/show_indicator.xml"
-            key="show_indicator"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Show Indicator</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/show_multiple_indicators.xml"
-            key="show_multiple_indicators"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Show Multiple Indicators</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/hide_indicator.xml"
-            key="hide_indicator"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Hide Indicator</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/hide_multiple_indicators.xml"
-            key="hide_multiple_indicators"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Hide Multiple Indicators</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/show_hide_multiple_indicators.xml"
-            key="show_hide_multiple_indicators"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Show/Hide Multiple Indicators</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/inline_button_indicator.xml"
-            key="inline_button_indicator"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Inline Button Indicator</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/shimmer_indicator.xml"
-            key="shimmer_indicator"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Shimmer Indicator</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Fragments</text>
-          </section-title>
-          <item
-            href="/behaviors/fragment_replace.xml"
-            key="fragment_replace"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Replace</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-          <item
-            href="/behaviors/rating.xml"
-            key="rating"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Rating</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-        </section>
-
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Once</text>
-          </section-title>
-          <item
-            href="/behaviors/once.xml"
-            key="once"
-            show-during-load="loadingScreen"
-            style="Item"
-          >
-            <text style="Item__Label">Once</text>
-            <text style="Item__Chevron">&gt;</text>
-          </item>
-        </section>
+        <!-- Section 1 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Actions</text>
+        </section-title>
+        <item
+          href="/behaviors/replace.xml"
+          key="replace"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Replace</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/replace_inner.xml"
+          key="replace_inner"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Replace Inner</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/append.xml"
+          key="append"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Append</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/prepend.xml"
+          key="prepend"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Prepend</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/hide.xml"
+          key="hide"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Hide</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/show.xml"
+          key="show"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Show</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/toggle.xml"
+          key="toggle"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Toggle</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/select_all.xml"
+          key="select_all"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Select All</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/unselect_all.xml"
+          key="unselect_all"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Unselect All</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <!-- Section 2 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Triggers</text>
+        </section-title>
+        <item
+          href="/behaviors/press.xml"
+          key="press"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Press</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/long_press.xml"
+          key="long_press"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Long press</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/press_in.xml"
+          key="press_in"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Press In</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/press_out.xml"
+          key="press_out"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Press Out</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/visible.xml"
+          key="visible"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Visible</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/visible_once.xml"
+          key="visible_once"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Visible Once</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/refresh.xml"
+          key="refresh"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Refresh</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/load.xml"
+          key="load"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Load</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/select.xml"
+          key="select"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Select</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/deselect.xml"
+          key="deselect"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Deselect</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/focus.xml"
+          key="focus"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Focus</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/blur.xml"
+          key="blur"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Blur</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/change.xml"
+          key="change"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Change</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <!-- Section 3 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Target</text>
+        </section-title>
+        <item
+          href="/behaviors/target_sibling.xml"
+          key="target_sibling"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Sibling</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/target_child.xml"
+          key="target_child"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Child</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/target_parent.xml"
+          key="target_parent"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Parent</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/target_parent_element.xml"
+          key="target_parent_element"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Parent Element</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/target_sibling_append.xml"
+          key="target_sibling_append"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Sibling Append</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <!-- Section 4 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Indicators</text>
+        </section-title>
+        <item
+          href="/behaviors/show_indicator.xml"
+          key="show_indicator"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Show Indicator</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/show_multiple_indicators.xml"
+          key="show_multiple_indicators"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Show Multiple Indicators</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/hide_indicator.xml"
+          key="hide_indicator"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Hide Indicator</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/hide_multiple_indicators.xml"
+          key="hide_multiple_indicators"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Hide Multiple Indicators</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/show_hide_multiple_indicators.xml"
+          key="show_hide_multiple_indicators"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Show/Hide Multiple Indicators</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/inline_button_indicator.xml"
+          key="inline_button_indicator"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Inline Button Indicator</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/shimmer_indicator.xml"
+          key="shimmer_indicator"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Shimmer Indicator</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <!-- Section 5 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Fragments</text>
+        </section-title>
+        <item
+          href="/behaviors/fragment_replace.xml"
+          key="fragment_replace"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Replace</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <item
+          href="/behaviors/rating.xml"
+          key="rating"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Rating</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
+        <!-- Section 6 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Once</text>
+        </section-title>
+        <item
+          href="/behaviors/once.xml"
+          key="once"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Once</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
       </section-list>
     </body>
   </screen>

--- a/examples/case_studies/photos/index.xml
+++ b/examples/case_studies/photos/index.xml
@@ -184,366 +184,129 @@
         </view>
       </view>
       <section-list>
-        <section>
-          <section-title />
-          <item key="stories">
-            <view scroll-orientation="horizontal" style="Stories">
-              <view href="/case_studies/photos/user.xml" style="Story">
-                <image
-                  source="/case_studies/photos/avatars/geordi.jpg"
-                  style="Story__Avatar"
-                />
-                <text numberOfLines="1" style="Story__Username">geordi</text>
-              </view>
-              <view href="/case_studies/photos/user.xml" style="Story">
-                <image
-                  source="/case_studies/photos/avatars/data.jpg"
-                  style="Story__Avatar"
-                />
-                <text numberOfLines="1" style="Story__Username">data</text>
-              </view>
-              <view href="/case_studies/photos/user.xml" style="Story">
-                <image
-                  source="/case_studies/photos/avatars/deanna.png"
-                  style="Story__Avatar"
-                />
-                <text numberOfLines="1" style="Story__Username">
-                  deanna.troi
-                </text>
-              </view>
-              <view href="/case_studies/photos/user.xml" style="Story">
-                <image
-                  source="/case_studies/photos/avatars/picard.jpg"
-                  style="Story__Avatar"
-                />
-                <text numberOfLines="1" style="Story__Username">
-                  jean.luc.p
-                </text>
-              </view>
-              <view href="/case_studies/photos/user.xml" style="Story">
-                <image
-                  source="/case_studies/photos/avatars/worf.jpg"
-                  style="Story__Avatar"
-                />
-                <text numberOfLines="1" style="Story__Username">og_worf</text>
-              </view>
-            </view>
-          </item>
-        </section>
-        <section>
-          <section-title style="ImageHeader">
-            <view style="ImageHeader__Left">
+        <!-- Section 1 -->
+        <section-title />
+        <item key="stories">
+          <view scroll-orientation="horizontal" style="Stories">
+            <view href="/case_studies/photos/user.xml" style="Story">
               <image
-                href="/case_studies/photos/index.xml"
-                source="/case_studies/photos/avatars/riker.jpg"
-                style="ImageHeader__Avatar"
+                source="/case_studies/photos/avatars/geordi.jpg"
+                style="Story__Avatar"
               />
-              <view style="ImageHeader__LeftLabels">
-                <text
-                  href="/case_studies/photos/user.xml"
-                  style="ImageHeader__Username"
-                >
-                  riker007
-                </text>
-                <text style="ImageHeader__Location">Las Vegas, CA</text>
-              </view>
+              <text numberOfLines="1" style="Story__Username">geordi</text>
             </view>
-            <view style="ImageHeader__Right">
-              <text style="ImageHeader__More">...</text>
-            </view>
-          </section-title>
-          <item key="image1">
-            <view style="ImageContainer">
+            <view href="/case_studies/photos/user.xml" style="Story">
               <image
-                source="/case_studies/photos/photos/concert.jpeg"
-                style="Image"
+                source="/case_studies/photos/avatars/data.jpg"
+                style="Story__Avatar"
               />
-              <view id="image1-overlay" style="ImageContainer__Overlay" />
+              <text numberOfLines="1" style="Story__Username">data</text>
             </view>
-            <view style="ActionBar">
-              <view style="ActionBar__Left">
-                <select-multiple name="image1-like">
-                  <option
-                    style="ActionBar__Icon ActionBar__Icon--First"
-                    value="like"
-                  >
-                    <behavior
-                      action="replace"
-                      href="/case_studies/photos/num_likes_increase.xml"
-                      target="image1-num-likes"
-                      trigger="select"
-                    />
-                    <behavior
-                      action="replace"
-                      href="/case_studies/photos/num_likes_decrease.xml"
-                      target="image1-num-likes"
-                      trigger="deselect"
-                    />
-                    <image
-                      source="/case_studies/photos/icons/heart2.png"
-                      style="ActionBar__IconImage"
-                    />
-                    <image
-                      source="/case_studies/photos/icons/heart_liked2.png"
-                      style="ActionBar__IconImage--Selected"
-                    />
-                  </option>
-                </select-multiple>
-                <image
-                  source="/case_studies/photos/icons/chat2.png"
-                  style="ActionBar__Icon"
-                />
-              </view>
-              <view style="ActionBar__Right" />
-            </view>
-            <text style="Caption">Best night of my life!</text>
-            <view style="Comments">
-              <text id="image1-num-likes" style="Comments__Likes">7 likes</text>
-              <text
-                action="prepend"
-                href="/case_studies/photos/more_comments.xml"
-                style="Comments__More"
-                target="comments-image1"
-              >
-                View all 140 comments
-              </text>
-              <view id="comments-image1">
-                <view style="Comment">
-                  <text
-                    href="/case_studies/photos/user.xml"
-                    style="Comment__Author"
-                  >
-                    og_worf
-                  </text>
-                  <text style="Comment__Content">hello!</text>
-                </view>
-                <view style="Comment">
-                  <text
-                    href="/case_studies/photos/user.xml"
-                    style="Comment__Author"
-                  >
-                    riker007
-                  </text>
-                  <text style="Comment__Content">hello!</text>
-                </view>
-                <view style="Comment">
-                  <text
-                    href="/case_studies/photos/user.xml"
-                    style="Comment__Author"
-                  >
-                    jean.luc.p
-                  </text>
-                  <text style="Comment__Content">hello!</text>
-                </view>
-              </view>
-            </view>
-          </item>
-        </section>
-        <section>
-          <section-title style="ImageHeader">
-            <view style="ImageHeader__Left">
-              <image
-                source="/case_studies/photos/avatars/picard.jpg"
-                style="ImageHeader__Avatar"
-              />
-              <view style="ImageHeader__LeftLabels">
-                <text
-                  href="/case_studies/photos/user.xml"
-                  style="ImageHeader__Username"
-                >
-                  jean.luc.p
-                </text>
-                <text style="ImageHeader__Location">San Francisco, CA</text>
-              </view>
-            </view>
-            <view style="ImageHeader__Right">
-              <text style="ImageHeader__More">...</text>
-            </view>
-          </section-title>
-          <item key="image2">
-            <image
-              source="/case_studies/photos/photos/dinner.jpeg"
-              style="Image"
-            />
-            <view style="ActionBar">
-              <view style="ActionBar__Left">
-                <select-multiple name="image2-like">
-                  <option
-                    selected="true"
-                    style="ActionBar__Icon ActionBar__Icon--First"
-                    value="like"
-                  >
-                    <image
-                      source="/case_studies/photos/icons/heart2.png"
-                      style="ActionBar__IconImage"
-                    />
-                    <image
-                      source="/case_studies/photos/icons/heart_liked2.png"
-                      style="ActionBar__IconImage--Selected"
-                    />
-                  </option>
-                </select-multiple>
-                <image
-                  source="/case_studies/photos/icons/chat2.png"
-                  style="ActionBar__Icon"
-                />
-              </view>
-              <view style="ActionBar__Right" />
-            </view>
-            <text style="Caption">Hottest rez in town, cheers!</text>
-            <view style="Comments">
-              <text style="Comments__Likes">8 likes</text>
-              <text style="Comments__More">View all 140 comments</text>
-              <view style="Comment">
-                <text
-                  href="/case_studies/photos/user.xml"
-                  style="Comment__Author"
-                >
-                  og_worf
-                </text>
-                <text style="Comment__Content">hello!</text>
-              </view>
-              <view style="Comment">
-                <text
-                  href="/case_studies/photos/user.xml"
-                  style="Comment__Author"
-                >
-                  riker007
-                </text>
-                <text style="Comment__Content">hello!</text>
-              </view>
-              <view style="Comment">
-                <text
-                  href="/case_studies/photos/user.xml"
-                  style="Comment__Author"
-                >
-                  jean.luc.p
-                </text>
-                <text style="Comment__Content">hello!</text>
-              </view>
-            </view>
-          </item>
-        </section>
-        <section>
-          <section-title style="ImageHeader">
-            <view style="ImageHeader__Left">
-              <image
-                source="/case_studies/photos/avatars/worf.jpg"
-                style="ImageHeader__Avatar"
-              />
-              <view style="ImageHeader__LeftLabels">
-                <text
-                  href="/case_studies/photos/user.xml"
-                  style="ImageHeader__Username"
-                >
-                  og_worf
-                </text>
-                <text style="ImageHeader__Location">Williamsburg, NY</text>
-              </view>
-            </view>
-            <view style="ImageHeader__Right">
-              <text style="ImageHeader__More">...</text>
-            </view>
-          </section-title>
-          <item key="image3">
-            <image
-              source="/case_studies/photos/photos/inspiration1.jpeg"
-              style="Image"
-            />
-            <view style="ActionBar">
-              <view style="ActionBar__Left">
-                <image
-                  source="/case_studies/photos/icons/heart2.png"
-                  style="ActionBar__Icon ActionBar__Icon--First"
-                />
-                <image
-                  source="/case_studies/photos/icons/chat2.png"
-                  style="ActionBar__Icon"
-                />
-              </view>
-              <view style="ActionBar__Right" />
-            </view>
-            <text style="Caption">
-              True words to live by... living every day to its fullest!!
-            </text>
-            <view style="Comments">
-              <text style="Comments__Likes">7 likes</text>
-              <text style="Comments__More">View all 140 comments</text>
-              <view style="Comment">
-                <text
-                  href="/case_studies/photos/user.xml"
-                  style="Comment__Author"
-                >
-                  og_worf
-                </text>
-                <text style="Comment__Content">hello!</text>
-              </view>
-              <view style="Comment">
-                <text
-                  href="/case_studies/photos/user.xml"
-                  style="Comment__Author"
-                >
-                  riker007
-                </text>
-                <text style="Comment__Content">hello!</text>
-              </view>
-              <view style="Comment">
-                <text
-                  href="/case_studies/photos/user.xml"
-                  style="Comment__Author"
-                >
-                  jean.luc.p
-                </text>
-                <text style="Comment__Content">hello!</text>
-              </view>
-            </view>
-          </item>
-        </section>
-        <section>
-          <section-title style="ImageHeader">
-            <view style="ImageHeader__Left">
+            <view href="/case_studies/photos/user.xml" style="Story">
               <image
                 source="/case_studies/photos/avatars/deanna.png"
-                style="ImageHeader__Avatar"
+                style="Story__Avatar"
               />
-              <view style="ImageHeader__LeftLabels">
-                <text
-                  href="/case_studies/photos/user.xml"
-                  style="ImageHeader__Username"
-                >
-                  deanna.troi
-                </text>
-                <text style="ImageHeader__Location">Portland, WA</text>
-              </view>
+              <text numberOfLines="1" style="Story__Username">
+                deanna.troi
+              </text>
             </view>
-            <view style="ImageHeader__Right">
-              <text style="ImageHeader__More">...</text>
+            <view href="/case_studies/photos/user.xml" style="Story">
+              <image
+                source="/case_studies/photos/avatars/picard.jpg"
+                style="Story__Avatar"
+              />
+              <text numberOfLines="1" style="Story__Username">
+                jean.luc.p
+              </text>
             </view>
-          </section-title>
-          <item key="image4">
+            <view href="/case_studies/photos/user.xml" style="Story">
+              <image
+                source="/case_studies/photos/avatars/worf.jpg"
+                style="Story__Avatar"
+              />
+              <text numberOfLines="1" style="Story__Username">og_worf</text>
+            </view>
+          </view>
+        </item>
+        <!-- Section 2 -->
+        <section-title style="ImageHeader">
+          <view style="ImageHeader__Left">
             <image
-              source="/case_studies/photos/photos/coffee.jpeg"
+              href="/case_studies/photos/index.xml"
+              source="/case_studies/photos/avatars/riker.jpg"
+              style="ImageHeader__Avatar"
+            />
+            <view style="ImageHeader__LeftLabels">
+              <text
+                href="/case_studies/photos/user.xml"
+                style="ImageHeader__Username"
+              >
+                riker007
+              </text>
+              <text style="ImageHeader__Location">Las Vegas, CA</text>
+            </view>
+          </view>
+          <view style="ImageHeader__Right">
+            <text style="ImageHeader__More">...</text>
+          </view>
+        </section-title>
+        <item key="image1">
+          <view style="ImageContainer">
+            <image
+              source="/case_studies/photos/photos/concert.jpeg"
               style="Image"
             />
-            <view style="ActionBar">
-              <view style="ActionBar__Left">
-                <image
-                  source="/case_studies/photos/icons/heart2.png"
+            <view id="image1-overlay" style="ImageContainer__Overlay" />
+          </view>
+          <view style="ActionBar">
+            <view style="ActionBar__Left">
+              <select-multiple name="image1-like">
+                <option
                   style="ActionBar__Icon ActionBar__Icon--First"
-                />
-                <image
-                  source="/case_studies/photos/icons/chat2.png"
-                  style="ActionBar__Icon"
-                />
-              </view>
-              <view style="ActionBar__Right" />
+                  value="like"
+                >
+                  <behavior
+                    action="replace"
+                    href="/case_studies/photos/num_likes_increase.xml"
+                    target="image1-num-likes"
+                    trigger="select"
+                  />
+                  <behavior
+                    action="replace"
+                    href="/case_studies/photos/num_likes_decrease.xml"
+                    target="image1-num-likes"
+                    trigger="deselect"
+                  />
+                  <image
+                    source="/case_studies/photos/icons/heart2.png"
+                    style="ActionBar__IconImage"
+                  />
+                  <image
+                    source="/case_studies/photos/icons/heart_liked2.png"
+                    style="ActionBar__IconImage--Selected"
+                  />
+                </option>
+              </select-multiple>
+              <image
+                source="/case_studies/photos/icons/chat2.png"
+                style="ActionBar__Icon"
+              />
             </view>
-            <text style="Caption">
-              Can't start the day without my 10 artisinal cups of coffee!
+            <view style="ActionBar__Right" />
+          </view>
+          <text style="Caption">Best night of my life!</text>
+          <view style="Comments">
+            <text id="image1-num-likes" style="Comments__Likes">7 likes</text>
+            <text
+              action="prepend"
+              href="/case_studies/photos/more_comments.xml"
+              style="Comments__More"
+              target="comments-image1"
+            >
+              View all 140 comments
             </text>
-            <view style="Comments">
-              <text style="Comments__Likes">7 likes</text>
-              <text style="Comments__More">View all 140 comments</text>
+            <view id="comments-image1">
               <view style="Comment">
                 <text
                   href="/case_studies/photos/user.xml"
@@ -551,7 +314,7 @@
                 >
                   og_worf
                 </text>
-                <text style="Comment__Content">love</text>
+                <text style="Comment__Content">hello!</text>
               </view>
               <view style="Comment">
                 <text
@@ -560,9 +323,7 @@
                 >
                   riker007
                 </text>
-                <text style="Comment__Content">
-                  feeling buzzed just looking at this lol!
-                </text>
+                <text style="Comment__Content">hello!</text>
               </view>
               <view style="Comment">
                 <text
@@ -571,11 +332,245 @@
                 >
                   jean.luc.p
                 </text>
-                <text style="Comment__Content">Engage!</text>
+                <text style="Comment__Content">hello!</text>
               </view>
             </view>
-          </item>
-        </section>
+          </view>
+        </item>
+        <!-- Section 3 -->
+        <section-title style="ImageHeader">
+          <view style="ImageHeader__Left">
+            <image
+              source="/case_studies/photos/avatars/picard.jpg"
+              style="ImageHeader__Avatar"
+            />
+            <view style="ImageHeader__LeftLabels">
+              <text
+                href="/case_studies/photos/user.xml"
+                style="ImageHeader__Username"
+              >
+                jean.luc.p
+              </text>
+              <text style="ImageHeader__Location">San Francisco, CA</text>
+            </view>
+          </view>
+          <view style="ImageHeader__Right">
+            <text style="ImageHeader__More">...</text>
+          </view>
+        </section-title>
+        <item key="image2">
+          <image
+            source="/case_studies/photos/photos/dinner.jpeg"
+            style="Image"
+          />
+          <view style="ActionBar">
+            <view style="ActionBar__Left">
+              <select-multiple name="image2-like">
+                <option
+                  selected="true"
+                  style="ActionBar__Icon ActionBar__Icon--First"
+                  value="like"
+                >
+                  <image
+                    source="/case_studies/photos/icons/heart2.png"
+                    style="ActionBar__IconImage"
+                  />
+                  <image
+                    source="/case_studies/photos/icons/heart_liked2.png"
+                    style="ActionBar__IconImage--Selected"
+                  />
+                </option>
+              </select-multiple>
+              <image
+                source="/case_studies/photos/icons/chat2.png"
+                style="ActionBar__Icon"
+              />
+            </view>
+            <view style="ActionBar__Right" />
+          </view>
+          <text style="Caption">Hottest rez in town, cheers!</text>
+          <view style="Comments">
+            <text style="Comments__Likes">8 likes</text>
+            <text style="Comments__More">View all 140 comments</text>
+            <view style="Comment">
+              <text
+                href="/case_studies/photos/user.xml"
+                style="Comment__Author"
+              >
+                og_worf
+              </text>
+              <text style="Comment__Content">hello!</text>
+            </view>
+            <view style="Comment">
+              <text
+                href="/case_studies/photos/user.xml"
+                style="Comment__Author"
+              >
+                riker007
+              </text>
+              <text style="Comment__Content">hello!</text>
+            </view>
+            <view style="Comment">
+              <text
+                href="/case_studies/photos/user.xml"
+                style="Comment__Author"
+              >
+                jean.luc.p
+              </text>
+              <text style="Comment__Content">hello!</text>
+            </view>
+          </view>
+        </item>
+        <!-- Section 4 -->
+        <section-title style="ImageHeader">
+          <view style="ImageHeader__Left">
+            <image
+              source="/case_studies/photos/avatars/worf.jpg"
+              style="ImageHeader__Avatar"
+            />
+            <view style="ImageHeader__LeftLabels">
+              <text
+                href="/case_studies/photos/user.xml"
+                style="ImageHeader__Username"
+              >
+                og_worf
+              </text>
+              <text style="ImageHeader__Location">Williamsburg, NY</text>
+            </view>
+          </view>
+          <view style="ImageHeader__Right">
+            <text style="ImageHeader__More">...</text>
+          </view>
+        </section-title>
+        <item key="image3">
+          <image
+            source="/case_studies/photos/photos/inspiration1.jpeg"
+            style="Image"
+          />
+          <view style="ActionBar">
+            <view style="ActionBar__Left">
+              <image
+                source="/case_studies/photos/icons/heart2.png"
+                style="ActionBar__Icon ActionBar__Icon--First"
+              />
+              <image
+                source="/case_studies/photos/icons/chat2.png"
+                style="ActionBar__Icon"
+              />
+            </view>
+            <view style="ActionBar__Right" />
+          </view>
+          <text style="Caption">
+            True words to live by... living every day to its fullest!!
+          </text>
+          <view style="Comments">
+            <text style="Comments__Likes">7 likes</text>
+            <text style="Comments__More">View all 140 comments</text>
+            <view style="Comment">
+              <text
+                href="/case_studies/photos/user.xml"
+                style="Comment__Author"
+              >
+                og_worf
+              </text>
+              <text style="Comment__Content">hello!</text>
+            </view>
+            <view style="Comment">
+              <text
+                href="/case_studies/photos/user.xml"
+                style="Comment__Author"
+              >
+                riker007
+              </text>
+              <text style="Comment__Content">hello!</text>
+            </view>
+            <view style="Comment">
+              <text
+                href="/case_studies/photos/user.xml"
+                style="Comment__Author"
+              >
+                jean.luc.p
+              </text>
+              <text style="Comment__Content">hello!</text>
+            </view>
+          </view>
+        </item>
+        <!-- Section 5 -->
+        <section-title style="ImageHeader">
+          <view style="ImageHeader__Left">
+            <image
+              source="/case_studies/photos/avatars/deanna.png"
+              style="ImageHeader__Avatar"
+            />
+            <view style="ImageHeader__LeftLabels">
+              <text
+                href="/case_studies/photos/user.xml"
+                style="ImageHeader__Username"
+              >
+                deanna.troi
+              </text>
+              <text style="ImageHeader__Location">Portland, WA</text>
+            </view>
+          </view>
+          <view style="ImageHeader__Right">
+            <text style="ImageHeader__More">...</text>
+          </view>
+        </section-title>
+        <item key="image4">
+          <image
+            source="/case_studies/photos/photos/coffee.jpeg"
+            style="Image"
+          />
+          <view style="ActionBar">
+            <view style="ActionBar__Left">
+              <image
+                source="/case_studies/photos/icons/heart2.png"
+                style="ActionBar__Icon ActionBar__Icon--First"
+              />
+              <image
+                source="/case_studies/photos/icons/chat2.png"
+                style="ActionBar__Icon"
+              />
+            </view>
+            <view style="ActionBar__Right" />
+          </view>
+          <text style="Caption">
+            Can't start the day without my 10 artisinal cups of coffee!
+          </text>
+          <view style="Comments">
+            <text style="Comments__Likes">7 likes</text>
+            <text style="Comments__More">View all 140 comments</text>
+            <view style="Comment">
+              <text
+                href="/case_studies/photos/user.xml"
+                style="Comment__Author"
+              >
+                og_worf
+              </text>
+              <text style="Comment__Content">love</text>
+            </view>
+            <view style="Comment">
+              <text
+                href="/case_studies/photos/user.xml"
+                style="Comment__Author"
+              >
+                riker007
+              </text>
+              <text style="Comment__Content">
+                feeling buzzed just looking at this lol!
+              </text>
+            </view>
+            <view style="Comment">
+              <text
+                href="/case_studies/photos/user.xml"
+                style="Comment__Author"
+              >
+                jean.luc.p
+              </text>
+              <text style="Comment__Content">Engage!</text>
+            </view>
+          </view>
+        </item>
       </section-list>
     </body>
   </screen>

--- a/examples/ui_elements/list/index.xml
+++ b/examples/ui_elements/list/index.xml
@@ -63,7 +63,7 @@
         </item>
         <item
           href="/ui_elements/list/horizontal.xml"
-          key="basic"
+          key="horizontal"
           show-during-load="loadingScreen"
           style="Item"
         >

--- a/examples/ui_elements/sectionlist/_deprecated_scroll_page2.xml
+++ b/examples/ui_elements/sectionlist/_deprecated_scroll_page2.xml
@@ -1,0 +1,21 @@
+<!-- 'section' can be replaced with 'items' -->
+<section xmlns="https://hyperview.org/hyperview">
+  <section-title style="List__Header">
+    <text style="List__HeaderText">Added: Section 2</text>
+  </section-title>
+  <item key="21" style="Item">
+    <text style="Item__Label">Added: List 21</text>
+  </item>
+  <item key="22" style="Item">
+    <text style="Item__Label">Added: List 22</text>
+  </item>
+  <item key="23" style="Item">
+    <text style="Item__Label">Added: List 23</text>
+  </item>
+  <item key="24" style="Item">
+    <text style="Item__Label">Added: List 24</text>
+  </item>
+  <item key="25" style="Item">
+    <text style="Item__Label">Added: List 25</text>
+  </item>
+</section>

--- a/examples/ui_elements/sectionlist/_infinite_scroll_append_page2.xml
+++ b/examples/ui_elements/sectionlist/_infinite_scroll_append_page2.xml
@@ -1,6 +1,6 @@
 <items xmlns="https://hyperview.org/hyperview">
   <item key="21" style="Item">
-    <text style="Item__Label">List 21 (appended)</text>
+    <text style="Item__Label">Added: List 21</text>
   </item>
   <section-title style="List__Header">
     <text style="List__HeaderText">Added: Section 5</text>
@@ -16,8 +16,5 @@
   </item>
   <item key="25" style="Item">
     <text style="Item__Label">Added: List 25</text>
-  </item>
-  <item key="26" style="Item">
-    <text style="Item__Label">Added: List 26</text>
   </item>
 </items>

--- a/examples/ui_elements/sectionlist/_infinite_scroll_page2.xml
+++ b/examples/ui_elements/sectionlist/_infinite_scroll_page2.xml
@@ -2,19 +2,19 @@
   <section-title style="List__Header">
     <text style="List__HeaderText">Added: Section 5</text>
   </section-title>
-  <item key="16" style="Item">
+  <item key="21" style="Item">
     <text style="Item__Label">Added: List 21</text>
   </item>
-  <item key="17" style="Item">
+  <item key="22" style="Item">
     <text style="Item__Label">Added: List 22</text>
   </item>
-  <item key="18" style="Item">
+  <item key="23" style="Item">
     <text style="Item__Label">Added: List 23</text>
   </item>
-  <item key="19" style="Item">
+  <item key="24" style="Item">
     <text style="Item__Label">Added: List 24</text>
   </item>
-  <item key="20" style="Item">
+  <item key="25" style="Item">
     <text style="Item__Label">Added: List 25</text>
   </item>
 </section>

--- a/examples/ui_elements/sectionlist/_refresh_load.xml
+++ b/examples/ui_elements/sectionlist/_refresh_load.xml
@@ -5,38 +5,36 @@
   trigger="refresh"
   xmlns="https://hyperview.org/hyperview"
 >
-  <section>
-    <section-title style="List__Header">
-      <text style="List__HeaderText">Section 1</text>
-    </section-title>
-    <item key="1" style="Item">
-      <text style="Item__Label">List 1</text>
-    </item>
-    <item key="2" style="Item">
-      <text style="Item__Label Item__Label--Special">List 2 Changed!</text>
-    </item>
-    <item key="3" style="Item">
-      <text style="Item__Label">List 3</text>
-    </item>
-    <item key="4" style="Item">
-      <text style="Item__Label">List 4</text>
-    </item>
-    <item key="5" style="Item">
-      <text style="Item__Label Item__Label--Special">List 5 Added!</text>
-    </item>
-  </section>
-  <section>
-    <section-title style="List__Header">
-      <text style="List__HeaderText">Section 2 Added!</text>
-    </section-title>
-    <item key="6" style="Item">
-      <text style="Item__Label">List 6 Added!</text>
-    </item>
-    <item key="7" style="Item">
-      <text style="Item__Label Item__Label--Special">List 7 Added!</text>
-    </item>
-    <item key="8" style="Item">
-      <text style="Item__Label Item__Label--Special">List 8 Added!</text>
-    </item>
-  </section>
+  <!-- Section 1 -->
+  <section-title style="List__Header">
+    <text style="List__HeaderText">Section 1</text>
+  </section-title>
+  <item key="1" style="Item">
+    <text style="Item__Label">List 1</text>
+  </item>
+  <item key="2" style="Item">
+    <text style="Item__Label Item__Label--Special">List 2 Changed!</text>
+  </item>
+  <item key="3" style="Item">
+    <text style="Item__Label">List 3</text>
+  </item>
+  <item key="4" style="Item">
+    <text style="Item__Label">List 4</text>
+  </item>
+  <item key="5" style="Item">
+    <text style="Item__Label Item__Label--Special">List 5 Added!</text>
+  </item>
+  <!-- Section 2 -->
+  <section-title style="List__Header">
+    <text style="List__HeaderText">Section 2 Added!</text>
+  </section-title>
+  <item key="6" style="Item">
+    <text style="Item__Label">List 6 Added!</text>
+  </item>
+  <item key="7" style="Item">
+    <text style="Item__Label Item__Label--Special">List 7 Added!</text>
+  </item>
+  <item key="8" style="Item">
+    <text style="Item__Label Item__Label--Special">List 8 Added!</text>
+  </item>
 </section-list>

--- a/examples/ui_elements/sectionlist/_refresh_load2.xml
+++ b/examples/ui_elements/sectionlist/_refresh_load2.xml
@@ -5,44 +5,42 @@
   trigger="refresh"
   xmlns="https://hyperview.org/hyperview"
 >
-  <section>
-    <section-title style="List__Header">
-      <text style="List__HeaderText">Section 1</text>
-    </section-title>
-    <item key="1" style="Item">
-      <text style="Item__Label">List 1</text>
-    </item>
-    <item key="2" style="Item">
-      <text style="Item__Label">List 2 Changed!</text>
-    </item>
-    <item key="3" style="Item">
-      <text style="Item__Label">List 3</text>
-    </item>
-    <item key="4" style="Item">
-      <text style="Item__Label">List 4</text>
-    </item>
-    <item key="5" style="Item">
-      <text style="Item__Label">List 5 Added!</text>
-    </item>
-  </section>
-  <section>
-    <section-title style="List__Header">
-      <text style="List__HeaderText">Section 2</text>
-    </section-title>
-    <item key="6" style="Item">
-      <text style="Item__Label">List 6</text>
-    </item>
-    <item key="7" style="Item">
-      <text style="Item__Label">List 7</text>
-    </item>
-    <item key="8" style="Item">
-      <text style="Item__Label">List 8</text>
-    </item>
-    <item key="9" style="Item">
-      <text style="Item__Label">List 9</text>
-    </item>
-    <item key="10" style="Item">
-      <text style="Item__Label">List 10</text>
-    </item>
-  </section>
+  <!-- Section 1 -->
+  <section-title style="List__Header">
+    <text style="List__HeaderText">Section 1</text>
+  </section-title>
+  <item key="1" style="Item">
+    <text style="Item__Label">List 1</text>
+  </item>
+  <item key="2" style="Item">
+    <text style="Item__Label">List 2 Changed!</text>
+  </item>
+  <item key="3" style="Item">
+    <text style="Item__Label">List 3</text>
+  </item>
+  <item key="4" style="Item">
+    <text style="Item__Label">List 4</text>
+  </item>
+  <item key="5" style="Item">
+    <text style="Item__Label">List 5 Added!</text>
+  </item>
+  <!-- Section 2 -->
+  <section-title style="List__Header">
+    <text style="List__HeaderText">Section 2</text>
+  </section-title>
+  <item key="6" style="Item">
+    <text style="Item__Label">List 6</text>
+  </item>
+  <item key="7" style="Item">
+    <text style="Item__Label">List 7</text>
+  </item>
+  <item key="8" style="Item">
+    <text style="Item__Label">List 8</text>
+  </item>
+  <item key="9" style="Item">
+    <text style="Item__Label">List 9</text>
+  </item>
+  <item key="10" style="Item">
+    <text style="Item__Label">List 10</text>
+  </item>
 </section-list>

--- a/examples/ui_elements/sectionlist/basic.xml
+++ b/examples/ui_elements/sectionlist/basic.xml
@@ -63,86 +63,82 @@
         <text style="Header__Title">Basic Section List</text>
       </header>
       <section-list>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 1</text>
-          </section-title>
-          <item key="1" style="Item">
-            <text style="Item__Label">List 1</text>
-          </item>
-          <item key="2" style="Item">
-            <text style="Item__Label">List 2</text>
-          </item>
-          <item key="3" style="Item">
-            <text style="Item__Label">List 3</text>
-          </item>
-          <item key="4" style="Item">
-            <text style="Item__Label">List 4</text>
-          </item>
-          <item key="5" style="Item">
-            <text style="Item__Label">List 5</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 2</text>
-          </section-title>
-          <item key="6" style="Item">
-            <text style="Item__Label">List 6</text>
-          </item>
-          <item key="7" style="Item">
-            <text style="Item__Label">List 7</text>
-          </item>
-          <item key="8" style="Item">
-            <text style="Item__Label">List 8</text>
-          </item>
-          <item key="9" style="Item">
-            <text style="Item__Label">List 9</text>
-          </item>
-          <item key="10" style="Item">
-            <text style="Item__Label">List 10</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 3</text>
-          </section-title>
-          <item key="11" style="Item">
-            <text style="Item__Label">List 11</text>
-          </item>
-          <item key="12" style="Item">
-            <text style="Item__Label">List 12</text>
-          </item>
-          <item key="13" style="Item">
-            <text style="Item__Label">List 13</text>
-          </item>
-          <item key="14" style="Item">
-            <text style="Item__Label">List 14</text>
-          </item>
-          <item key="15" style="Item">
-            <text style="Item__Label">List 15</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 4</text>
-          </section-title>
-          <item key="16" style="Item">
-            <text style="Item__Label">List 16</text>
-          </item>
-          <item key="17" style="Item">
-            <text style="Item__Label">List 17</text>
-          </item>
-          <item key="18" style="Item">
-            <text style="Item__Label">List 18</text>
-          </item>
-          <item key="19" style="Item">
-            <text style="Item__Label">List 19</text>
-          </item>
-          <item key="20" style="Item">
-            <text style="Item__Label">List 20</text>
-          </item>
-        </section>
+        <!-- Section 1-->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 1</text>
+        </section-title>
+        <item key="1" style="Item">
+          <text style="Item__Label">List 1</text>
+        </item>
+        <item key="2" style="Item">
+          <text style="Item__Label">List 2</text>
+        </item>
+        <item key="3" style="Item">
+          <text style="Item__Label">List 3</text>
+        </item>
+        <item key="4" style="Item">
+          <text style="Item__Label">List 4</text>
+        </item>
+        <item key="5" style="Item">
+          <text style="Item__Label">List 5</text>
+        </item>
+        <!-- Section 2 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 2</text>
+        </section-title>
+        <item key="6" style="Item">
+          <text style="Item__Label">List 6</text>
+        </item>
+        <item key="7" style="Item">
+          <text style="Item__Label">List 7</text>
+        </item>
+        <item key="8" style="Item">
+          <text style="Item__Label">List 8</text>
+        </item>
+        <item key="9" style="Item">
+          <text style="Item__Label">List 9</text>
+        </item>
+        <item key="10" style="Item">
+          <text style="Item__Label">List 10</text>
+        </item>
+        <!-- Section 3 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 3</text>
+        </section-title>
+        <item key="11" style="Item">
+          <text style="Item__Label">List 11</text>
+        </item>
+        <item key="12" style="Item">
+          <text style="Item__Label">List 12</text>
+        </item>
+        <item key="13" style="Item">
+          <text style="Item__Label">List 13</text>
+        </item>
+        <item key="14" style="Item">
+          <text style="Item__Label">List 14</text>
+        </item>
+        <item key="15" style="Item">
+          <text style="Item__Label">List 15</text>
+        </item>
+        <!-- Section 4 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 4</text>
+        </section-title>
+        <item key="16" style="Item">
+          <text style="Item__Label">List 16</text>
+        </item>
+        <item key="17" style="Item">
+          <text style="Item__Label">List 17</text>
+        </item>
+        <item key="18" style="Item">
+          <text style="Item__Label">List 18</text>
+        </item>
+        <item key="19" style="Item">
+          <text style="Item__Label">List 19</text>
+        </item>
+        <item key="20" style="Item">
+          <text style="Item__Label">List 20</text>
+        </item>
       </section-list>
     </body>
   </screen>

--- a/examples/ui_elements/sectionlist/deprecated_sections.xml
+++ b/examples/ui_elements/sectionlist/deprecated_sections.xml
@@ -1,0 +1,115 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style
+        id="Header"
+        alignItems="center"
+        backgroundColor="white"
+        borderBottomColor="#eee"
+        borderBottomWidth="1"
+        flexDirection="row"
+        paddingLeft="24"
+        paddingRight="24"
+        paddingBottom="16"
+      />
+      <style
+        id="Header__Back"
+        color="blue"
+        fontSize="16"
+        fontWeight="600"
+        paddingRight="16"
+      />
+      <style id="Header__Title" color="black" fontSize="24" fontWeight="600" />
+      <style id="Body" backgroundColor="white" flex="1" />
+      <style
+        id="Description"
+        borderColor="red"
+        borderRadius="4"
+        borderWidth="2"
+        fontSize="16"
+        fontWeight="600"
+        margin="24"
+        padding="16"
+      />
+      <style
+        id="List__Header"
+        alignItems="center"
+        backgroundColor="#eee"
+        flex="1"
+        flexDirection="row"
+        height="48"
+        paddingLeft="24"
+        paddingRight="24"
+      />
+      <style id="List__HeaderText" fontSize="18" fontWeight="bold" />
+      <style
+        id="Item"
+        alignItems="center"
+        borderBottomColor="#eee"
+        borderBottomWidth="1"
+        flex="1"
+        flexDirection="row"
+        height="48"
+        justifyContent="space-between"
+        paddingLeft="24"
+        paddingRight="24"
+      />
+      <style id="Item__Label" fontSize="18" fontWeight="normal" />
+      <style id="Item__Chevron" fontSize="18" fontWeight="bold" />
+      <style
+        id="Spinner"
+        flex="1"
+        flexDirection="row"
+        justifyContent="center"
+        padding="24"
+      />
+    </styles>
+    <body style="Body" safe-area="true">
+      <header style="Header">
+        <text action="back" href="#" style="Header__Back">Back</text>
+        <text
+          style="Header__Title"
+        >Section List Infinite Scroll - Deprecated</text>
+      </header>
+      <section-list id="myList">
+        <!-- section element no longer required -->
+        <section>
+          <section-title style="List__Header">
+            <text style="List__HeaderText">Section 1</text>
+          </section-title>
+          <item key="1" style="Item">
+            <text style="Item__Label">List 1</text>
+          </item>
+          <item key="2" style="Item">
+            <text style="Item__Label">List 2</text>
+          </item>
+          <item key="3" style="Item">
+            <text style="Item__Label">List 3</text>
+          </item>
+          <item key="4" style="Item">
+            <text style="Item__Label">List 4</text>
+          </item>
+          <item key="5" style="Item">
+            <text style="Item__Label">List 5</text>
+          </item>
+          <item
+            action="append"
+            delay="1000"
+            href="/ui_elements/sectionlist/_deprecated_scroll_page2.xml"
+            key="20"
+            once="true"
+            show-during-load="myIndicator"
+            style="Item"
+            target="myList"
+            trigger="visible"
+          >
+            <text style="Item__Label">List 20</text>
+          </item>
+        </section>
+      </section-list>
+      <view id="myIndicator" hide="true" style="Spinner">
+        <spinner />
+      </view>
+    </body>
+  </screen>
+</doc>

--- a/examples/ui_elements/sectionlist/deprecated_sections.xml
+++ b/examples/ui_elements/sectionlist/deprecated_sections.xml
@@ -67,9 +67,7 @@
     <body style="Body" safe-area="true">
       <header style="Header">
         <text action="back" href="#" style="Header__Back">Back</text>
-        <text
-          style="Header__Title"
-        >Section List Infinite Scroll - Deprecated</text>
+        <text style="Header__Title">Deprecated sections</text>
       </header>
       <section-list id="myList">
         <!-- section element no longer required -->

--- a/examples/ui_elements/sectionlist/index.xml
+++ b/examples/ui_elements/sectionlist/index.xml
@@ -88,6 +88,15 @@
           <text style="Item__Label">Section List With Non-Sticky Titles</text>
           <text style="Item__Chevron">&gt;</text>
         </item>
+        <item
+          href="/ui_elements/sectionlist/deprecated_sections.xml"
+          key="deprecated-sections"
+          show-during-load="loadingScreen"
+          style="Item"
+        >
+          <text style="Item__Label">Section List With Deprecated Sections</text>
+          <text style="Item__Chevron">&gt;</text>
+        </item>
       </list>
     </body>
   </screen>

--- a/examples/ui_elements/sectionlist/index.xml
+++ b/examples/ui_elements/sectionlist/index.xml
@@ -81,7 +81,7 @@
         </item>
         <item
           href="/ui_elements/sectionlist/non_sticky_titles.xml"
-          key="basic"
+          key="non-sticky-titles"
           show-during-load="loadingScreen"
           style="Item"
         >

--- a/examples/ui_elements/sectionlist/infinite_scroll.xml
+++ b/examples/ui_elements/sectionlist/infinite_scroll.xml
@@ -70,96 +70,92 @@
         <text style="Header__Title">Section List Infinite Scroll</text>
       </header>
       <section-list id="myList">
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 1</text>
-          </section-title>
-          <item key="1" style="Item">
-            <text style="Item__Label">List 1</text>
-          </item>
-          <item key="2" style="Item">
-            <text style="Item__Label">List 2</text>
-          </item>
-          <item key="3" style="Item">
-            <text style="Item__Label">List 3</text>
-          </item>
-          <item key="4" style="Item">
-            <text style="Item__Label">List 4</text>
-          </item>
-          <item key="5" style="Item">
-            <text style="Item__Label">List 5</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 2</text>
-          </section-title>
-          <item key="6" style="Item">
-            <text style="Item__Label">List 6</text>
-          </item>
-          <item key="7" style="Item">
-            <text style="Item__Label">List 7</text>
-          </item>
-          <item key="8" style="Item">
-            <text style="Item__Label">List 8</text>
-          </item>
-          <item key="9" style="Item">
-            <text style="Item__Label">List 9</text>
-          </item>
-          <item key="10" style="Item">
-            <text style="Item__Label">List 10</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 3</text>
-          </section-title>
-          <item key="11" style="Item">
-            <text style="Item__Label">List 11</text>
-          </item>
-          <item key="12" style="Item">
-            <text style="Item__Label">List 12</text>
-          </item>
-          <item key="13" style="Item">
-            <text style="Item__Label">List 13</text>
-          </item>
-          <item key="14" style="Item">
-            <text style="Item__Label">List 14</text>
-          </item>
-          <item key="15" style="Item">
-            <text style="Item__Label">List 15</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 4</text>
-          </section-title>
-          <item key="16" style="Item">
-            <text style="Item__Label">List 16</text>
-          </item>
-          <item key="17" style="Item">
-            <text style="Item__Label">List 17</text>
-          </item>
-          <item key="18" style="Item">
-            <text style="Item__Label">List 18</text>
-          </item>
-          <item key="19" style="Item">
-            <text style="Item__Label">List 19</text>
-          </item>
-          <item
-            action="append"
-            delay="1000"
-            href="/ui_elements/sectionlist/_infinite_scroll_page2.xml"
-            key="20"
-            once="true"
-            show-during-load="myIndicator"
-            style="Item"
-            target="myList"
-            trigger="visible"
-          >
-            <text style="Item__Label">List 20</text>
-          </item>
-        </section>
+        <!-- Section 1-->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 1</text>
+        </section-title>
+        <item key="1" style="Item">
+          <text style="Item__Label">List 1</text>
+        </item>
+        <item key="2" style="Item">
+          <text style="Item__Label">List 2</text>
+        </item>
+        <item key="3" style="Item">
+          <text style="Item__Label">List 3</text>
+        </item>
+        <item key="4" style="Item">
+          <text style="Item__Label">List 4</text>
+        </item>
+        <item key="5" style="Item">
+          <text style="Item__Label">List 5</text>
+        </item>
+        <!-- Section 2 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 2</text>
+        </section-title>
+        <item key="6" style="Item">
+          <text style="Item__Label">List 6</text>
+        </item>
+        <item key="7" style="Item">
+          <text style="Item__Label">List 7</text>
+        </item>
+        <item key="8" style="Item">
+          <text style="Item__Label">List 8</text>
+        </item>
+        <item key="9" style="Item">
+          <text style="Item__Label">List 9</text>
+        </item>
+        <item key="10" style="Item">
+          <text style="Item__Label">List 10</text>
+        </item>
+        <!-- Section 2 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 3</text>
+        </section-title>
+        <item key="11" style="Item">
+          <text style="Item__Label">List 11</text>
+        </item>
+        <item key="12" style="Item">
+          <text style="Item__Label">List 12</text>
+        </item>
+        <item key="13" style="Item">
+          <text style="Item__Label">List 13</text>
+        </item>
+        <item key="14" style="Item">
+          <text style="Item__Label">List 14</text>
+        </item>
+        <item key="15" style="Item">
+          <text style="Item__Label">List 15</text>
+        </item>
+        <!-- Section 3 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 4</text>
+        </section-title>
+        <item key="16" style="Item">
+          <text style="Item__Label">List 16</text>
+        </item>
+        <item key="17" style="Item">
+          <text style="Item__Label">List 17</text>
+        </item>
+        <item key="18" style="Item">
+          <text style="Item__Label">List 18</text>
+        </item>
+        <item key="19" style="Item">
+          <text style="Item__Label">List 19</text>
+        </item>
+        <item
+          action="append"
+          delay="1000"
+          href="/ui_elements/sectionlist/_infinite_scroll_page2.xml"
+          key="20"
+          once="true"
+          show-during-load="myIndicator"
+          style="Item"
+          target="myList"
+          trigger="visible"
+        >
+          <text style="Item__Label">List 20</text>
+        </item>
       </section-list>
       <view id="myIndicator" hide="true" style="Spinner">
         <spinner />

--- a/examples/ui_elements/sectionlist/non_sticky_titles.xml
+++ b/examples/ui_elements/sectionlist/non_sticky_titles.xml
@@ -63,86 +63,82 @@
         <text style="Header__Title">Non-Sticky Titles</text>
       </header>
       <section-list sticky-section-titles="false">
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 1</text>
-          </section-title>
-          <item key="1" style="Item">
-            <text style="Item__Label">List 1</text>
-          </item>
-          <item key="2" style="Item">
-            <text style="Item__Label">List 2</text>
-          </item>
-          <item key="3" style="Item">
-            <text style="Item__Label">List 3</text>
-          </item>
-          <item key="4" style="Item">
-            <text style="Item__Label">List 4</text>
-          </item>
-          <item key="5" style="Item">
-            <text style="Item__Label">List 5</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 2</text>
-          </section-title>
-          <item key="6" style="Item">
-            <text style="Item__Label">List 6</text>
-          </item>
-          <item key="7" style="Item">
-            <text style="Item__Label">List 7</text>
-          </item>
-          <item key="8" style="Item">
-            <text style="Item__Label">List 8</text>
-          </item>
-          <item key="9" style="Item">
-            <text style="Item__Label">List 9</text>
-          </item>
-          <item key="10" style="Item">
-            <text style="Item__Label">List 10</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 3</text>
-          </section-title>
-          <item key="11" style="Item">
-            <text style="Item__Label">List 11</text>
-          </item>
-          <item key="12" style="Item">
-            <text style="Item__Label">List 12</text>
-          </item>
-          <item key="13" style="Item">
-            <text style="Item__Label">List 13</text>
-          </item>
-          <item key="14" style="Item">
-            <text style="Item__Label">List 14</text>
-          </item>
-          <item key="15" style="Item">
-            <text style="Item__Label">List 15</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 4</text>
-          </section-title>
-          <item key="16" style="Item">
-            <text style="Item__Label">List 16</text>
-          </item>
-          <item key="17" style="Item">
-            <text style="Item__Label">List 17</text>
-          </item>
-          <item key="18" style="Item">
-            <text style="Item__Label">List 18</text>
-          </item>
-          <item key="19" style="Item">
-            <text style="Item__Label">List 19</text>
-          </item>
-          <item key="20" style="Item">
-            <text style="Item__Label">List 20</text>
-          </item>
-        </section>
+        <!-- Section 1 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 1</text>
+        </section-title>
+        <item key="1" style="Item">
+          <text style="Item__Label">List 1</text>
+        </item>
+        <item key="2" style="Item">
+          <text style="Item__Label">List 2</text>
+        </item>
+        <item key="3" style="Item">
+          <text style="Item__Label">List 3</text>
+        </item>
+        <item key="4" style="Item">
+          <text style="Item__Label">List 4</text>
+        </item>
+        <item key="5" style="Item">
+          <text style="Item__Label">List 5</text>
+        </item>
+        <!-- Section 2 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 2</text>
+        </section-title>
+        <item key="6" style="Item">
+          <text style="Item__Label">List 6</text>
+        </item>
+        <item key="7" style="Item">
+          <text style="Item__Label">List 7</text>
+        </item>
+        <item key="8" style="Item">
+          <text style="Item__Label">List 8</text>
+        </item>
+        <item key="9" style="Item">
+          <text style="Item__Label">List 9</text>
+        </item>
+        <item key="10" style="Item">
+          <text style="Item__Label">List 10</text>
+        </item>
+        <!-- Section 3 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 3</text>
+        </section-title>
+        <item key="11" style="Item">
+          <text style="Item__Label">List 11</text>
+        </item>
+        <item key="12" style="Item">
+          <text style="Item__Label">List 12</text>
+        </item>
+        <item key="13" style="Item">
+          <text style="Item__Label">List 13</text>
+        </item>
+        <item key="14" style="Item">
+          <text style="Item__Label">List 14</text>
+        </item>
+        <item key="15" style="Item">
+          <text style="Item__Label">List 15</text>
+        </item>
+        <!-- Section 4 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 4</text>
+        </section-title>
+        <item key="16" style="Item">
+          <text style="Item__Label">List 16</text>
+        </item>
+        <item key="17" style="Item">
+          <text style="Item__Label">List 17</text>
+        </item>
+        <item key="18" style="Item">
+          <text style="Item__Label">List 18</text>
+        </item>
+        <item key="19" style="Item">
+          <text style="Item__Label">List 19</text>
+        </item>
+        <item key="20" style="Item">
+          <text style="Item__Label">List 20</text>
+        </item>
       </section-list>
     </body>
   </screen>

--- a/examples/ui_elements/sectionlist/refresh.xml
+++ b/examples/ui_elements/sectionlist/refresh.xml
@@ -72,20 +72,19 @@
         href="/ui_elements/sectionlist/_refresh_load.xml"
         trigger="refresh"
       >
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 1</text>
-          </section-title>
-          <item key="1" style="Item">
-            <text style="Item__Label">List 1</text>
-          </item>
-          <item key="2" style="Item">
-            <text style="Item__Label">List 2</text>
-          </item>
-          <item key="3" style="Item">
-            <text style="Item__Label">List 3</text>
-          </item>
-        </section>
+        <!-- Section 1-->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 1</text>
+        </section-title>
+        <item key="1" style="Item">
+          <text style="Item__Label">List 1</text>
+        </item>
+        <item key="2" style="Item">
+          <text style="Item__Label">List 2</text>
+        </item>
+        <item key="3" style="Item">
+          <text style="Item__Label">List 3</text>
+        </item>
       </section-list>
     </body>
   </screen>

--- a/examples/ui_elements/web_views/index.xml
+++ b/examples/ui_elements/web_views/index.xml
@@ -81,7 +81,7 @@
         </item>
         <item
           href="/ui_elements/web_views/dispatch_event.xml"
-          key="js"
+          key="dispatch"
           show-during-load="loadingScreen"
           style="Item"
         >

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -855,11 +855,11 @@
   <xs:element name="section">
     <xs:complexType>
       <xs:sequence>
-        <xs:element minOccurs="1" maxOccurs="1" ref="hv:section-title" />
         <xs:choice minOccurs="0" maxOccurs="unbounded">
           <xs:element ref="hv:item" />
+          <xs:element ref="hv:item" />
           <xs:element ref="hv:items" />
-          <xs:element ref="hv:behavior" />
+          <xs:element ref="hv:section-title" />
         </xs:choice>
       </xs:sequence>
       <xs:attribute name="id" type="xs:NCName" />

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -837,6 +837,8 @@
       <xs:sequence>
         <xs:choice minOccurs="0" maxOccurs="unbounded">
           <xs:element ref="hv:section" />
+          <xs:element ref="hv:section-title" />
+          <xs:element ref="hv:item" />
           <xs:element ref="hv:behavior" />
         </xs:choice>
       </xs:sequence>
@@ -880,8 +882,11 @@
   <xs:element name="items">
     <xs:complexType>
       <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:item" />
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="hv:section" />
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="hv:item" />
+          <xs:element ref="hv:section-title" />
+          <xs:element ref="hv:section" />
+        </xs:choice>
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/src/components/hv-section-list/stories/basic.xml
+++ b/src/components/hv-section-list/stories/basic.xml
@@ -69,86 +69,82 @@
         <text style="Header__Title">Basic Section List</text>
       </header>
       <section-list>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 1</text>
-          </section-title>
-          <item key="1" style="Item">
-            <text style="Item__Label">List 1</text>
-          </item>
-          <item key="2" style="Item">
-            <text style="Item__Label">List 2</text>
-          </item>
-          <item key="3" style="Item">
-            <text style="Item__Label">List 3</text>
-          </item>
-          <item key="4" style="Item">
-            <text style="Item__Label">List 4</text>
-          </item>
-          <item key="5" style="Item">
-            <text style="Item__Label">List 5</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 2</text>
-          </section-title>
-          <item key="6" style="Item">
-            <text style="Item__Label">List 6</text>
-          </item>
-          <item key="7" style="Item">
-            <text style="Item__Label">List 7</text>
-          </item>
-          <item key="8" style="Item">
-            <text style="Item__Label">List 8</text>
-          </item>
-          <item key="9" style="Item">
-            <text style="Item__Label">List 9</text>
-          </item>
-          <item key="10" style="Item">
-            <text style="Item__Label">List 10</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 3</text>
-          </section-title>
-          <item key="11" style="Item">
-            <text style="Item__Label">List 11</text>
-          </item>
-          <item key="12" style="Item">
-            <text style="Item__Label">List 12</text>
-          </item>
-          <item key="13" style="Item">
-            <text style="Item__Label">List 13</text>
-          </item>
-          <item key="14" style="Item">
-            <text style="Item__Label">List 14</text>
-          </item>
-          <item key="15" style="Item">
-            <text style="Item__Label">List 15</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 4</text>
-          </section-title>
-          <item key="16" style="Item">
-            <text style="Item__Label">List 16</text>
-          </item>
-          <item key="17" style="Item">
-            <text style="Item__Label">List 17</text>
-          </item>
-          <item key="18" style="Item">
-            <text style="Item__Label">List 18</text>
-          </item>
-          <item key="19" style="Item">
-            <text style="Item__Label">List 19</text>
-          </item>
-          <item key="20" style="Item">
-            <text style="Item__Label">List 20</text>
-          </item>
-        </section>
+        <!-- Section 1 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 1</text>
+        </section-title>
+        <item key="1" style="Item">
+          <text style="Item__Label">List 1</text>
+        </item>
+        <item key="2" style="Item">
+          <text style="Item__Label">List 2</text>
+        </item>
+        <item key="3" style="Item">
+          <text style="Item__Label">List 3</text>
+        </item>
+        <item key="4" style="Item">
+          <text style="Item__Label">List 4</text>
+        </item>
+        <item key="5" style="Item">
+          <text style="Item__Label">List 5</text>
+        </item>
+        <!-- Section 2 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 2</text>
+        </section-title>
+        <item key="6" style="Item">
+          <text style="Item__Label">List 6</text>
+        </item>
+        <item key="7" style="Item">
+          <text style="Item__Label">List 7</text>
+        </item>
+        <item key="8" style="Item">
+          <text style="Item__Label">List 8</text>
+        </item>
+        <item key="9" style="Item">
+          <text style="Item__Label">List 9</text>
+        </item>
+        <item key="10" style="Item">
+          <text style="Item__Label">List 10</text>
+        </item>
+        <!-- Section 3 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 3</text>
+        </section-title>
+        <item key="11" style="Item">
+          <text style="Item__Label">List 11</text>
+        </item>
+        <item key="12" style="Item">
+          <text style="Item__Label">List 12</text>
+        </item>
+        <item key="13" style="Item">
+          <text style="Item__Label">List 13</text>
+        </item>
+        <item key="14" style="Item">
+          <text style="Item__Label">List 14</text>
+        </item>
+        <item key="15" style="Item">
+          <text style="Item__Label">List 15</text>
+        </item>
+        <!-- Section 4 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 4</text>
+        </section-title>
+        <item key="16" style="Item">
+          <text style="Item__Label">List 16</text>
+        </item>
+        <item key="17" style="Item">
+          <text style="Item__Label">List 17</text>
+        </item>
+        <item key="18" style="Item">
+          <text style="Item__Label">List 18</text>
+        </item>
+        <item key="19" style="Item">
+          <text style="Item__Label">List 19</text>
+        </item>
+        <item key="20" style="Item">
+          <text style="Item__Label">List 20</text>
+        </item>
       </section-list>
     </body>
   </screen>

--- a/src/components/hv-section-list/stories/index.js
+++ b/src/components/hv-section-list/stories/index.js
@@ -30,3 +30,11 @@ createStory('infinite_scroll', ({ element, stylesheets }) => (
     stylesheets={stylesheets}
   />
 ));
+createStory('infinite_scroll_append', ({ element, stylesheets }) => (
+  <HvSectionList
+    element={element}
+    onUpdate={action('onUpdate')}
+    options={Helpers.getOptions()}
+    stylesheets={stylesheets}
+  />
+));

--- a/src/components/hv-section-list/stories/infinite_scroll_append.xml
+++ b/src/components/hv-section-list/stories/infinite_scroll_append.xml
@@ -73,7 +73,9 @@
     <body style="Body">
       <header style="Header">
         <text action="back" href="#" style="Header__Back">Back</text>
-        <text style="Header__Title">Section List Infinite Scroll</text>
+        <text
+          style="Header__Title"
+        >Section List Infinite Scroll With Appended Items</text>
       </header>
       <section-list id="myList">
         <!-- Section 1 -->
@@ -152,7 +154,7 @@
         <item
           action="append"
           delay="1000"
-          href="/ui_elements/sectionlist/_infinite_scroll_page2.xml"
+          href="/ui_elements/sectionlist/_infinite_scroll_append_page2.xml"
           key="20"
           once="true"
           show-during-load="myIndicator"

--- a/src/types.js
+++ b/src/types.js
@@ -31,6 +31,7 @@ export const LOCAL_NAME = {
   PICKER_FIELD: 'picker-field',
   PICKER_ITEM: 'picker-item',
   SCREEN: 'screen',
+  SECTION: 'section',
   SECTION_LIST: 'section-list',
   SECTION_TITLE: 'section-title',
   SELECT_MULTIPLE: 'select-multiple',

--- a/storybook/templates.gen.js
+++ b/storybook/templates.gen.js
@@ -931,86 +931,82 @@ export default {
         <text style="Header__Title">Basic Section List</text>
       </header>
       <section-list>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 1</text>
-          </section-title>
-          <item key="1" style="Item">
-            <text style="Item__Label">List 1</text>
-          </item>
-          <item key="2" style="Item">
-            <text style="Item__Label">List 2</text>
-          </item>
-          <item key="3" style="Item">
-            <text style="Item__Label">List 3</text>
-          </item>
-          <item key="4" style="Item">
-            <text style="Item__Label">List 4</text>
-          </item>
-          <item key="5" style="Item">
-            <text style="Item__Label">List 5</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 2</text>
-          </section-title>
-          <item key="6" style="Item">
-            <text style="Item__Label">List 6</text>
-          </item>
-          <item key="7" style="Item">
-            <text style="Item__Label">List 7</text>
-          </item>
-          <item key="8" style="Item">
-            <text style="Item__Label">List 8</text>
-          </item>
-          <item key="9" style="Item">
-            <text style="Item__Label">List 9</text>
-          </item>
-          <item key="10" style="Item">
-            <text style="Item__Label">List 10</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 3</text>
-          </section-title>
-          <item key="11" style="Item">
-            <text style="Item__Label">List 11</text>
-          </item>
-          <item key="12" style="Item">
-            <text style="Item__Label">List 12</text>
-          </item>
-          <item key="13" style="Item">
-            <text style="Item__Label">List 13</text>
-          </item>
-          <item key="14" style="Item">
-            <text style="Item__Label">List 14</text>
-          </item>
-          <item key="15" style="Item">
-            <text style="Item__Label">List 15</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 4</text>
-          </section-title>
-          <item key="16" style="Item">
-            <text style="Item__Label">List 16</text>
-          </item>
-          <item key="17" style="Item">
-            <text style="Item__Label">List 17</text>
-          </item>
-          <item key="18" style="Item">
-            <text style="Item__Label">List 18</text>
-          </item>
-          <item key="19" style="Item">
-            <text style="Item__Label">List 19</text>
-          </item>
-          <item key="20" style="Item">
-            <text style="Item__Label">List 20</text>
-          </item>
-        </section>
+        <!-- Section 1 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 1</text>
+        </section-title>
+        <item key="1" style="Item">
+          <text style="Item__Label">List 1</text>
+        </item>
+        <item key="2" style="Item">
+          <text style="Item__Label">List 2</text>
+        </item>
+        <item key="3" style="Item">
+          <text style="Item__Label">List 3</text>
+        </item>
+        <item key="4" style="Item">
+          <text style="Item__Label">List 4</text>
+        </item>
+        <item key="5" style="Item">
+          <text style="Item__Label">List 5</text>
+        </item>
+        <!-- Section 2 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 2</text>
+        </section-title>
+        <item key="6" style="Item">
+          <text style="Item__Label">List 6</text>
+        </item>
+        <item key="7" style="Item">
+          <text style="Item__Label">List 7</text>
+        </item>
+        <item key="8" style="Item">
+          <text style="Item__Label">List 8</text>
+        </item>
+        <item key="9" style="Item">
+          <text style="Item__Label">List 9</text>
+        </item>
+        <item key="10" style="Item">
+          <text style="Item__Label">List 10</text>
+        </item>
+        <!-- Section 3 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 3</text>
+        </section-title>
+        <item key="11" style="Item">
+          <text style="Item__Label">List 11</text>
+        </item>
+        <item key="12" style="Item">
+          <text style="Item__Label">List 12</text>
+        </item>
+        <item key="13" style="Item">
+          <text style="Item__Label">List 13</text>
+        </item>
+        <item key="14" style="Item">
+          <text style="Item__Label">List 14</text>
+        </item>
+        <item key="15" style="Item">
+          <text style="Item__Label">List 15</text>
+        </item>
+        <!-- Section 4 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 4</text>
+        </section-title>
+        <item key="16" style="Item">
+          <text style="Item__Label">List 16</text>
+        </item>
+        <item key="17" style="Item">
+          <text style="Item__Label">List 17</text>
+        </item>
+        <item key="18" style="Item">
+          <text style="Item__Label">List 18</text>
+        </item>
+        <item key="19" style="Item">
+          <text style="Item__Label">List 19</text>
+        </item>
+        <item key="20" style="Item">
+          <text style="Item__Label">List 20</text>
+        </item>
       </section-list>
     </body>
   </screen>
@@ -1095,96 +1091,267 @@ export default {
         <text style="Header__Title">Section List Infinite Scroll</text>
       </header>
       <section-list id="myList">
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 1</text>
-          </section-title>
-          <item key="1" style="Item">
-            <text style="Item__Label">List 1</text>
-          </item>
-          <item key="2" style="Item">
-            <text style="Item__Label">List 2</text>
-          </item>
-          <item key="3" style="Item">
-            <text style="Item__Label">List 3</text>
-          </item>
-          <item key="4" style="Item">
-            <text style="Item__Label">List 4</text>
-          </item>
-          <item key="5" style="Item">
-            <text style="Item__Label">List 5</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 2</text>
-          </section-title>
-          <item key="6" style="Item">
-            <text style="Item__Label">List 6</text>
-          </item>
-          <item key="7" style="Item">
-            <text style="Item__Label">List 7</text>
-          </item>
-          <item key="8" style="Item">
-            <text style="Item__Label">List 8</text>
-          </item>
-          <item key="9" style="Item">
-            <text style="Item__Label">List 9</text>
-          </item>
-          <item key="10" style="Item">
-            <text style="Item__Label">List 10</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 3</text>
-          </section-title>
-          <item key="11" style="Item">
-            <text style="Item__Label">List 11</text>
-          </item>
-          <item key="12" style="Item">
-            <text style="Item__Label">List 12</text>
-          </item>
-          <item key="13" style="Item">
-            <text style="Item__Label">List 13</text>
-          </item>
-          <item key="14" style="Item">
-            <text style="Item__Label">List 14</text>
-          </item>
-          <item key="15" style="Item">
-            <text style="Item__Label">List 15</text>
-          </item>
-        </section>
-        <section>
-          <section-title style="List__Header">
-            <text style="List__HeaderText">Section 4</text>
-          </section-title>
-          <item key="16" style="Item">
-            <text style="Item__Label">List 16</text>
-          </item>
-          <item key="17" style="Item">
-            <text style="Item__Label">List 17</text>
-          </item>
-          <item key="18" style="Item">
-            <text style="Item__Label">List 18</text>
-          </item>
-          <item key="19" style="Item">
-            <text style="Item__Label">List 19</text>
-          </item>
-          <item
-            action="append"
-            delay="1000"
-            href="/ui_elements/sectionlist/_infinite_scroll_page2.xml"
-            key="20"
-            once="true"
-            show-during-load="myIndicator"
-            style="Item"
-            target="myList"
-            trigger="visible"
-          >
-            <text style="Item__Label">List 20</text>
-          </item>
-        </section>
+        <!-- Section 1 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 1</text>
+        </section-title>
+        <item key="1" style="Item">
+          <text style="Item__Label">List 1</text>
+        </item>
+        <item key="2" style="Item">
+          <text style="Item__Label">List 2</text>
+        </item>
+        <item key="3" style="Item">
+          <text style="Item__Label">List 3</text>
+        </item>
+        <item key="4" style="Item">
+          <text style="Item__Label">List 4</text>
+        </item>
+        <item key="5" style="Item">
+          <text style="Item__Label">List 5</text>
+        </item>
+        <!-- Section 2 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 2</text>
+        </section-title>
+        <item key="6" style="Item">
+          <text style="Item__Label">List 6</text>
+        </item>
+        <item key="7" style="Item">
+          <text style="Item__Label">List 7</text>
+        </item>
+        <item key="8" style="Item">
+          <text style="Item__Label">List 8</text>
+        </item>
+        <item key="9" style="Item">
+          <text style="Item__Label">List 9</text>
+        </item>
+        <item key="10" style="Item">
+          <text style="Item__Label">List 10</text>
+        </item>
+        <!-- Section 3 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 3</text>
+        </section-title>
+        <item key="11" style="Item">
+          <text style="Item__Label">List 11</text>
+        </item>
+        <item key="12" style="Item">
+          <text style="Item__Label">List 12</text>
+        </item>
+        <item key="13" style="Item">
+          <text style="Item__Label">List 13</text>
+        </item>
+        <item key="14" style="Item">
+          <text style="Item__Label">List 14</text>
+        </item>
+        <item key="15" style="Item">
+          <text style="Item__Label">List 15</text>
+        </item>
+        <!-- Section 4 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 4</text>
+        </section-title>
+        <item key="16" style="Item">
+          <text style="Item__Label">List 16</text>
+        </item>
+        <item key="17" style="Item">
+          <text style="Item__Label">List 17</text>
+        </item>
+        <item key="18" style="Item">
+          <text style="Item__Label">List 18</text>
+        </item>
+        <item key="19" style="Item">
+          <text style="Item__Label">List 19</text>
+        </item>
+        <item
+          action="append"
+          delay="1000"
+          href="/ui_elements/sectionlist/_infinite_scroll_page2.xml"
+          key="20"
+          once="true"
+          show-during-load="myIndicator"
+          style="Item"
+          target="myList"
+          trigger="visible"
+        >
+          <text style="Item__Label">List 20</text>
+        </item>
+      </section-list>
+      <view hide="true" id="myIndicator" style="Spinner">
+        <spinner />
+      </view>
+    </body>
+  </screen>
+</doc>
+`,
+  'hyperview/src/components/hv-section-list/stories/infinite_scroll_append.xml':
+  `<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style
+        alignItems="center"
+        backgroundColor="white"
+        borderBottomColor="#eee"
+        borderBottomWidth="1"
+        flexDirection="row"
+        height="72"
+        id="Header"
+        paddingLeft="24"
+        paddingRight="24"
+        paddingTop="24"
+      />
+      <style
+        color="blue"
+        fontFamily="HKGrotesk-SemiBold"
+        fontSize="16"
+        id="Header__Back"
+        paddingRight="16"
+      />
+      <style
+        color="black"
+        fontFamily="HKGrotesk-SemiBold"
+        fontSize="24"
+        id="Header__Title"
+      />
+      <style backgroundColor="white" flex="1" id="Body" />
+      <style
+        borderColor="red"
+        borderRadius="4"
+        borderWidth="2"
+        fontFamily="HKGrotesk-SemiBold"
+        fontSize="16"
+        id="Description"
+        margin="24"
+        padding="16"
+      />
+      <style
+        alignItems="center"
+        backgroundColor="#eee"
+        flex="1"
+        flexDirection="row"
+        height="48"
+        id="List__Header"
+        paddingLeft="24"
+        paddingRight="24"
+      />
+      <style fontFamily="HKGrotesk-Bold" fontSize="18" id="List__HeaderText" />
+      <style
+        alignItems="center"
+        borderBottomColor="#eee"
+        borderBottomWidth="1"
+        flex="1"
+        flexDirection="row"
+        height="48"
+        id="Item"
+        justifyContent="space-between"
+        paddingLeft="24"
+        paddingRight="24"
+      />
+      <style fontFamily="HKGrotesk-Regular" fontSize="18" id="Item__Label" />
+      <style fontFamily="HKGrotesk-Bold" fontSize="18" id="Item__Chevron" />
+      <style
+        flex="1"
+        flexDirection="row"
+        id="Spinner"
+        justifyContent="center"
+        padding="24"
+      />
+    </styles>
+    <body style="Body">
+      <header style="Header">
+        <text action="back" href="#" style="Header__Back">Back</text>
+        <text
+          style="Header__Title"
+        >Section List Infinite Scroll With Appended Items</text>
+      </header>
+      <section-list id="myList">
+        <!-- Section 1 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 1</text>
+        </section-title>
+        <item key="1" style="Item">
+          <text style="Item__Label">List 1</text>
+        </item>
+        <item key="2" style="Item">
+          <text style="Item__Label">List 2</text>
+        </item>
+        <item key="3" style="Item">
+          <text style="Item__Label">List 3</text>
+        </item>
+        <item key="4" style="Item">
+          <text style="Item__Label">List 4</text>
+        </item>
+        <item key="5" style="Item">
+          <text style="Item__Label">List 5</text>
+        </item>
+        <!-- Section 2 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 2</text>
+        </section-title>
+        <item key="6" style="Item">
+          <text style="Item__Label">List 6</text>
+        </item>
+        <item key="7" style="Item">
+          <text style="Item__Label">List 7</text>
+        </item>
+        <item key="8" style="Item">
+          <text style="Item__Label">List 8</text>
+        </item>
+        <item key="9" style="Item">
+          <text style="Item__Label">List 9</text>
+        </item>
+        <item key="10" style="Item">
+          <text style="Item__Label">List 10</text>
+        </item>
+        <!-- Section 3 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 3</text>
+        </section-title>
+        <item key="11" style="Item">
+          <text style="Item__Label">List 11</text>
+        </item>
+        <item key="12" style="Item">
+          <text style="Item__Label">List 12</text>
+        </item>
+        <item key="13" style="Item">
+          <text style="Item__Label">List 13</text>
+        </item>
+        <item key="14" style="Item">
+          <text style="Item__Label">List 14</text>
+        </item>
+        <item key="15" style="Item">
+          <text style="Item__Label">List 15</text>
+        </item>
+        <!-- Section 4 -->
+        <section-title style="List__Header">
+          <text style="List__HeaderText">Section 4</text>
+        </section-title>
+        <item key="16" style="Item">
+          <text style="Item__Label">List 16</text>
+        </item>
+        <item key="17" style="Item">
+          <text style="Item__Label">List 17</text>
+        </item>
+        <item key="18" style="Item">
+          <text style="Item__Label">List 18</text>
+        </item>
+        <item key="19" style="Item">
+          <text style="Item__Label">List 19</text>
+        </item>
+        <item
+          action="append"
+          delay="1000"
+          href="/ui_elements/sectionlist/_infinite_scroll_append_page2.xml"
+          key="20"
+          once="true"
+          show-during-load="myIndicator"
+          style="Item"
+          target="myList"
+          trigger="visible"
+        >
+          <text style="Item__Label">List 20</text>
+        </item>
       </section-list>
       <view hide="true" id="myIndicator" style="Spinner">
         <spinner />


### PR DESCRIPTION
Update section-list to not require grouping via \<section\> children

Added a new 'deprecated' example which displays backwards compatibility for including \<section\> elements within a \<section-list\> and as the top element in a reload/refresh page.

Resolves #294 