### PR TITLE
fix(flow): disable flow on entrypoint file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-// @flow
-
 /**
  * Copyright (c) Garuda Labs, Inc.
  *
@@ -8,9 +6,9 @@
  *
  */
 
+/* eslint instawork/flow-annotate: 0 */
 import * as Events from 'hyperview/src/services/events';
 import * as Namespaces from 'hyperview/src/services/namespaces';
-// $FlowFixMe
 import Hyperview from 'hyperview/src/core/components/hv-root';
 
 export * from 'hyperview/src/types';


### PR DESCRIPTION
This used to be disabled on the legacy entry point, and apparently helped obfuscating a lot of typing errors in our apps, which now have resurfaced. This reverts the original behavior.