### PR TITLE
fix: add 'id' to 'items'

### DIFF
--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -889,6 +889,7 @@
           <xs:element ref="hv:section" />
         </xs:choice>
       </xs:sequence>
+      <xs:attribute name="id" type="hv:ID" />
     </xs:complexType>
   </xs:element>
 


### PR DESCRIPTION
The 'id' attribute is required to allow `items` as an identifiable container element