### PR TITLE
fix(navigator) - improved handling of nested navigators

### DIFF
--- a/src/contexts/navigator-map.tsx
+++ b/src/contexts/navigator-map.tsx
@@ -12,8 +12,6 @@ import React, { createContext, useState } from 'react';
 export type NavigatorMapContextProps = {
   setRoute: (key: string, route: string) => void;
   getRoute: (key: string) => string | undefined;
-  setElement: (key: string, element: TypesLegacy.Element) => void;
-  getElement: (key: string) => TypesLegacy.Element | undefined;
   setPreload: (key: number, element: TypesLegacy.Element) => void;
   getPreload: (key: number) => TypesLegacy.Element | undefined;
   initialRouteName?: string;
@@ -28,10 +26,8 @@ export type NavigatorMapContextProps = {
  *  - preloadMap: A map of preload elements by their id
  */
 export const NavigatorMapContext = createContext<NavigatorMapContextProps>({
-  getElement: () => undefined,
   getPreload: () => undefined,
   getRoute: () => '',
-  setElement: () => undefined,
   setPreload: () => undefined,
   setRoute: () => undefined,
 });
@@ -44,7 +40,6 @@ type Props = { children: React.ReactNode };
  */
 export function NavigatorMapProvider(props: Props) {
   const [routeMap] = useState<Map<string, string>>(new Map());
-  const [elementMap] = useState<Map<string, TypesLegacy.Element>>(new Map());
   const [preloadMap] = useState<Map<number, TypesLegacy.Element>>(new Map());
 
   const setRoute = (key: string, route: string) => {
@@ -53,14 +48,6 @@ export function NavigatorMapProvider(props: Props) {
 
   const getRoute = (key: string): string | undefined => {
     return routeMap.get(key);
-  };
-
-  const setElement = (key: string, element: TypesLegacy.Element) => {
-    elementMap.set(key, element);
-  };
-
-  const getElement = (key: string): TypesLegacy.Element | undefined => {
-    return elementMap.get(key);
   };
 
   const setPreload = (key: number, element: TypesLegacy.Element) => {
@@ -74,10 +61,8 @@ export function NavigatorMapProvider(props: Props) {
   return (
     <NavigatorMapContext.Provider
       value={{
-        getElement,
         getPreload,
         getRoute,
-        setElement,
         setPreload,
         setRoute,
       }}

--- a/src/contexts/navigator-map.tsx
+++ b/src/contexts/navigator-map.tsx
@@ -14,7 +14,6 @@ export type NavigatorMapContextProps = {
   getRoute: (key: string) => string | undefined;
   setPreload: (key: number, element: TypesLegacy.Element) => void;
   getPreload: (key: number) => TypesLegacy.Element | undefined;
-  initialRouteName?: string;
 };
 
 /**
@@ -22,7 +21,6 @@ export type NavigatorMapContextProps = {
  * Each navigator creates its own context
  *  - routeMap: Urls defined in <nav-route> elements are stored in the routeMap by their key
  *  - elementMap: Contains element sub-navigators defined in a <nav-route> element
- *  - initialRouteName: The name of the first route to render
  *  - preloadMap: A map of preload elements by their id
  */
 export const NavigatorMapContext = createContext<NavigatorMapContextProps>({

--- a/src/contexts/route-doc.tsx
+++ b/src/contexts/route-doc.tsx
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import * as TypesLegacy from 'hyperview/src/types-legacy';
+import { createContext } from 'react';
+
+export type RouteDocContextProps = {
+  doc?: TypesLegacy.Document;
+};
+
+export const Context = createContext<TypesLegacy.Document | undefined>(
+  undefined,
+);

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -89,10 +89,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
           navRoute,
           TypesLegacy.LOCAL_NAME.NAVIGATOR,
         );
-        if (nestedNavigator) {
-          // Cache the navigator for the route
-          navigatorMapContext.setElement(id, nestedNavigator);
-        } else {
+        if (!nestedNavigator) {
           const href:
             | TypesLegacy.DOMString
             | null

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -26,13 +26,23 @@ export default class HvNavigator extends PureComponent<Types.Props> {
   /**
    * Build an individual tab screen
    */
-  buildTabScreen = (
+  buildScreen = (
     id: string,
     type: TypesLegacy.DOMString,
   ): React.ReactElement => {
     if (type === NavigatorService.NAVIGATOR_TYPE.TAB) {
       return (
         <BottomTab.Screen
+          key={id}
+          component={this.props.routeComponent}
+          initialParams={{ id }}
+          name={id}
+        />
+      );
+    }
+    if (type === NavigatorService.NAVIGATOR_TYPE.STACK) {
+      return (
+        <Stack.Screen
           key={id}
           component={this.props.routeComponent}
           initialParams={{ id }}
@@ -63,7 +73,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
       throw new NavigatorService.HvRouteError('No context found');
     }
 
-    const { buildTabScreen } = this;
+    const { buildScreen } = this;
     const elements: TypesLegacy.Element[] = NavigatorService.getChildElements(
       element,
     );
@@ -108,11 +118,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
           // Cache the url for the route by nav-route id
           navigatorMapContext.setRoute(id, url);
         }
-
-        // 'stack' uses route urls, other types build out the screens
-        if (type !== NavigatorService.NAVIGATOR_TYPE.STACK) {
-          screens.push(buildTabScreen(id, type));
-        }
+        screens.push(buildScreen(id, type));
       }
     });
 
@@ -184,16 +190,14 @@ export default class HvNavigator extends PureComponent<Types.Props> {
     const initialId: string | undefined = initial
       .getAttribute('id')
       ?.toString();
-    if (initialId) {
-      navigatorMapContext.initialRouteName = initialId;
-    }
+
     const { buildScreens } = this;
     switch (type) {
       case NavigatorService.NAVIGATOR_TYPE.STACK:
         return (
           <Stack.Navigator
             id={id}
-            initialRouteName={NavigatorService.ID_DYNAMIC}
+            initialRouteName={initialId}
             screenOptions={({ route }: Types.NavigatorParams) => ({
               header: undefined,
               headerMode: 'screen',

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -12,7 +12,7 @@ import * as NavigatorService from 'hyperview/src/services/navigator';
 import * as Types from './types';
 import * as TypesLegacy from 'hyperview/src/types-legacy';
 import React, { PureComponent, useContext } from 'react';
-import { getFirstTag } from 'hyperview/src/services/dom/helpers-legacy';
+import { getFirstChildTag } from 'hyperview/src/services/dom/helpers-legacy';
 
 /**
  * Flag to show the navigator UIs
@@ -85,10 +85,11 @@ export default class HvNavigator extends PureComponent<Types.Props> {
         }
 
         // Check for nested navigators
-        const nestedNavigator: TypesLegacy.Element | null = getFirstTag(
+        const nestedNavigator: TypesLegacy.Element | null = getFirstChildTag<TypesLegacy.Element>(
           navRoute,
           TypesLegacy.LOCAL_NAME.NAVIGATOR,
         );
+
         if (!nestedNavigator) {
           const href:
             | TypesLegacy.DOMString

--- a/src/core/components/hv-navigator/types.ts
+++ b/src/core/components/hv-navigator/types.ts
@@ -14,10 +14,7 @@ export type RouteParams = {
   url: string;
 };
 
-export type ParamTypes = {
-  dynamic: RouteParams;
-  modal: RouteParams;
-};
+export type ParamTypes = Record<string, RouteParams>;
 
 export type ScreenParams = {
   params: RouteParams;

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -344,11 +344,12 @@ const getNestedNavigator = (
     });
   const route = routes && routes.length > 0 ? routes[0] : undefined;
   if (route) {
-    const navigators = route.getElementsByTagNameNS(
-      Namespaces.HYPERVIEW,
-      TypesLegacy.LOCAL_NAME.NAVIGATOR,
+    return (
+      Helpers.getFirstChildTag<TypesLegacy.Element>(
+        route,
+        TypesLegacy.LOCAL_NAME.NAVIGATOR,
+      ) || undefined
     );
-    return navigators && navigators.length > 0 ? navigators[0] : undefined;
   }
   return undefined;
 };

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -51,9 +51,6 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     this.state = {
       doc: undefined,
       error: undefined,
-      navigator: undefined,
-      root: undefined,
-      screen: undefined,
     };
     this.navLogic = new NavigatorService.Navigator(this.props);
     this.componentRegistry = Components.getRegistry(this.props.components);
@@ -93,9 +90,6 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
       this.setState({
         doc: undefined,
         error: new NavigatorService.HvRouteError('No parser or context found'),
-        navigator: undefined,
-        root: undefined,
-        screen: undefined,
       });
       return;
     }
@@ -104,26 +98,14 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
       const url: string = this.getUrl();
 
       const { doc } = await this.parser.loadDocument(url);
-      const root = Helpers.getFirstTag(doc, TypesLegacy.LOCAL_NAME.DOC);
-      const navigator = Helpers.getFirstTag(
-        doc,
-        TypesLegacy.LOCAL_NAME.NAVIGATOR,
-      );
-      const screen = Helpers.getFirstTag(doc, TypesLegacy.LOCAL_NAME.SCREEN);
       this.setState({
         doc,
         error: undefined,
-        navigator: navigator || undefined,
-        root: root || undefined,
-        screen: screen || undefined,
       });
     } catch (err: unknown) {
       this.setState({
         doc: undefined,
         error: err as Error,
-        navigator: undefined,
-        root: undefined,
-        screen: undefined,
       });
     }
   };
@@ -137,18 +119,34 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     }
 
     // Get the <doc> element
-    if (!this.state.root) {
+    const root: TypesLegacy.Element | null = Helpers.getFirstTag(
+      this.state.doc,
+      TypesLegacy.LOCAL_NAME.DOC,
+    );
+    if (!root) {
       throw new NavigatorService.HvRenderError('No root element found');
     }
 
     // Get the first child as <screen> or <navigator>
-    if (!this.state.screen && !this.state.navigator) {
-      throw new NavigatorService.HvRenderError(
-        'No <screen> or <navigator> element found',
-      );
+    const screenElement: TypesLegacy.Element | null = Helpers.getFirstTag(
+      root,
+      TypesLegacy.LOCAL_NAME.SCREEN,
+    );
+    if (screenElement) {
+      return screenElement;
     }
 
-    return this.state.screen || this.state.navigator || null;
+    const navigatorElement: TypesLegacy.Element | null = Helpers.getFirstTag(
+      root,
+      TypesLegacy.LOCAL_NAME.NAVIGATOR,
+    );
+    if (navigatorElement) {
+      return navigatorElement;
+    }
+
+    throw new NavigatorService.HvRenderError(
+      'No <screen> or <navigator> element found',
+    );
   };
 
   registerPreload = (id: number, element: TypesLegacy.Element): void => {

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -344,23 +344,24 @@ export default function HvRoute(props: Types.Props) {
     url = navigatorMapContext.getRoute(NavigatorService.cleanHrefFragment(url));
   }
 
-  if (!url) {
-    // Use the route id if available to look up the url
-    if (props.route?.params?.id) {
-      url = navigatorMapContext.getRoute(props.route.params.id);
-    } else if (navigatorMapContext.initialRouteName) {
-      // Try to use the initial route for this <navigator>
-      url = navigatorMapContext.getRoute(navigatorMapContext.initialRouteName);
-    }
-  }
-
-  // Fall back to the entrypoint url
-  url = url || navigationContext.entrypointUrl;
-
   const id: string | undefined =
     props.route?.params?.id ||
     navigatorMapContext.initialRouteName ||
     undefined;
+
+  if (!url) {
+    // Use the route id or initial routeto look up the url
+    if (id) {
+      url = navigatorMapContext.getRoute(id);
+    }
+  }
+
+  // Fall back to the entrypoint url, only for the top route
+  if (!url && !props.navigation) {
+    url = navigationContext.entrypointUrl;
+  } else {
+    url = url || '';
+  }
 
   const { index, type } = props.navigation?.getState() || {};
   // The nested element is only used when the navigator is not a stack

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -40,7 +40,6 @@ export type NavigationContextProps = {
 
 export type NavigatorMapContextProps = {
   getRoute: (key: string) => string | undefined;
-  getElement: (key: string) => TypesLegacy.Element | undefined;
   setPreload: (key: number, element: TypesLegacy.Element) => void;
   getPreload: (key: number) => TypesLegacy.Element | undefined;
   initialRouteName?: string;
@@ -78,7 +77,6 @@ export type InnerRouteProps = {
   loadingScreen?: ComponentType<LoadingProps>;
   handleBack?: ComponentType<{ children: ReactNode }>;
   getRoute: (key: string) => string | undefined;
-  getElement: (key: string) => TypesLegacy.Element | undefined;
   setPreload: (key: number, element: TypesLegacy.Element) => void;
   getPreload: (key: number) => TypesLegacy.Element | undefined;
   initialRouteName?: string;

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -49,9 +49,6 @@ export type NavigatorMapContextProps = {
 export type State = {
   doc?: TypesLegacy.Document;
   error?: Error;
-  navigator?: TypesLegacy.Element;
-  root?: TypesLegacy.Element;
-  screen?: TypesLegacy.Element;
 };
 
 /**

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -42,7 +42,6 @@ export type NavigatorMapContextProps = {
   getRoute: (key: string) => string | undefined;
   setPreload: (key: number, element: TypesLegacy.Element) => void;
   getPreload: (key: number) => TypesLegacy.Element | undefined;
-  initialRouteName?: string;
 };
 
 export type State = {
@@ -59,8 +58,7 @@ export type RouteProps = NavigatorService.Route<string, { url?: string }>;
  * The props used by inner components of hv-route
  */
 export type InnerRouteProps = {
-  id?: string;
-  url: string;
+  url?: string;
   navigation?: NavigatorService.NavigationProp;
   route?: NavigatorService.Route<string, RouteParams>;
   entrypointUrl: string;
@@ -79,7 +77,6 @@ export type InnerRouteProps = {
   getRoute: (key: string) => string | undefined;
   setPreload: (key: number, element: TypesLegacy.Element) => void;
   getPreload: (key: number) => TypesLegacy.Element | undefined;
-  initialRouteName?: string;
   element?: TypesLegacy.Element;
 };
 

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -49,6 +49,9 @@ export type NavigatorMapContextProps = {
 export type State = {
   doc?: TypesLegacy.Document;
   error?: Error;
+  navigator?: TypesLegacy.Element;
+  root?: TypesLegacy.Element;
+  screen?: TypesLegacy.Element;
 };
 
 /**

--- a/src/services/dom/helpers-legacy.ts
+++ b/src/services/dom/helpers-legacy.ts
@@ -15,7 +15,9 @@ import {
   Document,
   Element,
   LocalName,
+  NODE_TYPE,
   NamespaceURI,
+  Node,
 } from 'hyperview/src/types-legacy';
 
 export const getFirstTag = (
@@ -26,6 +28,30 @@ export const getFirstTag = (
   const elements = document.getElementsByTagNameNS(namespace, localName);
   if (elements && elements[0]) {
     return elements[0];
+  }
+  return null;
+};
+
+/**
+ * Find the first child element of a node with a given local name and namespace
+ */
+export const getFirstChildTag = <T extends Node>(
+  node: Node,
+  localName: LocalName,
+  namespace: NamespaceURI = Namespaces.HYPERVIEW,
+): T | null => {
+  if (!node || !node.childNodes) {
+    return null;
+  }
+  for (let i = 0; i < node.childNodes.length; i += 1) {
+    const child = node.childNodes[i];
+    if (
+      child.nodeType === NODE_TYPE.ELEMENT_NODE &&
+      child.localName === localName &&
+      child.namespaceURI === namespace
+    ) {
+      return child as T;
+    }
   }
   return null;
 };

--- a/src/types-legacy.ts
+++ b/src/types-legacy.ts
@@ -73,6 +73,9 @@ export type DOMString = string;
 export type NamespaceURI = string;
 
 export type NodeList<T> = {
+  // ***** ADDED *****
+  filter: (predicate: (item: T) => boolean) => T[];
+
   length: number;
   item: (index: number) => T | null | undefined;
 } & {


### PR DESCRIPTION
The original implementation for handling `<navigator>` elements nested inside `<nav-route>` elements relied on storing Dom elements in a map by the id of the route which contained them.

This had several problems:
- A cache had to be created
- The items in the cache could become orphaned from their parent doc
  - Mutations to the doc would not be reflected in the cache
- The cache was never cleared
- The id or index of the implementation could change

This new solution uses a context to wrap every `hv-route` which contains its own document. This allows child routes to retrieve their Dom element and retrieve any nested navigator direction from the doc.

Improvements are also made to the initial route by creating all routes into the stack navigator.