### PR TITLE
Removing redundant entry in <section>

### DIFF
--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -857,7 +857,6 @@
       <xs:sequence>
         <xs:choice minOccurs="0" maxOccurs="unbounded">
           <xs:element ref="hv:item" />
-          <xs:element ref="hv:item" />
           <xs:element ref="hv:items" />
           <xs:element ref="hv:section-title" />
         </xs:choice>


### PR DESCRIPTION
Removing the redundant `hv:item` inside `section`