### PR TITLE
fix(navigation) - ensure correct element index

### DIFF
--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -23,6 +23,13 @@ const Stack = NavigatorService.createStackNavigator<Types.ParamTypes>();
 const BottomTab = NavigatorService.createBottomTabNavigator();
 
 export default class HvNavigator extends PureComponent<Types.Props> {
+  uuid: string;
+
+  constructor(props: Types.Props) {
+    super(props);
+    this.uuid = Date.now().toString();
+  }
+
   /**
    * Build an individual tab screen
    */
@@ -72,7 +79,8 @@ export default class HvNavigator extends PureComponent<Types.Props> {
     // For stack navigators, the dynamic screens are added later
     // This iteration will also process nested navigators
     //    and retrieve additional urls from child routes
-    elements.forEach((navRoute: TypesLegacy.Element) => {
+    for (let index = 0; index < elements.length; index += 1) {
+      const navRoute: TypesLegacy.Element = elements[index];
       if (navRoute.localName === TypesLegacy.LOCAL_NAME.NAV_ROUTE) {
         const id:
           | TypesLegacy.DOMString
@@ -91,7 +99,12 @@ export default class HvNavigator extends PureComponent<Types.Props> {
         );
         if (nestedNavigator) {
           // Cache the navigator for the route
-          navigatorMapContext.setElement(id, nestedNavigator);
+          // using the unique instance id of this navigator, the id of the route, and the index
+          // to ensure it's injected into the correct route
+          navigatorMapContext.setElement(
+            `${this.uuid}:${id}:${index}`,
+            nestedNavigator,
+          );
         } else {
           const href:
             | TypesLegacy.DOMString
@@ -116,7 +129,9 @@ export default class HvNavigator extends PureComponent<Types.Props> {
           screens.push(buildTabScreen(id, type));
         }
       }
-    });
+    }
+
+    const initialParams = { parentId: this.uuid };
 
     // Add the dynamic stack screens
     if (type === NavigatorService.NAVIGATOR_TYPE.STACK) {
@@ -127,7 +142,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
           component={this.props.routeComponent}
           getId={({ params }: Types.ScreenParams) => params.url}
           // empty object required because hv-screen doesn't check for undefined param
-          initialParams={{}}
+          initialParams={initialParams}
           name={NavigatorService.ID_DYNAMIC}
         />,
       );
@@ -139,7 +154,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
           component={this.props.routeComponent}
           getId={({ params }: Types.ScreenParams) => params.url}
           // empty object required because hv-screen doesn't check for undefined param
-          initialParams={{}}
+          initialParams={initialParams}
           name={NavigatorService.ID_MODAL}
           options={{ presentation: 'modal' }}
         />,

--- a/src/core/components/hv-navigator/types.ts
+++ b/src/core/components/hv-navigator/types.ts
@@ -12,6 +12,7 @@ import { FC } from 'react';
 export type RouteParams = {
   id?: string;
   url: string;
+  parentId?: string;
 };
 
 export type ParamTypes = {

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -363,15 +363,22 @@ export default function HvRoute(props: Types.Props) {
     url = url || '';
   }
 
-  const { index, type } = props.navigation?.getState() || {};
-  // The nested element is only used when the navigator is not a stack
-  //    or is the first screen in a stack. Other stack screens will require a url
-  const includeElement: boolean =
-    type !== NavigatorService.NAVIGATOR_TYPE.STACK || index === 0;
+  // Get the index of the route in the stack
+  const state = props.navigation?.getState();
+  let index = -1;
+  if (state && state.routes) {
+    index = state.routes.findIndex(r => r.key === props.route?.key);
+  }
 
   // Get the navigator element from the context
-  const element: TypesLegacy.Element | undefined =
-    id && includeElement ? navigatorMapContext.getElement(id) : undefined;
+  // The parentId is injected into params by hv-navigator
+  // The element was stored by id by hv-navigator
+  const routeElementId: string | undefined = id
+    ? `${props.route?.params?.parentId || 'none'}:${id}:${index}`
+    : undefined;
+  const element: TypesLegacy.Element | undefined = routeElementId
+    ? navigatorMapContext.getElement(routeElementId)
+    : undefined;
 
   return (
     <HvRouteInner

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -19,6 +19,7 @@ type RouteParams = {
   id?: string;
   url: string;
   preloadScreen?: number;
+  parentId?: string;
 };
 
 export type NavigationContextProps = {


### PR DESCRIPTION
The original implementation assumed the first route was the only one with a nested element:
\<navigator\>
   \<nav-route ...\>
      \<navigator ...\/>
   \</nav-route\>
\</navigator\>

The index was assumed based on the document being read and built only once (index=0 on first run).

These changes allow for the correct element to be injected into the correct route regardless of its position or of the current index of the navigator state. They are necessary to properly handle deep link state updates.

Asana: https://app.asana.com/0/0/1205157207660925/f