### PR TITLE
chore(initial) - Change 'initial' attribute to 'selected'

### DIFF
--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -1195,7 +1195,7 @@
       </xs:sequence>
       <xs:attribute name="id" use="required" type="hv:ID" />
       <xs:attribute name="href" use="required" type="xs:string" />
-      <xs:attribute name="initial" type="xs:boolean" />
+      <xs:attribute name="selected" type="xs:boolean" />
     </xs:complexType>
   </xs:element>
 

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -174,20 +174,20 @@ export default class HvNavigator extends PureComponent<Types.Props> {
       | TypesLegacy.DOMString
       | null
       | undefined = props.element.getAttribute('type');
-    const initial:
+    const selected:
       | TypesLegacy.Element
-      | undefined = NavigatorService.getInitialNavRouteElement(props.element);
-    if (!initial) {
+      | undefined = NavigatorService.getSelectedNavRouteElement(props.element);
+    if (!selected) {
       throw new NavigatorService.HvNavigatorError(
-        `No initial route defined for '${id}'`,
+        `No selected route defined for '${id}'`,
       );
     }
 
-    const initialId: string | undefined = initial
+    const selectedId: string | undefined = selected
       .getAttribute('id')
       ?.toString();
-    if (initialId) {
-      navigatorMapContext.initialRouteName = initialId;
+    if (selectedId) {
+      navigatorMapContext.initialRouteName = selectedId;
     }
     const { buildScreens } = this;
     switch (type) {
@@ -211,7 +211,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
           <BottomTab.Navigator
             backBehavior="none"
             id={id}
-            initialRouteName={initialId}
+            initialRouteName={selectedId}
             screenOptions={{
               headerShown: SHOW_NAVIGATION_UI,
               tabBarStyle: { display: SHOW_NAVIGATION_UI ? 'flex' : 'none' },

--- a/src/services/navigator/helpers.test.ts
+++ b/src/services/navigator/helpers.test.ts
@@ -1,7 +1,7 @@
 import * as DomErrors from '../dom/errors';
 import * as Errors from './errors';
-import * as Imports from './imports';
 import * as Namespaces from '../namespaces';
+import * as Types from './types';
 import * as TypesLegacy from '../../types-legacy';
 import { ID_DYNAMIC, ID_MODAL } from './types';
 import {
@@ -10,9 +10,9 @@ import {
   cleanHrefFragment,
   findPath,
   getChildElements,
-  getInitialNavRouteElement,
   getNavAction,
   getRouteId,
+  getSelectedNavRouteElement,
   getUrlFromHref,
   isNavigationElement,
   isUrlFragment,
@@ -24,14 +24,14 @@ import StateSource from './test.state.json';
 
 /**
  * Test document response
- * Includes a navigator with two routes, the second of which is marked as initial
+ * Includes a navigator with two routes, the second of which is marked as selected
  */
 const navDocSource =
-  '<doc xmlns="https://hyperview.org/hyperview"><navigator id="navigator"><nav-route id="route1" href="/route1" /><nav-route id="route2" href="/route2" initial="true" /></navigator></doc>';
+  '<doc xmlns="https://hyperview.org/hyperview"><navigator id="navigator"><nav-route id="route1" href="/route1" /><nav-route id="route2" href="/route2" selected="true" /></navigator></doc>';
 
 /**
  * Alternate test document response
- * Includes a navigator with two routes, neither of which is marked as initial
+ * Includes a navigator with two routes, neither of which is marked as selected
  */
 const navDocSourceAlt =
   '<doc xmlns="https://hyperview.org/hyperview"><navigator id="navigator"><nav-route id="route1" href="/route1" /><nav-route id="route2" href="/route2" /></navigator></doc>';
@@ -135,26 +135,26 @@ describe('isNavigationElement', () => {
   });
 });
 
-describe('getInitialNavRouteElement', () => {
-  it('should find route2 as initial', () => {
+describe('getSelectedNavRouteElement', () => {
+  it('should find route2 as selected', () => {
     const doc = parser.parseFromString(navDocSource);
     const navigators = doc.getElementsByTagNameNS(
       Namespaces.HYPERVIEW,
       'navigator',
     );
-    const initial = getInitialNavRouteElement(navigators[0]);
-    expect(initial?.getAttribute('id')).toEqual('route2');
+    const selected = getSelectedNavRouteElement(navigators[0]);
+    expect(selected?.getAttribute('id')).toEqual('route2');
   });
-  it('should find route1 as initial', () => {
+  it('should find route1 as selected', () => {
     const doc = parser.parseFromString(navDocSourceAlt);
     const navigators = doc.getElementsByTagNameNS(
       Namespaces.HYPERVIEW,
       'navigator',
     );
-    const initial = getInitialNavRouteElement(navigators[0]);
-    expect(initial?.getAttribute('id')).toEqual('route1');
+    const selected = getSelectedNavRouteElement(navigators[0]);
+    expect(selected?.getAttribute('id')).toEqual('route1');
   });
-  it('should not find an initial route', () => {
+  it('should not find an selected route', () => {
     const doc = parser.parseFromString(
       '<doc xmlns="https://hyperview.org/hyperview"><navigator id="navigator"></navigator></doc>',
     );
@@ -162,8 +162,8 @@ describe('getInitialNavRouteElement', () => {
       Namespaces.HYPERVIEW,
       'navigator',
     );
-    const initial = getInitialNavRouteElement(navigators[0]);
-    expect(initial).toBeUndefined();
+    const selected = getSelectedNavRouteElement(navigators[0]);
+    expect(selected).toBeUndefined();
   });
 });
 
@@ -318,7 +318,7 @@ describe('validateUrl', () => {
 });
 
 describe('findPath', () => {
-  const state = StateSource as Imports.NavigationState;
+  const state = StateSource as Types.NavigationState;
   describe('found', () => {
     const path = findPath(state, 'performance_2');
     it('should find the path 3 levels from the top', () => {

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -36,9 +36,9 @@ export const isNavigationElement = (element: TypesLegacy.Element): boolean => {
 };
 
 /**
- * Get the route designated as 'initial' or the first route if none is marked
+ * Get the route designated as 'selected' or the first route if none is marked
  */
-export const getInitialNavRouteElement = (
+export const getSelectedNavRouteElement = (
   element: TypesLegacy.Element,
 ): TypesLegacy.Element | undefined => {
   const elements: TypesLegacy.Element[] = getChildElements(
@@ -49,11 +49,11 @@ export const getInitialNavRouteElement = (
     return undefined;
   }
 
-  const initialChild = elements.find(
-    child => child.getAttribute('initial')?.toLowerCase() === 'true',
+  const selectedChild = elements.find(
+    child => child.getAttribute('selected')?.toLowerCase() === 'true',
   );
 
-  return initialChild || elements[0];
+  return selectedChild || elements[0];
 };
 
 /**

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -126,7 +126,7 @@ export {
   isUrlFragment,
   cleanHrefFragment,
   getChildElements,
-  getInitialNavRouteElement,
+  getSelectedNavRouteElement,
   getUrlFromHref,
 } from './helpers';
 export { ID_DYNAMIC, ID_MODAL, NAVIGATOR_TYPE } from './types';


### PR DESCRIPTION
To better reflect both the initial state and the potential tracking of current state, the 'initial' attribute is being renamed 'selected'

- Updated method name in helpers and exports
- Updated tests
- Updated schema