### PR TITLE
fix: scrollbar bug with iOS 13+

### DIFF
--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -15,6 +15,7 @@ import * as Render from 'hyperview/src/services/render';
 import {
   RefreshControl as DefaultRefreshControl,
   FlatList,
+  Platform,
 } from 'react-native';
 import React, { PureComponent } from 'react';
 import { DOMParser } from 'xmldom-instawork';
@@ -106,6 +107,13 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
     const showScrollIndicator =
       this.props.element.getAttribute('shows-scroll-indicator') !== 'false';
 
+    // Fix scrollbar rendering issue in iOS 13+
+    // https://github.com/facebook/react-native/issues/26610#issuecomment-539843444
+    const scrollIndicatorInsets =
+      Platform.OS === 'ios' && parseInt(Platform.Version, 10) >= 13
+        ? { right: 1 }
+        : undefined;
+
     const listProps = {
       data: this.getItems(),
       horizontal,
@@ -118,6 +126,7 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
           this.props.onUpdate,
           this.props.options,
         ),
+      scrollIndicatorInsets,
       showsHorizontalScrollIndicator: horizontal && showScrollIndicator,
       showsVerticalScrollIndicator: !horizontal && showScrollIndicator,
       style,

--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -13,6 +13,7 @@ import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
 import {
   RefreshControl as DefaultRefreshControl,
+  Platform,
   SectionList,
 } from 'react-native';
 
@@ -138,6 +139,13 @@ export default class HvSectionList extends PureComponent<
       });
     }
 
+    // Fix scrollbar rendering issue in iOS 13+
+    // https://github.com/facebook/react-native/issues/26610#issuecomment-539843444
+    const scrollIndicatorInsets =
+      Platform.OS === 'ios' && parseInt(Platform.Version, 10) >= 13
+        ? { right: 1 }
+        : undefined;
+
     const listProps = {
       keyExtractor: item => item.getAttribute('key'),
       renderItem: ({ item }) =>
@@ -154,6 +162,7 @@ export default class HvSectionList extends PureComponent<
           this.props.onUpdate,
           this.props.options,
         ),
+      scrollIndicatorInsets,
       sections,
       stickySectionHeadersEnabled: this.getStickySectionHeadersEnabled(),
       style,


### PR DESCRIPTION
Follow up for #413

Apply the same fix for `list` and `section-list` that was originally applied to scrollable `view`.


|  | Before | After |
|--|--------|-------|
| `list` | ![before-list](https://github.com/Instawork/hyperview/assets/309515/e933862a-3631-4cf5-9302-ff2a4d7a0847) | ![after-list](https://github.com/Instawork/hyperview/assets/309515/ed8e7f09-bb5f-4415-a64f-b69941f6577a) |
| `section-list` | ![before-section-list](https://github.com/Instawork/hyperview/assets/309515/0ec527ca-eee1-4787-a92c-1067fe461587) | ![after-section-list](https://github.com/Instawork/hyperview/assets/309515/7ff16fa7-0aed-41c7-a22c-39caf83071ce) |


