### PR TITLE
fix(error): explicitly set text color for android

### DIFF
--- a/src/core/components/load-error/styles.js
+++ b/src/core/components/load-error/styles.js
@@ -26,6 +26,7 @@ export default StyleSheet.create({
     margin: 24,
   },
   title: {
+    color: 'black',
     textAlign: 'center',
   },
 });


### PR DESCRIPTION
Android sets text color to white in dark mode. Setting the error color explicitly for full page error, text on element error is already set in this [pr](https://github.com/Instawork/hyperview/pull/567).

### Screenshots
| Before | After |
| --- | --- |
| <img src="https://github.com/Instawork/hyperview/assets/28518512/2eaac7ba-cf01-4e13-a933-d08a877d048f)" /> | <img src="https://github.com/Instawork/hyperview/assets/28518512/8b107574-2c63-40c4-921f-ab0aa12d229d" /> |

