### PR TITLE
feat(section-list): add 'items' to list of 'section-list' child types

### DIFF
--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -840,6 +840,7 @@
           <xs:element ref="hv:section-title" />
           <xs:element ref="hv:item" />
           <xs:element ref="hv:behavior" />
+          <xs:element ref="hv:items" />
         </xs:choice>
       </xs:sequence>
       <xs:attribute name="style" type="hv:styleList" />


### PR DESCRIPTION
`items` is required as an element of `section-list` to allow grouped elements like a loading indicator