### PR TITLE
fix: ignore Eleventy generated files from Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 flow-typed
 *.gen.js
+_examples_site/
 website/
 /src/index.js
 /src/VisibilityDetectingView.js

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:render": "npx patch-package && jest test/render.test.js --forceExit",
     "test:unit": "jest --testPathPattern src",
     "test:xmlserver": "eleventy --serve --port=8085",
-    "test:validate-xml": "eleventy; find _examples_site/ -name '*.xml' -not -path '*/advanced_behaviors/instawork.xml' -not -path '*/advanced_behaviors/custom_share.xml' -not -path '*/advanced_behaviors/alert/behavior.xml' -not -path '*/case_studies/business_rating.xml' -not -path '*/case_studies/_rating_save.xml' | xargs xmllint --schema schema/hyperview.xsd --noout",
+    "test:validate-xml": "eleventy; find _examples_site -name '*.xml' -not -path '*/advanced_behaviors/instawork.xml' -not -path '*/advanced_behaviors/custom_share.xml' -not -path '*/advanced_behaviors/alert/behavior.xml' -not -path '*/case_studies/business_rating.xml' -not -path '*/case_studies/_rating_save.xml' | xargs xmllint --schema schema/hyperview.xsd --noout",
     "test": "yarn generate test && yarn test:flow && yarn test:lint && yarn test:render && yarn test:unit && yarn test:validate-xml"
   },
   "dependencies": {


### PR DESCRIPTION
Before this change, one would need to delete the `_examples_site` directory before being able to run Prettier tests. This change also removes the trailing slash in the command that validates XML (doesnt change the test behavior, but makes the output of validated file paths correct).