### PR TITLE
fix: `flex-basis` style

### DIFF
--- a/docs/reference_style.md
+++ b/docs/reference_style.md
@@ -240,9 +240,9 @@ flexGrow, flexShrink, and flexBasis work the same as in CSS.
 
 #### `flexBasis`
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type           | Required |
+| -------------- | -------- |
+| number, string | No       |
 
 #### `flexDirection`
 

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -278,7 +278,7 @@
     </xs:union>
   </xs:simpleType>
 
-  <xs:simpleType name="margin">
+  <xs:simpleType name="sizing">
     <xs:union>
       <xs:simpleType>
         <xs:restriction base="xs:integer" />
@@ -572,6 +572,8 @@
         </xs:simpleType>
       </xs:attribute>
 
+      <xs:attribute name="flexBasis" type="hv:sizing" />
+
       <xs:attribute name="flexDirection">
         <xs:simpleType>
           <xs:restriction base="xs:string">
@@ -644,13 +646,13 @@
 
       <xs:attribute name="left" type="hv:pointsOrPercent" />
       <xs:attribute name="lineHeight" type="xs:integer" />
-      <xs:attribute name="margin" type="hv:margin" />
-      <xs:attribute name="marginBottom" type="hv:margin" />
-      <xs:attribute name="marginHorizontal" type="hv:margin" />
-      <xs:attribute name="marginLeft" type="hv:margin" />
-      <xs:attribute name="marginRight" type="hv:margin" />
-      <xs:attribute name="marginTop" type="hv:margin" />
-      <xs:attribute name="marginVertical" type="hv:margin" />
+      <xs:attribute name="margin" type="hv:sizing" />
+      <xs:attribute name="marginBottom" type="hv:sizing" />
+      <xs:attribute name="marginHorizontal" type="hv:sizing" />
+      <xs:attribute name="marginLeft" type="hv:sizing" />
+      <xs:attribute name="marginRight" type="hv:sizing" />
+      <xs:attribute name="marginTop" type="hv:sizing" />
+      <xs:attribute name="marginVertical" type="hv:sizing" />
       <xs:attribute name="maxHeight" type="hv:pointsOrPercent" />
       <xs:attribute name="maxWidth" type="hv:pointsOrPercent" />
       <xs:attribute name="minHeight" type="hv:pointsOrPercent" />

--- a/src/services/stylesheets/index.js
+++ b/src/services/stylesheets/index.js
@@ -82,7 +82,7 @@ const STYLE_ATTRIBUTE_CONVERTERS = {
   display: string,
   elevation: number,
   flex: number,
-  flexBasis: number,
+  flexBasis: numberOrString,
   flexDirection: string,
   flexGrow: number,
   flexShrink: number,


### PR DESCRIPTION
Allow `flex-basis` to be a string or number (previously only number). This allows setting the underlying RN style attribute to `auto`. Also update the schema to make a comparable style type reusable (`margin` becomes `sizing`)