### PR TITLE
feat(items): support nested items

### DIFF
--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -888,6 +888,7 @@
           <xs:element ref="hv:item" />
           <xs:element ref="hv:section-title" />
           <xs:element ref="hv:section" />
+          <xs:element ref="hv:items" />
         </xs:choice>
       </xs:sequence>
       <xs:attribute name="id" type="hv:ID" />


### PR DESCRIPTION
- `items` element must support `items` as a child element to allow fully replacing `section`