### PR TITLE
feature(navigation) - Add preload functionality to HvRoute

### DIFF
--- a/src/contexts/navigator.tsx
+++ b/src/contexts/navigator.tsx
@@ -13,6 +13,7 @@ export type NavigatorContextProps = {
   routeMap?: Map<string, string>;
   elementMap?: Map<string, TypesLegacy.Element>;
   initialRouteName?: string;
+  preloadMap?: Map<number, TypesLegacy.Element>;
 };
 
 /**
@@ -30,8 +31,9 @@ type Props = { children: React.ReactNode };
 export function NavigatorMapProvider(props: Props) {
   const routeMap: Map<string, string> = new Map();
   const elementMap: Map<string, TypesLegacy.Element> = new Map();
+  const preloadMap: Map<number, TypesLegacy.Element> = new Map();
   return (
-    <NavigatorMapContext.Provider value={{ elementMap, routeMap }}>
+    <NavigatorMapContext.Provider value={{ elementMap, preloadMap, routeMap }}>
       {props.children}
     </NavigatorMapContext.Provider>
   );

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -18,6 +18,7 @@ import type { Props as LoadingProps } from 'hyperview/src/core/components/loadin
 type RouteParams = {
   id?: string;
   url: string;
+  preloadScreen?: number;
 };
 
 /**
@@ -80,6 +81,7 @@ export type InnerRouteProps = {
   loadingScreen?: ComponentType<LoadingProps>;
   handleBack?: ComponentType<{ children: ReactNode }>;
   routeMap?: Map<string, string>;
+  preloadMap?: Map<number, TypesLegacy.Element>;
   elementMap?: Map<string, TypesLegacy.Element>;
   initialRouteName?: string;
   element?: TypesLegacy.Element;

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -353,6 +353,12 @@ export default class HvScreen extends React.Component {
     return null;
   }
 
+  registerPreload = (id, element) => {
+    if (this.props.registerPreload){
+      this.props.registerPreload(id, element);
+    }
+  }
+
   /**
    *
    */
@@ -364,7 +370,7 @@ export default class HvScreen extends React.Component {
     } else if (Object.values(NAV_ACTIONS).includes(action)) {
       this.navigation.setUrl(this.state.url);
       this.navigation.setDocument(this.doc);
-      this.navigation.navigate(href || ANCHOR_ID_SEPARATOR, action, currentElement, this.formComponentRegistry, opts);
+      this.navigation.navigate(href || ANCHOR_ID_SEPARATOR, action, currentElement, this.formComponentRegistry, opts, this.registerPreload);
     } else if (Object.values(UPDATE_ACTIONS).includes(action)) {
       this.onUpdateFragment(href, action, currentElement, opts);
     } else if (action === ACTIONS.SWAP) {

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -51,4 +51,5 @@ export type Props = {
   loadingScreen?: ComponentType<LoadingProps>;
   handleBack?: ComponentType<{ children: ReactNode }>;
   doc?: TypesLegacy.Document;
+  registerPreload?: (id: number, element: TypesLegacy.Element) => void;
 };

--- a/src/services/components.d.ts
+++ b/src/services/components.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import * as TypesLegacy from 'hyperview/src/types-legacy';
+
+export function getRegistry(
+  components: TypesLegacy.HvComponent[] = [],
+): TypesLegacy.ComponentRegistry;

--- a/src/services/navigation/index.js
+++ b/src/services/navigation/index.js
@@ -68,6 +68,7 @@ export default class Navigation {
     element: Element,
     formComponents: ComponentRegistry,
     opts: BehaviorOptions,
+    registerPreload?: (id: number, element: Element) => void,
   ): void => {
     const { showIndicatorId, delay, targetId } = opts;
     const formData: ?FormData = getFormData(element, formComponents);
@@ -91,6 +92,9 @@ export default class Navigation {
       if (loadingScreen) {
         preloadScreen = Date.now(); // Not trully unique but sufficient for our use-case
         this.setPreloadScreen(preloadScreen, loadingScreen);
+        if (registerPreload) {
+          registerPreload(preloadScreen, loadingScreen);
+        }
       }
     }
 

--- a/src/services/stylesheets.d.ts
+++ b/src/services/stylesheets.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import * as TypesLegacy from 'hyperview/src/types-legacy';
+
+export function createStylesheets(
+  document: TypesLegacy.Document,
+): TypesLegacy.StyleSheets;

--- a/src/types-legacy.ts
+++ b/src/types-legacy.ts
@@ -144,3 +144,11 @@ export type HvBehavior = {
 };
 
 export type HvComponent = unknown;
+
+export type ComponentRegistry = {
+  [key: string]: {
+    [key: string]: HvComponent;
+  };
+};
+
+export type StyleSheet = unknown;


### PR DESCRIPTION
Adding preload screen functionality to HvRoute since it is now handling loading
- Added global preload screen registry to navigator context
  - In legacy code, this is local to the screen as each screen instantiates its own navigation service. This change allows the preload registry to continue to live in the local navigation service and also in a global context available to all HvRoutes in the hierarchy.
  - provided callback to allow HvScreen+local navigation service to also register in the global context registry
- Added preloadScreen to route params
  - previous requirement included only id and url
- Added preload screen rendering into HvRoute
  - HvRoute now performs the loading which HvScreen previously performed
- Created description files for services required for preload render
  - Components and Stylesheet now have *.d.ts files

Asana: https://app.asana.com/0/0/1204952399375930/f

| With preload  | No preload |
| ------------- | ------------- |
|  ![with](https://github.com/Instawork/hyperview/assets/127122858/942e588e-d60b-4773-aca8-56f56bf36920)  | ![without](https://github.com/Instawork/hyperview/assets/127122858/290426c6-e59c-42ab-b94d-eb3ec2157673)  |








