### PR TITLE
feat: alert button style

### DIFF
--- a/docs/reference_behavior_alert.md
+++ b/docs/reference_behavior_alert.md
@@ -137,6 +137,14 @@ The following attributes are part of the `https://hyperview.org/hyperview-alert`
 
 The label of the alert option. Appears as a pressable button below the title and message.
 
+### style
+
+| Type                                 | Required |
+| ------------------------------------ | -------- |
+| "default", "cancel" or "destructive" | **No**   |
+
+(iOS only) The style to be applied to the option's button - when unset, default style is "default"
+
 ### Behavior attributes
 
 See the standard [behavior attributes](/docs/reference_behavior_attributes). To support multiple behaviors, use `<behavior>` child elements instead.

--- a/examples/advanced_behaviors/alert/options.xml.njk
+++ b/examples/advanced_behaviors/alert/options.xml.njk
@@ -63,4 +63,22 @@ tags: alert
     </behavior>
     <text style="Button__Label">Three options</text>
   </view>
+  <text style="Description">
+    On iOS, options buttons can have their style set to "default", "cancel" or "destructive"
+  </text>
+  <view style="Button">
+    <behavior
+      action="alert"
+      alert:message="iOS button styles"
+      alert:title="Options buttons can have their style set to `default`, `cancel` or `destructive`"
+      trigger="press"
+      xmlns:alert="https://hyperview.org/hyperview-alert"
+    >
+      <alert:option alert:style="default" alert:label="Update"/>
+      <alert:option alert:style="destructive" alert:label="Delete"/>
+      <alert:option alert:style="cancel" alert:label="Cancel"/>
+      
+    </behavior>
+    <text style="Button__Label">Option button styles</text>
+  </view>
 {% endblock %}

--- a/schema/alert.xsd
+++ b/schema/alert.xsd
@@ -23,5 +23,14 @@
   <xs:attributeGroup name="alertAttributes">
     <xs:attribute name="message" type="xs:string" />
     <xs:attribute name="title" type="xs:string" />
+    <xs:attribute name="style">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="default" />
+          <xs:enumeration value="destructive" />
+          <xs:enumeration value="cancel" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
   </xs:attributeGroup>
 </xs:schema>

--- a/src/behaviors/hv-alert/index.js
+++ b/src/behaviors/hv-alert/index.js
@@ -77,6 +77,9 @@ export default {
             );
           });
       },
+      style:
+        optionElement &&
+        optionElement.getAttributeNS(Namespaces.HYPERVIEW_ALERT, 'style'),
       text:
         optionElement &&
         optionElement.getAttributeNS(Namespaces.HYPERVIEW_ALERT, 'label'),


### PR DESCRIPTION
Allow alert option button style to be defined.

![Simulator Screenshot - iPhone 14 Pro - 2023-06-15 at 18 38 23](https://github.com/Instawork/hyperview/assets/309515/333eec96-73a8-4811-85f4-0041f8412092)
