### PR TITLE
fix: error text color

### DIFF
--- a/src/core/components/load-element-error/styles.js
+++ b/src/core/components/load-element-error/styles.js
@@ -36,6 +36,7 @@ export default StyleSheet.create({
     paddingTop: 8,
   },
   title: {
+    color: 'black',
     textAlign: 'center',
   },
 });


### PR DESCRIPTION
Some devices are not inheriting black color by default, explicitly setting the color


![Screenshot 2023-06-01 at 11 55 14](https://github.com/Instawork/hyperview/assets/28518512/77896edc-f4c8-4024-abb8-6c869c6df912)