### PR TITLE
chore: update schema to add new attributes to option and text-field elements

### DIFF
--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -1062,6 +1062,7 @@
       <xs:attribute name="type" type="xs:string" />
       <xs:attributeGroup ref="hv:behaviorAttributes" />
       <xs:attribute name="text-content-type" type="hv:text-content-type" />
+      <xs:attribute name="change" type="xs:string" />
     </xs:complexType>
   </xs:element>
 
@@ -1115,6 +1116,8 @@
       <xs:attribute name="style" type="hv:styleList" />
       <xs:attribute name="selected" type="xs:boolean" />
       <xs:attribute name="value" type="xs:string" />
+      <xs:attribute name="select" type="xs:string" />
+      <xs:attribute name="deselect" type="xs:string" />
     </xs:complexType>
   </xs:element>
 


### PR DESCRIPTION
Adding 3 new attributes for adding strings that are going to be use to hold event names for later usage:

option:
 - select
 - deselect
 
 text-field:
 - change
 
 ## use case example using `django`:
 
 the attribute is taken from the widget attribute list, then the attribute value is going to be injected in the context to be use as an event-name attribute in a behavior.
 
 ```python
 def get_attr(attr_name: str):
     if attr_name not in context["widget"]["attrs"]:
         return None
     return context["widget"]["attrs"][attr_name]

 context["change_event"] = get_attr("change")
 ```
 
 ```xml
 <text-field>
  {% if change_event %}
    <behavior delay="0" trigger="change" action="dispatch-event" event-name="{{ change_event }}" />
  {% endif %}
</text-field>
```