### PR TITLE
feature(selection) - Track the current selection state of each nav-route

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -386,15 +386,7 @@ const getNestedNavigator = (
     return undefined;
   }
 
-  const routes = doc
-    .getElementsByTagNameNS(
-      Namespaces.HYPERVIEW,
-      TypesLegacy.LOCAL_NAME.NAV_ROUTE,
-    )
-    .filter((n: TypesLegacy.Element) => {
-      return n.getAttribute('id') === id;
-    });
-  const route = routes && routes.length > 0 ? routes[0] : undefined;
+  const route = NavigatorService.getRouteById(doc, id);
   if (route) {
     return (
       Helpers.getFirstChildTag<TypesLegacy.Element>(

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -430,6 +430,17 @@ export default function HvRoute(props: Types.Props) {
     routeDocContext,
   );
 
+  React.useEffect(() => {
+    if (props.navigation) {
+      const unsubscribe = props.navigation.addListener('focus', () => {
+        NavigatorService.setSelected(routeDocContext, props.route?.params?.id);
+      });
+
+      return unsubscribe;
+    }
+    return undefined;
+  }, [props.navigation, props.route?.params?.id, routeDocContext]);
+
   return (
     <HvRouteInner
       // eslint-disable-next-line react/jsx-props-no-spreading

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -447,3 +447,31 @@ export const mergeDocument = (
   mergeNodes(currentRoot, newRoot.childNodes);
   return composite;
 };
+
+export const setSelected = (
+  routeDocContext: TypesLegacy.Document | undefined,
+  id: string | undefined,
+) => {
+  if (!routeDocContext || !id) {
+    return;
+  }
+  const route = getRouteById(routeDocContext, id);
+  if (route) {
+    // Reset all siblings
+    if (route.parentNode && route.parentNode.childNodes) {
+      Array.from(route.parentNode.childNodes).forEach(
+        (sibling: TypesLegacy.Node) => {
+          if (sibling.localName === TypesLegacy.LOCAL_NAME.NAV_ROUTE) {
+            (sibling as TypesLegacy.Element)?.setAttribute(
+              Types.KEY_SELECTED,
+              'false',
+            );
+          }
+        },
+      );
+    }
+
+    // Set the selected route
+    route.setAttribute(Types.KEY_SELECTED, 'true');
+  }
+};

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -15,13 +15,6 @@ import * as UrlService from 'hyperview/src/services/url';
 import { ANCHOR_ID_SEPARATOR } from './types';
 
 /**
- * Type defining a map of <id, element>
- */
-type RouteMap = {
-  [key: string]: TypesLegacy.Element;
-};
-
-/**
  * Get an array of all child elements of a node
  */
 export const getChildElements = (
@@ -231,6 +224,24 @@ export const getRouteId = (
 };
 
 /**
+ * Search for a route with the given id
+ */
+export const getRouteById = (
+  doc: TypesLegacy.Document,
+  id: string,
+): TypesLegacy.Element | undefined => {
+  const routes = doc
+    .getElementsByTagNameNS(
+      Namespaces.HYPERVIEW,
+      TypesLegacy.LOCAL_NAME.NAV_ROUTE,
+    )
+    .filter((n: TypesLegacy.Element) => {
+      return n.getAttribute('id') === id;
+    });
+  return routes && routes.length > 0 ? routes[0] : undefined;
+};
+
+/**
  * Determine the action to perform based on the route params
  * Correct for a push action being introduced in
  * `this.getRouteKey(url);` in `hyperview/src/services/navigation`
@@ -317,8 +328,8 @@ export const buildRequest = (
  */
 const nodesToMap = (
   nodes: TypesLegacy.NodeList<TypesLegacy.Node>,
-): RouteMap => {
-  const map: RouteMap = {};
+): Types.RouteMap => {
+  const map: Types.RouteMap = {};
   if (!nodes) {
     return map;
   }
@@ -335,9 +346,6 @@ const nodesToMap = (
   });
   return map;
 };
-
-const KEY_MERGE = 'merge';
-const KEY_SELECTED = 'selected';
 
 /**
  * Merge the nodes from the new document into the current
@@ -359,14 +367,14 @@ const mergeNodes = (
     const element = node as TypesLegacy.Element;
     if (isNavigationElement(element)) {
       if (element.localName === TypesLegacy.LOCAL_NAME.NAVIGATOR) {
-        element.setAttribute(KEY_MERGE, 'false');
+        element.setAttribute(Types.KEY_MERGE, 'false');
       } else if (element.localName === TypesLegacy.LOCAL_NAME.NAV_ROUTE) {
-        element.setAttribute(KEY_SELECTED, 'false');
+        element.setAttribute(Types.KEY_SELECTED, 'false');
       }
     }
   });
 
-  const currentMap: RouteMap = nodesToMap(current.childNodes);
+  const currentMap: Types.RouteMap = nodesToMap(current.childNodes);
 
   Array.from(newNodes).forEach(node => {
     if (node.nodeType === TypesLegacy.NODE_TYPE.ELEMENT_NODE) {
@@ -379,7 +387,7 @@ const mergeNodes = (
             if (newElement.localName === TypesLegacy.LOCAL_NAME.NAVIGATOR) {
               const isMergeable = newElement.getAttribute('merge') === 'true';
               if (isMergeable) {
-                currentElement.setAttribute(KEY_MERGE, 'true');
+                currentElement.setAttribute(Types.KEY_MERGE, 'true');
                 mergeNodes(currentElement, newElement.childNodes);
               } else {
                 current.replaceChild(newElement, currentElement);
@@ -389,8 +397,8 @@ const mergeNodes = (
             ) {
               // Update the selected route
               currentElement.setAttribute(
-                KEY_SELECTED,
-                newElement.getAttribute(KEY_SELECTED) || 'false',
+                Types.KEY_SELECTED,
+                newElement.getAttribute(Types.KEY_SELECTED) || 'false',
               );
               mergeNodes(currentElement, newElement.childNodes);
             }

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -130,5 +130,6 @@ export {
   getSelectedNavRouteElement,
   getUrlFromHref,
   mergeDocument,
+  setSelected,
 } from './helpers';
 export { ID_DYNAMIC, ID_MODAL, NAVIGATOR_TYPE } from './types';

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -126,6 +126,7 @@ export {
   isUrlFragment,
   cleanHrefFragment,
   getChildElements,
+  getRouteById,
   getSelectedNavRouteElement,
   getUrlFromHref,
   mergeDocument,

--- a/src/services/navigator/types.ts
+++ b/src/services/navigator/types.ts
@@ -11,6 +11,8 @@ import * as TypesLegacy from 'hyperview/src/types-legacy';
 export const ANCHOR_ID_SEPARATOR = '#';
 export const ID_DYNAMIC = 'dynamic';
 export const ID_MODAL = 'modal';
+export const KEY_MERGE = 'merge';
+export const KEY_SELECTED = 'selected';
 
 /**
  * Definition of the available navigator types
@@ -63,4 +65,11 @@ export type NavigationState = {
   stale: false;
   type: string;
   history?: unknown[];
+};
+
+/**
+ * Type defining a map of <id, element>
+ */
+export type RouteMap = {
+  [key: string]: TypesLegacy.Element;
 };

--- a/src/services/navigator/types.ts
+++ b/src/services/navigator/types.ts
@@ -39,6 +39,7 @@ export type NavigationProp = {
   goBack: () => void;
   getState: () => NavigationState;
   getParent: (id?: string) => NavigationProp | undefined;
+  addListener: (event: string, callback: () => void) => void;
 };
 
 /**

--- a/src/types-legacy.ts
+++ b/src/types-legacy.ts
@@ -93,6 +93,7 @@ export type Node = {
   readonly namespaceURI: NamespaceURI | null | undefined;
   readonly nextSibling: Node | null | undefined;
   readonly nodeType: NodeType;
+  parentNode: Node | null | undefined;
   appendChild: (newChild: Node) => Node;
   hasChildNodes: () => boolean;
   replaceChild: (newChild: Node, oldChild: Node) => Node;


### PR DESCRIPTION
Reflect the user's selections in the document

- Use the 'focus' listener to allow each hv-route to set its selected state within the document
- De-select any sibling routes to ensure the current is the only selected

Note: I did not use 'blur' to have each route deselect itself as that would cause routes in the background to lose their state.

In the video, as the user selects between the different tabs, the various \<nav-route\> children of `tabs-navigator` are shown to reflect current selection. When the `company` modal is popped up, the `company` \<nav-route\> shows selected while its sibling `tabs-route` becomes deselected. Note that the `tabs-navigator` children retain their correct selection state.

Asana: https://app.asana.com/0/0/1205197138955014/f

https://github.com/Instawork/hyperview/assets/127122858/0687558f-c500-419a-bd69-bbd0843ade72

