### PR TITLE
fix(alert): Android alert without options

### DIFF
--- a/src/behaviors/hv-alert/index.js
+++ b/src/behaviors/hv-alert/index.js
@@ -10,8 +10,8 @@
 
 import * as Dom from 'hyperview/src/services/dom';
 import * as Namespaces from 'hyperview/src/services/namespaces';
+import { Alert, Platform } from 'react-native';
 import type { Element, HvComponentOnUpdate } from 'hyperview/src/types';
-import { Alert } from 'react-native';
 import { later } from 'hyperview/src/services';
 
 export default {
@@ -84,6 +84,15 @@ export default {
         optionElement &&
         optionElement.getAttributeNS(Namespaces.HYPERVIEW_ALERT, 'label'),
     }));
+
+    // On Android, alerts don't have a default button when unspecified, so we need to set one.
+    if (!options.length && Platform.OS === 'android') {
+      options.push({
+        onPress: () => {},
+        text: 'OK',
+      });
+    }
+
     // Show alert
     Alert.alert(title, message, options);
   },


### PR DESCRIPTION
Add a default option on Android when none specified.

| Before | After |
|------|------|
| <img width="559" alt="Screenshot 2023-06-26 at 1 04 24 PM" src="https://github.com/Instawork/hyperview/assets/309515/cb382cac-a066-4447-8e68-e2f199c9ed5e"> | <img width="559" alt="Screenshot 2023-06-26 at 1 01 24 PM" src="https://github.com/Instawork/hyperview/assets/309515/04a1d227-e8ce-41db-8995-4bf259c228b9"> |
