### PR TITLE
fix(hv-view): remove attributes caching

### DIFF
--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -47,31 +47,16 @@ export default class HvView extends PureComponent<HvComponentProps> {
 
   props: HvComponentProps;
 
-  attributes: Attributes;
-
-  constructor(props: HvComponentProps) {
-    super(props);
-    this.updateAttributes();
-  }
-
-  componentDidUpdate(prevProps: HvComponentProps) {
-    if (prevProps.element === this.props.element) {
-      return;
-    }
-
-    this.updateAttributes();
-  }
-
-  updateAttributes = () => {
+  get attributes(): Attributes {
     // $FlowFixMe: reduce returns a mixed type, not Attributes
-    this.attributes = Object.values(ATTRIBUTES).reduce(
+    return Object.values(ATTRIBUTES).reduce(
       (attributes, name: string) => ({
         ...attributes,
         [name]: this.props.element.getAttribute(name),
       }),
       {},
     );
-  };
+  }
 
   hasInputFields = (): boolean => {
     const textFields = this.props.element.getElementsByTagNameNS(


### PR DESCRIPTION
[This commit](https://github.com/Instawork/hyperview/commit/76a367a660683645c6819e04987f423103573581) (added in 0.58.0) introduced element attributes caching in `HvView`, which was mostly a refactor for convenience before restructuring the component itself, so that the attributes could be shared by multiple instance methods of `HvView`. It was first assumed that any state/props changes would cause the `componentDidUpdate` method, which in turn could help us re-set the attributes. However, the caching mechanism appear to cause incorrect attributes to be initially set but never updated to expected values. It's unclear if this is due to DOM mutations which could cause the `element` prop to remain unchanged when some parts of the object have changed, or something else. Removing caching help getting this bug circunvented.

| Before | After |
|-------|------|
| ![before](https://github.com/Instawork/hyperview/assets/309515/f02e2749-8c3f-49dc-bef7-8802feed41c0) | ![after](https://github.com/Instawork/hyperview/assets/309515/6b36d9bd-8c8f-41a3-9808-1edae4ade8fc) |

