### PR TITLE
switch to new xmldom lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repo contains a React Native implementation of the Hyperview Client. It can
 The Hyperview client only has two required dependencies:
 
 - url-parse 1.4.3
-- xmldom-instawork 0.0.1
+- @instawork/xmldom 0.0.2
 
 More importantly, the client is designed to be incorporated into an existing React Native project, and thus has the following peer dependencies:
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -16,7 +16,7 @@
     "@react-navigation/stack": "^6.2.2",
     "expo": "~45.0.0",
     "expo-status-bar": "~1.3.0",
-    "hyperview": "0.66.0",
+    "hyperview": "0.66.1-rc.0",
     "moment": "^2.29.4",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -1553,6 +1553,13 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
+"@instawork/xmldom@0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@instawork/xmldom/-/xmldom-0.0.2.tgz#3c6348fc9dfd101cb939aa41d149274a3781ce27"
+  integrity sha512-6a0WM8OcgnAujFksEcdynrESb1OciKHEPWgSSinSO++oDgICTdMpzvK2j1gfVo1i1o8QC641q67DkJccvf48BA==
+  dependencies:
+    string.prototype.matchall "3.0.1"
+
 "@jest/create-cache-key-function@^27.0.1":
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/@jest/create-cache-key-function/-/create-cache-key-function-27.5.1.tgz#7448fae15602ea95c828f5eceed35c202a820b31"
@@ -5619,14 +5626,14 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==
 
-hyperview@0.66.0:
-  version "0.66.0"
-  resolved "https://registry.yarnpkg.com/hyperview/-/hyperview-0.66.0.tgz#8c920cbcdee67562d6315e06169af4cd3ea7770f"
-  integrity sha512-oL0gPyeva7Okmk6vDQjwCgBUEjA8M/TkcZ5yTT6taMe5ajmuLuD3rYLNbRiE0eG4Gulmj5iLoFEhJUhVcNOQVw==
+hyperview@0.66.1-rc.0:
+  version "0.66.1-rc.0"
+  resolved "https://registry.yarnpkg.com/hyperview/-/hyperview-0.66.1-rc.0.tgz#a53a608c41a643afce62f6ad7eb9c7ea03a5fe0f"
+  integrity sha512-gAxhy+H50efYodtYCizaBHd/kpgxHlR+MSboye+7aETJX5q8zlkfD5GAbqQA3SU0t0Fs5NwFRgNyFYTLu3HagQ==
   dependencies:
+    "@instawork/xmldom" "0.0.2"
     tiny-emitter "2.1.0"
     url-parse "1.5.10"
-    xmldom-instawork "0.0.1"
 
 hyphenate-style-name@^1.0.2, hyphenate-style-name@^1.0.4:
   version "1.0.4"
@@ -10802,13 +10809,6 @@ xmldoc@^1.1.2:
   integrity sha512-2eN8QhjBsMW2uVj7JHLHkMytpvGHLHxKXBy4J3fAT/HujsEtM6yU84iGjpESYGHg6XwK0Vu4l+KgqQ2dv2cCqg==
   dependencies:
     sax "^1.2.4"
-
-xmldom-instawork@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/xmldom-instawork/-/xmldom-instawork-0.0.1.tgz#57c7351a68126d3407c6a685588bc51eef8e3623"
-  integrity sha512-i+txX8H1jFxoAPgJyAHhErk5+ede5pb51w0yknWL6ITPrv4Vu8W1GRzAYh5eH32HKw5n5yh3IWvGjcidKRa6DQ==
-  dependencies:
-    string.prototype.matchall "3.0.1"
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperview",
-  "version": "0.66.0",
+  "version": "0.66.1-rc.0",
   "main": "lib/index.js",
   "description": "React Native client for Hyperview XML",
   "homepage": "https://hyperview.org",
@@ -45,9 +45,9 @@
     "test": "yarn generate test && yarn test:flow && yarn test:lint && yarn test:render && yarn test:unit && yarn test:validate-xml"
   },
   "dependencies": {
+    "@instawork/xmldom": "0.0.2",
     "tiny-emitter": "2.1.0",
-    "url-parse": "1.5.10",
-    "@instawork/xmldom": "0.0.2"
+    "url-parse": "1.5.10"
   },
   "peerDependencies": {
     "@react-native-community/datetimepicker": ">= 3.0.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "tiny-emitter": "2.1.0",
     "url-parse": "1.5.10",
-    "xmldom-instawork": "0.0.1"
+    "@instawork/xmldom": "0.0.2"
   },
   "peerDependencies": {
     "@react-native-community/datetimepicker": ">= 3.0.3",

--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -18,7 +18,7 @@ import {
   Platform,
 } from 'react-native';
 import React, { PureComponent } from 'react';
-import { DOMParser } from 'xmldom-instawork';
+import { DOMParser } from '@instawork/xmldom';
 import type { HvComponentProps } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import type { State } from './types';

--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -19,7 +19,7 @@ import {
 
 import React, { PureComponent } from 'react';
 
-import { DOMParser } from 'xmldom-instawork';
+import { DOMParser } from '@instawork/xmldom';
 import type { HvComponentProps } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import type { State } from './types';

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -40,7 +40,7 @@ import {
 } from 'react-native';
 import type { Node } from 'react';
 import VisibilityDetectingView from 'hyperview/src/VisibilityDetectingView';
-import { XMLSerializer } from 'xmldom-instawork';
+import { XMLSerializer } from '@instawork/xmldom';
 import { X_RESPONSE_STALE_REASON } from 'hyperview/src/services/dom/types';
 import { createTestProps } from 'hyperview/src/services';
 

--- a/src/services/dom/index.test.js
+++ b/src/services/dom/index.test.js
@@ -13,10 +13,10 @@ import * as UrlService from 'hyperview/src/services/url';
 import { X_RESPONSE_STALE_REASON } from './types';
 import { version } from 'hyperview/package.json';
 
-// Mock instawork-xmldom module
+// Mock @instawork/xmldom module
 const mockExpectedDocument = { foo: 'bar' };
 const mockParseFromString = jest.fn().mockReturnValue(mockExpectedDocument);
-jest.mock('xmldom-instawork', () => {
+jest.mock('@instawork/xmldom', () => {
   const DOMParser = () => null;
   DOMParser.prototype.parseFromString = (...args) =>
     mockParseFromString.apply(this, args);

--- a/src/services/dom/parser.js
+++ b/src/services/dom/parser.js
@@ -22,7 +22,7 @@ import {
   HTTP_METHODS,
   X_RESPONSE_STALE_REASON,
 } from './types';
-import { DOMParser } from 'xmldom-instawork';
+import { DOMParser } from '@instawork/xmldom';
 import { Dimensions } from 'react-native';
 import type { Document } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';

--- a/src/services/index.test.js
+++ b/src/services/index.test.js
@@ -16,7 +16,7 @@ import {
   encodeXml,
   flattenRegistry,
 } from 'hyperview/src/services';
-import { DOMParser } from 'xmldom-instawork';
+import { DOMParser } from '@instawork/xmldom';
 import HvDateField from 'hyperview/src/components/hv-date-field';
 import HvPickerField from 'hyperview/src/components/hv-picker-field';
 import HvSelectMultiple from 'hyperview/src/components/hv-select-multiple';

--- a/storybook/helpers.js
+++ b/storybook/helpers.js
@@ -3,7 +3,7 @@
 import * as Components from 'hyperview/src/services/components';
 import * as Dom from 'hyperview/src/services/dom';
 import * as Stylesheets from 'hyperview/src/services/stylesheets';
-import { DOMParser } from 'xmldom-instawork';
+import { DOMParser } from '@instawork/xmldom';
 import type { HvComponent } from 'hyperview/src/types';
 import humps from 'humps';
 import { storiesOf } from '@storybook/react-native';

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -13,7 +13,7 @@ import * as Dom from 'hyperview/src/services/dom';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Stylesheets from 'hyperview/src/services/stylesheets';
 import type { Element, HvComponent, LocalName } from 'hyperview/src/types';
-import { DOMParser } from 'xmldom-instawork';
+import { DOMParser } from '@instawork/xmldom';
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,6 +1454,13 @@
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
   integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
+"@instawork/xmldom@0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@instawork/xmldom/-/xmldom-0.0.2.tgz#3c6348fc9dfd101cb939aa41d149274a3781ce27"
+  integrity sha512-6a0WM8OcgnAujFksEcdynrESb1OciKHEPWgSSinSO++oDgICTdMpzvK2j1gfVo1i1o8QC641q67DkJccvf48BA==
+  dependencies:
+    string.prototype.matchall "3.0.1"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -14992,12 +14999,6 @@ xmldoc@^1.1.2:
   integrity sha512-ruPC/fyPNck2BD1dpz0AZZyrEwMOrWTO5lDdIXS91rs3wtm4j+T8Rp2o+zoOYkkAxJTZRPOSnOGei1egoRmKMQ==
   dependencies:
     sax "^1.2.1"
-
-xmldom-instawork@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/xmldom-instawork/-/xmldom-instawork-0.0.1.tgz#57c7351a68126d3407c6a685588bc51eef8e3623"
-  dependencies:
-    string.prototype.matchall "3.0.1"
 
 xmldom@0.1.x:
   version "0.1.27"


### PR DESCRIPTION
Addresses https://github.com/Instawork/hyperview/issues/520

Switching from `xmldom-instawork` NPM package to `@instawork/xmldom`. The new NPM package is branched from a version of https://github.com/xmldom/xmldom that has a critical security fix. We applied our own parser error fix on top of it.

NOTE: before creating a full release, we will create a pre-release on NPM to do a full regression test.

### Testing
- [x] Tested the Hyperview demo app, no issues encountered
- [x] Test integration into Instawork's apps
- [x] Verify the parse error is still fixed on Android 