### PR TITLE
fix(behavior): respect `once` for custom update

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -289,13 +289,8 @@ export default class HyperScreen extends React.Component {
     return false;
   }
 
-  /**
-   * Sets `ran-once` if applicable.
-   */
-  setOnceIfApplicable = (behaviorElement) => {
-    if (!this.isOncePreviouslyApplied(behaviorElement)) {
-      behaviorElement.setAttribute('ran-once', 'true');
-    }
+  setRanOnce = (behaviorElement) => {
+    behaviorElement.setAttribute('ran-once', 'true');
   }
 
   /**
@@ -371,7 +366,7 @@ export default class HyperScreen extends React.Component {
         return;
       }
 
-      this.setOnceIfApplicable(behaviorElement);
+      this.setRanOnce(behaviorElement);
 
       // Check for event loop formation
       if (trigger === 'on-event') {
@@ -532,7 +527,7 @@ export default class HyperScreen extends React.Component {
       return;
     }
 
-    this.setOnceIfApplicable(behaviorElement);
+    this.setRanOnce(behaviorElement);
 
     if (behavior) {
       const updateRoot = (newRoot, updateStylesheet = false) => updateStylesheet

--- a/src/index.js
+++ b/src/index.js
@@ -278,20 +278,24 @@ export default class HyperScreen extends React.Component {
   }
 
   /**
-   * Checks if `once` is previously applied and sets `ran-once` if required.
+   * Checks if `once` is previously applied.
    */
   isOncePreviouslyApplied = (behaviorElement) => {
     const once = behaviorElement.getAttribute('once');
     const ranOnce = behaviorElement.getAttribute('ran-once');
-
     if (once === 'true' && ranOnce === 'true') {
-      return true;
-    } 
-    if (once === 'true') {
+        return true;
+    }
+    return false;
+  }
+
+  /**
+   * Sets `ran-once` if applicable.
+   */
+  setOnceIfApplicable = (behaviorElement) => {
+    if (!this.isOncePreviouslyApplied(behaviorElement)) {
       behaviorElement.setAttribute('ran-once', 'true');
     }
-
-    return false;
   }
 
   /**
@@ -366,6 +370,8 @@ export default class HyperScreen extends React.Component {
       if (this.isOncePreviouslyApplied(behaviorElement)) {
         return;
       }
+
+      this.setOnceIfApplicable(behaviorElement);
 
       // Check for event loop formation
       if (trigger === 'on-event') {
@@ -525,6 +531,8 @@ export default class HyperScreen extends React.Component {
     if (this.isOncePreviouslyApplied(behaviorElement)) {
       return;
     }
+
+    this.setOnceIfApplicable(behaviorElement);
 
     if (behavior) {
       const updateRoot = (newRoot, updateStylesheet = false) => updateStylesheet

--- a/src/index.js
+++ b/src/index.js
@@ -286,7 +286,8 @@ export default class HyperScreen extends React.Component {
 
     if (once === 'true' && ranOnce === 'true') {
       return true;
-    } else if (once === 'true') {
+    } 
+    if (once === 'true') {
       behaviorElement.setAttribute('ran-once', 'true');
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -278,6 +278,22 @@ export default class HyperScreen extends React.Component {
   }
 
   /**
+   * Checks if `once` is previously applied and sets `ran-once` if required.
+   */
+  isOncePreviouslyApplied = (behaviorElement) => {
+    const once = behaviorElement.getAttribute('once');
+    const ranOnce = behaviorElement.getAttribute('ran-once');
+
+    if (once === 'true' && ranOnce === 'true') {
+      return true;
+    } else if (once === 'true') {
+      behaviorElement.setAttribute('ran-once', 'true');
+    }
+
+    return false;
+  }
+
+  /**
    * Returns a navigation object similar to the one provided by React Navigation,
    * but connected to props injected by the parent app.
    */
@@ -344,14 +360,10 @@ export default class HyperScreen extends React.Component {
       const { behaviorElement } = opts;
       const eventName = behaviorElement.getAttribute('event-name');
       const trigger = behaviorElement.getAttribute('trigger');
-      const ranOnce = behaviorElement.getAttribute('ran-once');
-      const once = behaviorElement.getAttribute('once');
       const delay = behaviorElement.getAttribute('delay');
 
-      if (once === 'true' && ranOnce === 'true') {
+      if (this.isOncePreviouslyApplied(behaviorElement)) {
         return;
-      } if (once === 'true') {
-        behaviorElement.setAttribute('ran-once', 'true');
       }
 
       // Check for event loop formation
@@ -508,6 +520,11 @@ export default class HyperScreen extends React.Component {
   onCustomUpdate = (behaviorElement) => {
     const action = behaviorElement.getAttribute('action');
     const behavior = this.behaviorRegistry[action];
+
+    if (this.isOncePreviouslyApplied(behaviorElement)) {
+      return;
+    }
+
     if (behavior) {
       const updateRoot = (newRoot, updateStylesheet = false) => updateStylesheet
         ? this.setState({ doc: newRoot, styles: Stylesheets.createStylesheets(newRoot) })


### PR DESCRIPTION
Currently `once` is only respected for [update actions](https://github.com/Instawork/hyperview/blob/master/src/types.js#L390). All the other actions such as `load`, `load-stale-error` etc. ignore `once`.
This causes an infinite render of `HyperScreen` and thereby causing a crash in some situations. The same is true with custom behaviors (https://github.com/Instawork/hyperview/issues/290).

| Before | After |
| --- | --- |
| <video src="https://user-images.githubusercontent.com/28518512/235128036-23e453ad-79e4-4c44-9b02-2e19910552fc.mp4" /> | <video src="https://user-images.githubusercontent.com/28518512/235133854-4cc711f3-ff0d-4255-90de-60085085e493.mp4" /> |