### PR TITLE
fix(navigation) - Allow injecting a doc into HvScreen

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -187,7 +187,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
             behaviors={props.routeProps.behaviors}
             closeModal={props.navLogic.closeModal}
             components={props.routeProps.components}
-            doc={props.doc}
+            doc={props.doc?.cloneNode(true)}
             elementErrorComponent={props.routeProps.elementErrorComponent}
             entrypointUrl={props.routeProps.entrypointUrl}
             errorScreen={props.routeProps.errorScreen}

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -139,10 +139,6 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     );
   };
 
-  updateDoc = (doc: TypesLegacy.Document) => {
-    this.setState({ doc });
-  };
-
   /**
    * View shown while loading
    */
@@ -205,7 +201,6 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
             openModal={props.navLogic.openModal}
             push={props.navLogic.push}
             route={route}
-            updateDoc={this.updateDoc}
             url={props.url || undefined}
           />
         )}

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -139,6 +139,10 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     );
   };
 
+  updateDoc = (doc: TypesLegacy.Document) => {
+    this.setState({ doc });
+  };
+
   /**
    * View shown while loading
    */
@@ -201,6 +205,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
             openModal={props.navLogic.openModal}
             push={props.navLogic.push}
             route={route}
+            updateDoc={this.updateDoc}
             url={props.url || undefined}
           />
         )}

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -53,21 +53,6 @@ export type State = {
   error?: Error;
 };
 
-export type BuildScreenProps = {
-  doc?: TypesLegacy.Document;
-  navLogic: NavigatorService.Navigator;
-  routeProps: InnerRouteProps;
-  url: string | null;
-};
-
-export type RouteRenderProps = {
-  doc?: TypesLegacy.Document;
-  element?: TypesLegacy.Element;
-  navLogic: NavigatorService.Navigator;
-  routeProps: InnerRouteProps;
-  url: string;
-};
-
 /**
  * The route prop used by react-navigation
  */

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -59,6 +59,8 @@ export default class HvScreen extends React.Component {
       styles: null,
       url: null,
     };
+    // Injecting a passed document as a single-use document
+    this.initialDoc = props.doc;
 
     // <HACK>
     // In addition to storing the document on the react state, we keep a reference to it
@@ -199,8 +201,18 @@ export default class HvScreen extends React.Component {
         await later(parseInt(params.delay, 10));
       }
 
-      // eslint-disable-next-line react/no-access-state-in-setstate
-      const { doc, staleHeaderType } = await this.parser.loadDocument(this.state.url);
+      // If an initial document was passed, use it once and then remove
+      let doc;
+      let staleHeaderType;
+      if (this.initialDoc){
+        doc = this.initialDoc;
+        this.initialDoc = null;
+      } else {
+        // eslint-disable-next-line react/no-access-state-in-setstate
+        const { doc : loadedDoc, staleHeaderType : loadedType } = await this.parser.loadDocument(this.state.url);
+        doc = loadedDoc;
+        staleHeaderType = loadedType;
+      }
       const stylesheets = Stylesheets.createStylesheets(doc);
       this.navigation.setRouteKey(this.state.url, routeKey);
       this.setState({

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -75,6 +75,7 @@ export default class HvScreen extends React.Component {
     this.setState = (...args) => {
       if (args[0].doc !== undefined) {
         this.doc = args[0].doc;
+        this.props.updateDoc?.(args[0].doc)
       }
       this.oldSetState(...args);
     }

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -75,7 +75,6 @@ export default class HvScreen extends React.Component {
     this.setState = (...args) => {
       if (args[0].doc !== undefined) {
         this.doc = args[0].doc;
-        this.props.updateDoc?.(args[0].doc)
       }
       this.oldSetState(...args);
     }

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -51,5 +51,4 @@ export type Props = {
   loadingScreen?: ComponentType<LoadingProps>;
   handleBack?: ComponentType<{ children: ReactNode }>;
   doc?: TypesLegacy.Document;
-  updateDoc?: (doc: TypesLegacy.Document) => void;
 };

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -51,4 +51,5 @@ export type Props = {
   loadingScreen?: ComponentType<LoadingProps>;
   handleBack?: ComponentType<{ children: ReactNode }>;
   doc?: TypesLegacy.Document;
+  updateDoc?: (doc: TypesLegacy.Document) => void;
 };

--- a/src/types-legacy.ts
+++ b/src/types-legacy.ts
@@ -97,6 +97,9 @@ export type Node = {
  * Minimal Element type copy from 'hyperview/src/types.js'
  */
 export type Element = Node & {
+  // ***** ADDED *****
+  cloneNode: (deep: boolean) => Element;
+
   childNodes: NodeList<Element>;
   getAttribute: (name: DOMString) => DOMString | null | undefined;
 
@@ -110,6 +113,9 @@ export type Element = Node & {
  * Minimal Document type copy from 'hyperview/src/types.js'
  */
 export type Document = Node & {
+  // ***** ADDED *****
+  cloneNode: (deep: boolean) => Document;
+
   getElementsByTagNameNS: (
     namespaceURI: NamespaceURI,
     localName: LocalName,


### PR DESCRIPTION
- Provide a document to HvScreen when it is created from HvRoute
- Use the document once in lieu of loading from url
- Remove the initial document so it won't be used after initialization completes

Asana: https://app.asana.com/0/1204008699308084/1204911836776291/f