### PR TITLE
feat(error): add back button on error

### DIFF
--- a/src/core/components/load-error/index.js
+++ b/src/core/components/load-error/index.js
@@ -53,6 +53,9 @@ export default class LoadError extends PureComponent<Props> {
         <TouchableOpacity onPress={this.props.onPressReload}>
           <Text style={styles.button}>Reload</Text>
         </TouchableOpacity>
+        <TouchableOpacity onPress={this.props.back}>
+          <Text style={styles.button}>Back</Text>
+        </TouchableOpacity>
       </View>
     );
   };

--- a/src/core/components/load-error/types.js
+++ b/src/core/components/load-error/types.js
@@ -9,6 +9,7 @@
  */
 
 export type Props = {|
+  back: () => void,
   error: ?Error,
   onPressReload: () => void,
   onPressViewDetails: (uri: string) => void,

--- a/src/index.js
+++ b/src/index.js
@@ -245,6 +245,7 @@ export default class HyperScreen extends React.Component {
     if (this.state.error) {
       const errorScreen = this.props.errorScreen || LoadError;
       return React.createElement(errorScreen, {
+        back: () => this.getNavigation().back(),
         error: this.state.error,
         onPressReload: () => this.reload(),  // Make sure reload() is called without any args
         onPressViewDetails: (uri) => this.props.openModal({ url: uri }),


### PR DESCRIPTION
Add back button on full page error so that the user is not stuck on the error screen in case they open a modal. This will be useful when offline mode is enabled.