### PR TITLE
fix(fetch-element): Don't update the state when fetch fails

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -447,6 +447,10 @@ export default class HyperScreen extends React.Component {
     // Fetch the resource, then perform the action on the target and undo indicators.
     const fetchAndUpdate = () => this.fetchElement(href, verb, newRoot, formData)
       .then((newElement) => {
+        // If the fetch failed, don't update the doc state.
+        if (!newElement) {
+          return;
+        }
         // If a target is specified and exists, use it. Otherwise, the action target defaults
         // to the element triggering the action.
         let targetElement = targetId ? this.doc.getElementById(targetId) : currentElement;
@@ -454,9 +458,7 @@ export default class HyperScreen extends React.Component {
           targetElement = currentElement;
         }
 
-        if (newElement) {
-          newRoot = Behaviors.performUpdate(action, targetElement, newElement);
-        }
+        newRoot = Behaviors.performUpdate(action, targetElement, newElement);
         newRoot = Behaviors.setIndicatorsAfterLoad(showIndicatorIdList, hideIndicatorIdList, newRoot);
         // Re-render the modifications
         this.setState({


### PR DESCRIPTION
When fetching a partial fails then don't update the state with new doc.

### Videos
| Before | After |
| --- | --- |
| <video src="https://github.com/Instawork/hyperview/assets/28518512/8c885640-2c7c-4741-ab9f-7fcbce12cf91" /> | <video src="https://github.com/Instawork/hyperview/assets/28518512/47ee48c5-590f-4746-bb66-0386c062a71a" /> |