### PR TITLE
fix(types) - adding peer dependency for types/react

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@react-navigation/core": "6.4.8",
     "@react-navigation/native": "6.1.6",
     "@react-navigation/stack": "6.3.16",
+    "@types/react": "18.0.28",
     "react": ">= 16.13.1",
     "react-native": ">= 0.63.3",
     "react-native-gesture-handler": "2.11.0",


### PR DESCRIPTION
- The package was defined in devDependencies but needs to be in the peer as well