### PR TITLE
fix(navigation) - corrected source path in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperview",
   "version": "0.67.0",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "description": "React Native client for Hyperview XML",
   "homepage": "https://hyperview.org",
   "keywords": [


### PR DESCRIPTION
The main path in package was reverted to 'lib' during merging latest master