### PR TITLE
chore: add trigger `load-stale-error` to the schema

### DIFF
--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -33,6 +33,7 @@
       <xs:enumeration value="blur" />
       <xs:enumeration value="on-event" />
       <xs:enumeration value="change" />
+      <xs:enumeration value="load-stale-error" />
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
`load-stale-error` was introduced in this [PR](https://github.com/Instawork/hyperview/pull/504), adding it to the schema as well.