### PR TITLE
fix(navigator) - Stack navigator with defined sub-navigator

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -362,9 +362,7 @@ export default function HvRoute(props: Types.Props) {
   const id: string | undefined =
     props.route?.params?.id || navigatorContext.initialRouteName || undefined;
 
-  const state = props.navigation?.getState();
-  const index = state?.index;
-  const type = state?.type;
+  const { index, type } = props.navigation?.getState() || {};
   // The nested element is only used when there is an id
   //    and the navigator is not a stack or is the first screen in a stack
   //    other stack screens will use a url

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -363,16 +363,14 @@ export default function HvRoute(props: Types.Props) {
     props.route?.params?.id || navigatorContext.initialRouteName || undefined;
 
   const { index, type } = props.navigation?.getState() || {};
-  // The nested element is only used when there is an id
-  //    and the navigator is not a stack or is the first screen in a stack
-  //    other stack screens will use a url
-  const includeElement =
-    id && (type !== NavigatorService.NAVIGATOR_TYPE.STACK || index === 0);
+  // The nested element is only used when the navigator is not a stack
+  //    or is the first screen in a stack. Other stack screens will require a url
+  const includeElement: boolean =
+    type !== NavigatorService.NAVIGATOR_TYPE.STACK || index === 0;
 
   // Get the navigator element from the context
-  const element: TypesLegacy.Element | undefined = includeElement
-    ? navigatorContext.elementMap?.get(id)
-    : undefined;
+  const element: TypesLegacy.Element | undefined =
+    id && includeElement ? navigatorContext.elementMap?.get(id) : undefined;
 
   return (
     <HvRouteInner

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -362,8 +362,17 @@ export default function HvRoute(props: Types.Props) {
   const id: string | undefined =
     props.route?.params?.id || navigatorContext.initialRouteName || undefined;
 
+  const state = props.navigation?.getState();
+  const index = state?.index;
+  const type = state?.type;
+  // The nested element is only used when there is an id
+  //    and the navigator is not a stack or is the first screen in a stack
+  //    other stack screens will use a url
+  const includeElement =
+    id && (type !== NavigatorService.NAVIGATOR_TYPE.STACK || index === 0);
+
   // Get the navigator element from the context
-  const element: TypesLegacy.Element | undefined = id
+  const element: TypesLegacy.Element | undefined = includeElement
     ? navigatorContext.elementMap?.get(id)
     : undefined;
 


### PR DESCRIPTION
Resolve an issue where subsequent dynamic screens were reloading the defined sub-navigator rather than using the passed url.

Asana: https://app.asana.com/0/0/1204865667381531/f