### PR TITLE
chore(cleanup) - avoid xml lookups

### DIFF
--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -49,6 +49,9 @@ export type NavigatorMapContextProps = {
 export type State = {
   doc?: TypesLegacy.Document;
   error?: Error;
+  navigator?: TypesLegacy.Element;
+  root?: TypesLegacy.Element;
+  screen?: TypesLegacy.Element;
 };
 
 /**


### PR DESCRIPTION
Storing root, navigator, and screen into state to avoid having to look them up in XML every render