### PR TITLE
chore(navigator) - removing different tab types

### DIFF
--- a/demo/App.js
+++ b/demo/App.js
@@ -6,7 +6,7 @@
  *
  */
 
-import 'react-native-gesture-handler';
+import './src/gesture-handler';
 import Root from './src/Root';
 
 export default function App() {

--- a/demo/package.json
+++ b/demo/package.json
@@ -13,7 +13,6 @@
     "@react-native-community/datetimepicker": "6.1.2",
     "@react-native-picker/picker": "2.4.0",
     "@react-navigation/bottom-tabs": "6.5.7",
-    "@react-navigation/material-top-tabs": "6.6.2",
     "@react-navigation/native": "6.1.6",
     "@react-navigation/stack": "6.3.16",
     "expo": "~45.0.0",
@@ -25,10 +24,8 @@
     "react-native": "0.68.2",
     "react-native-gesture-handler": "2.11.0",
     "react-native-keyboard-aware-scrollview": "2.1.0",
-    "react-native-pager-view": "6.2.0",
     "react-native-safe-area-context": "4.2.4",
     "react-native-screens": "~3.11.1",
-    "react-native-tab-view": "3.5.1",
     "react-native-web": "0.17.7",
     "react-native-webview": "11.18.1"
   },

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -1881,14 +1881,6 @@
   resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.3.17.tgz#9cb95765940f2841916fc71686598c22a3e4067e"
   integrity sha512-sui8AzHm6TxeEvWT/NEXlz3egYvCUog4tlXA4Xlb2Vxvy3purVXDq/XsM56lJl344U5Aj/jDzkVanOTMWyk4UA==
 
-"@react-navigation/material-top-tabs@6.6.2":
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/@react-navigation/material-top-tabs/-/material-top-tabs-6.6.2.tgz#ff68e597451a86d26421d5f516a1aa7e1fb30048"
-  integrity sha512-qq0iyMzWApeSvhxovurhk5hluAH2VYbSObTZIKt4KbVXZ0KP8ir1tRQ+IAwkMea+hCnd26glpXRVQI+YqXH0Gw==
-  dependencies:
-    color "^4.2.3"
-    warn-once "^0.1.0"
-
 "@react-navigation/native@6.1.6":
   version "6.1.6"
   resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-6.1.6.tgz#84ff5cf85b91f660470fa9407c06c8ee393d5792"
@@ -8687,11 +8679,6 @@ react-native-keyboard-aware-scrollview@2.1.0:
   resolved "https://registry.yarnpkg.com/react-native-keyboard-aware-scrollview/-/react-native-keyboard-aware-scrollview-2.1.0.tgz#418a6b868f4cf2f9d28e77914f11ecbf8ae8e556"
   integrity sha512-XfWozWFPhdecfxN+wuqERX3mCGDrAim5siC6TWg3Qw7wK/zlwIwe1UIsHDNOQCzf9oIh0SkZXvoOFsMrnyIVmQ==
 
-react-native-pager-view@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.2.0.tgz#51380d93fbe47f6380dc71d613a787bf27a4ca37"
-  integrity sha512-pf9OnL/Tkr+5s4Gjmsn7xh91PtJLDa6qxYa/bmtUhd/+s4cQdWQ8DIFoOFghwZIHHHwVdWtoXkp6HtpjN+r20g==
-
 react-native-safe-area-context@4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.2.4.tgz#4df42819759c4d3c74252c8678c2772cfa2271a6"
@@ -8704,13 +8691,6 @@ react-native-screens@~3.11.1:
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
-
-react-native-tab-view@3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-3.5.1.tgz#2ad454afc0e186b43ea8b89053f39180d480d48b"
-  integrity sha512-qdrS5t+AEhfuKQyuCXkwHu4IVppkuTvzWWlkSZKrPaSkjjIa32xrsGxt1UW9YDdro2w4AMw5hKn1hFmg/5mvzA==
-  dependencies:
-    use-latest-callback "^0.1.5"
 
 react-native-web@0.17.7:
   version "0.17.7"

--- a/examples/navigator/dynamic-complex.xml
+++ b/examples/navigator/dynamic-complex.xml
@@ -1,5 +1,5 @@
 <doc xmlns="https://hyperview.org/hyperview">
-  <navigator id="dynamic-2-nav" type="top-tab">
+  <navigator id="dynamic-2-nav" type="tab">
     <nav-route id="pending-shifts-route" href="/navigator/pending-shifts.xml" />
     <nav-route
       id="completed-shifts-route"

--- a/examples/navigator/home.xml
+++ b/examples/navigator/home.xml
@@ -1,10 +1,10 @@
 <doc xmlns="https://hyperview.org/hyperview">
-  <navigator id="home-nav" type="bottom-tab">
+  <navigator id="home-nav" type="tab">
     <nav-route id="shifts-route" href="/navigator/shifts.xml" />
     <nav-route id="messages-route" href="/navigator/messages.xml" />
     <nav-route id="info-route" href="/navigator/info.xml" initial="true" />
     <nav-route id="settings-route" href="">
-      <navigator id="setting-nav" type="top-tab">
+      <navigator id="setting-nav" type="tab">
         <nav-route id="setting-1-route" href="/navigator/settings-1.xml" />
         <nav-route id="setting-2-route" href="/navigator/settings-2.xml" />
         <nav-route id="setting-3-route" href="index.xml" />

--- a/examples/navigator/my-shifts.xml
+++ b/examples/navigator/my-shifts.xml
@@ -1,5 +1,5 @@
 <doc xmlns="https://hyperview.org/hyperview">
-  <navigator id="my-shifts-nav" type="top-tab">
+  <navigator id="my-shifts-nav" type="tab">
     <nav-route id="pending-shifts-route" href="/navigator/pending-shifts.xml" />
     <nav-route
       id="completed-shifts-route"

--- a/examples/navigator/shifts.xml
+++ b/examples/navigator/shifts.xml
@@ -1,5 +1,5 @@
 <doc xmlns="https://hyperview.org/hyperview">
-  <navigator id="shifts-nav" type="top-tab">
+  <navigator id="shifts-nav" type="tab">
     <nav-route id="open-shifts-route" href="/navigator/open-shifts.xml" />
     <nav-route id="my-shifts-route" href="/navigator/my-shifts.xml" />
   </navigator>

--- a/package.json
+++ b/package.json
@@ -55,14 +55,11 @@
     "@react-native-picker/picker": ">= 2.2.1",
     "@react-navigation/bottom-tabs": "6.5.7",
     "@react-navigation/core": "6.4.8",
-    "@react-navigation/material-top-tabs": "6.6.2",
     "@react-navigation/stack": "6.3.16",
     "react": ">= 16.13.1",
     "react-native": ">= 0.63.3",
     "react-native-gesture-handler": "2.10.1",
     "react-native-keyboard-aware-scrollview": ">= 2.1.0",
-    "react-native-pager-view": "6.2.0",
-    "react-native-tab-view": "3.5.1",
     "react-native-webview": ">= 10.10.2"
   },
   "devDependencies": {
@@ -77,7 +74,6 @@
     "@react-native-picker/picker": "2.2.1",
     "@react-navigation/bottom-tabs": "6.5.7",
     "@react-navigation/core": "6.4.8",
-    "@react-navigation/material-top-tabs": "6.6.2",
     "@react-navigation/stack": "6.3.16",
     "@storybook/addon-actions": "4.1.18",
     "@storybook/addon-storyshots": "4.1.18",
@@ -109,8 +105,6 @@
     "react-native": "0.63.3",
     "react-native-gesture-handler": "2.11.0",
     "react-native-keyboard-aware-scrollview": "2.1.0",
-    "react-native-pager-view": "6.2.0",
-    "react-native-tab-view": "3.5.1",
     "react-native-webview": "10.10.2",
     "react-test-renderer": "16.13.1",
     "typescript": "4.9.5"

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -1202,8 +1202,7 @@
   <xs:simpleType name="navigator-type">
     <xs:restriction base="xs:string">
       <xs:enumeration value="stack" />
-      <xs:enumeration value="bottom-tab" />
-      <xs:enumeration value="top-tab" />
+      <xs:enumeration value="tab" />
     </xs:restriction>
   </xs:simpleType>
 

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -27,7 +27,6 @@ const SHOW_NAVIGATION_UI = true;
 
 const Stack = NavigatorService.createStackNavigator<ParamTypes>();
 const BottomTab = NavigatorService.createBottomTabNavigator();
-const TopTab = NavigatorService.createMaterialTopTabNavigator();
 
 export default class HvNavigator extends PureComponent<Props> {
   /**
@@ -37,17 +36,7 @@ export default class HvNavigator extends PureComponent<Props> {
     id: string,
     type: TypesLegacy.DOMString,
   ): React.ReactElement => {
-    if (type === NavigatorService.NAVIGATOR_TYPE.TOP_TAB) {
-      return (
-        <TopTab.Screen
-          key={id}
-          component={HvRoute}
-          initialParams={{ id }}
-          name={id}
-        />
-      );
-    }
-    if (type === NavigatorService.NAVIGATOR_TYPE.BOTTOM_TAB) {
+    if (type === NavigatorService.NAVIGATOR_TYPE.TAB) {
       return (
         <BottomTab.Screen
           key={id}
@@ -222,20 +211,7 @@ export default class HvNavigator extends PureComponent<Props> {
             {buildScreens(props.element, type)}
           </Stack.Navigator>
         );
-      case NavigatorService.NAVIGATOR_TYPE.TOP_TAB:
-        return (
-          <TopTab.Navigator
-            backBehavior="none"
-            id={id}
-            initialRouteName={initialId}
-            screenOptions={{
-              tabBarStyle: { display: SHOW_NAVIGATION_UI ? 'flex' : 'none' },
-            }}
-          >
-            {buildScreens(props.element, type)}
-          </TopTab.Navigator>
-        );
-      case NavigatorService.NAVIGATOR_TYPE.BOTTOM_TAB:
+      case NavigatorService.NAVIGATOR_TYPE.TAB:
         return (
           <BottomTab.Navigator
             backBehavior="none"

--- a/src/services/navigator/imports.ts
+++ b/src/services/navigator/imports.ts
@@ -17,6 +17,5 @@ export type {
 } from '@react-navigation/native';
 export type { NavigationState } from '@react-navigation/core';
 export { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-export { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 export { createStackNavigator } from '@react-navigation/stack';
 export { CommonActions, StackActions } from '@react-navigation/native';

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -120,11 +120,7 @@ export class Navigator {
 }
 
 export type { NavigationProp, Route } from './imports';
-export {
-  createStackNavigator,
-  createBottomTabNavigator,
-  createMaterialTopTabNavigator,
-} from './imports';
+export { createStackNavigator, createBottomTabNavigator } from './imports';
 export { HvRouteError, HvNavigatorError, HvRenderError } from './errors';
 export {
   isUrlFragment,

--- a/src/services/navigator/types.ts
+++ b/src/services/navigator/types.ts
@@ -16,9 +16,8 @@ export const ID_MODAL = 'modal';
  * Definition of the available navigator types
  */
 export const NAVIGATOR_TYPE = {
-  BOTTOM_TAB: 'bottom-tab',
   STACK: 'stack',
-  TOP_TAB: 'top-tab',
+  TAB: 'tab',
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1946,14 +1946,6 @@
   resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.3.17.tgz#9cb95765940f2841916fc71686598c22a3e4067e"
   integrity sha512-sui8AzHm6TxeEvWT/NEXlz3egYvCUog4tlXA4Xlb2Vxvy3purVXDq/XsM56lJl344U5Aj/jDzkVanOTMWyk4UA==
 
-"@react-navigation/material-top-tabs@6.6.2":
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/@react-navigation/material-top-tabs/-/material-top-tabs-6.6.2.tgz#ff68e597451a86d26421d5f516a1aa7e1fb30048"
-  integrity sha512-qq0iyMzWApeSvhxovurhk5hluAH2VYbSObTZIKt4KbVXZ0KP8ir1tRQ+IAwkMea+hCnd26glpXRVQI+YqXH0Gw==
-  dependencies:
-    color "^4.2.3"
-    warn-once "^0.1.0"
-
 "@react-navigation/native@6.1.6":
   version "6.1.6"
   resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-6.1.6.tgz#84ff5cf85b91f660470fa9407c06c8ee393d5792"
@@ -12406,22 +12398,10 @@ react-native-keyboard-aware-scrollview@2.1.0:
   resolved "https://registry.yarnpkg.com/react-native-keyboard-aware-scrollview/-/react-native-keyboard-aware-scrollview-2.1.0.tgz#418a6b868f4cf2f9d28e77914f11ecbf8ae8e556"
   integrity sha512-XfWozWFPhdecfxN+wuqERX3mCGDrAim5siC6TWg3Qw7wK/zlwIwe1UIsHDNOQCzf9oIh0SkZXvoOFsMrnyIVmQ==
 
-react-native-pager-view@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.2.0.tgz#51380d93fbe47f6380dc71d613a787bf27a4ca37"
-  integrity sha512-pf9OnL/Tkr+5s4Gjmsn7xh91PtJLDa6qxYa/bmtUhd/+s4cQdWQ8DIFoOFghwZIHHHwVdWtoXkp6HtpjN+r20g==
-
 react-native-swipe-gestures@^1.0.2:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz#a172cb0f3e7478ccd681fd36b8bfbcdd098bde7c"
   integrity sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==
-
-react-native-tab-view@3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-3.5.1.tgz#2ad454afc0e186b43ea8b89053f39180d480d48b"
-  integrity sha512-qdrS5t+AEhfuKQyuCXkwHu4IVppkuTvzWWlkSZKrPaSkjjIa32xrsGxt1UW9YDdro2w4AMw5hKn1hFmg/5mvzA==
-  dependencies:
-    use-latest-callback "^0.1.5"
 
 react-native-webview@10.10.2:
   version "10.10.2"


### PR DESCRIPTION
- Correct App.js to import gestures from local src to support multi-platform
- Replacing 'top-tab' and 'bottom-tab' with 'tab'
  - Updated schema
  - Remove material top tab package and dependencies from package manifest
  - Updated temp demo to use new types