### PR TITLE
chore(nav-routes) - Update to support adding all defined routes to navigators

### DIFF
--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -1197,6 +1197,7 @@
       <xs:attribute name="id" use="required" type="hv:ID" />
       <xs:attribute name="href" use="required" type="xs:string" />
       <xs:attribute name="selected" type="xs:boolean" />
+      <xs:attribute name="modal" type="xs:boolean" />
     </xs:complexType>
   </xs:element>
 

--- a/src/contexts/navigator-map.tsx
+++ b/src/contexts/navigator-map.tsx
@@ -10,8 +10,6 @@ import * as TypesLegacy from 'hyperview/src/types-legacy';
 import React, { createContext, useState } from 'react';
 
 export type NavigatorMapContextProps = {
-  setRoute: (key: string, route: string) => void;
-  getRoute: (key: string) => string | undefined;
   setPreload: (key: number, element: TypesLegacy.Element) => void;
   getPreload: (key: number) => TypesLegacy.Element | undefined;
 };
@@ -25,9 +23,7 @@ export type NavigatorMapContextProps = {
  */
 export const NavigatorMapContext = createContext<NavigatorMapContextProps>({
   getPreload: () => undefined,
-  getRoute: () => '',
   setPreload: () => undefined,
-  setRoute: () => undefined,
 });
 
 type Props = { children: React.ReactNode };
@@ -37,16 +33,7 @@ type Props = { children: React.ReactNode };
  * store runtime information about the navigator and urls.
  */
 export function NavigatorMapProvider(props: Props) {
-  const [routeMap] = useState<Map<string, string>>(new Map());
   const [preloadMap] = useState<Map<number, TypesLegacy.Element>>(new Map());
-
-  const setRoute = (key: string, route: string) => {
-    routeMap.set(key, route);
-  };
-
-  const getRoute = (key: string): string | undefined => {
-    return routeMap.get(key);
-  };
 
   const setPreload = (key: number, element: TypesLegacy.Element) => {
     preloadMap.set(key, element);
@@ -60,9 +47,7 @@ export function NavigatorMapProvider(props: Props) {
     <NavigatorMapContext.Provider
       value={{
         getPreload,
-        getRoute,
         setPreload,
-        setRoute,
       }}
     >
       {props.children}

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -114,9 +114,6 @@ export default class HvNavigator extends PureComponent<Types.Props> {
             href,
             navigationContext?.entrypointUrl,
           );
-
-          // Cache the url for the route by nav-route id
-          navigatorMapContext.setRoute(id, url);
         }
         screens.push(buildScreen(id, type));
       }

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -29,13 +29,16 @@ export default class HvNavigator extends PureComponent<Types.Props> {
   buildScreen = (
     id: string,
     type: TypesLegacy.DOMString,
+    href: TypesLegacy.DOMString | undefined,
+    isModal: boolean,
   ): React.ReactElement => {
+    const initialParams = { id, url: href };
     if (type === NavigatorService.NAVIGATOR_TYPE.TAB) {
       return (
         <BottomTab.Screen
           key={id}
           component={this.props.routeComponent}
-          initialParams={{ id }}
+          initialParams={initialParams}
           name={id}
         />
       );
@@ -45,8 +48,9 @@ export default class HvNavigator extends PureComponent<Types.Props> {
         <Stack.Screen
           key={id}
           component={this.props.routeComponent}
-          initialParams={{ id }}
+          initialParams={initialParams}
           name={id}
+          options={{ presentation: isModal ? 'modal' : 'card' }}
         />
       );
     }
@@ -93,6 +97,12 @@ export default class HvNavigator extends PureComponent<Types.Props> {
             `No id provided for ${navRoute.localName}`,
           );
         }
+        const href:
+          | TypesLegacy.DOMString
+          | null
+          | undefined = navRoute.getAttribute('href');
+        const isModal =
+          navRoute.getAttribute(NavigatorService.KEY_MODAL) === 'true';
 
         // Check for nested navigators
         const nestedNavigator: TypesLegacy.Element | null = getFirstChildTag<TypesLegacy.Element>(
@@ -100,22 +110,12 @@ export default class HvNavigator extends PureComponent<Types.Props> {
           TypesLegacy.LOCAL_NAME.NAVIGATOR,
         );
 
-        if (!nestedNavigator) {
-          const href:
-            | TypesLegacy.DOMString
-            | null
-            | undefined = navRoute.getAttribute('href');
-          if (!href) {
-            throw new NavigatorService.HvNavigatorError(
-              `No href provided for route '${id}'`,
-            );
-          }
-          const url = NavigatorService.getUrlFromHref(
-            href,
-            navigationContext?.entrypointUrl,
+        if (!nestedNavigator && !href) {
+          throw new NavigatorService.HvNavigatorError(
+            `No href provided for route '${id}'`,
           );
         }
-        screens.push(buildScreen(id, type));
+        screens.push(buildScreen(id, type, href || undefined, isModal));
       }
     });
 
@@ -178,15 +178,10 @@ export default class HvNavigator extends PureComponent<Types.Props> {
     const selected:
       | TypesLegacy.Element
       | undefined = NavigatorService.getSelectedNavRouteElement(props.element);
-    if (!selected) {
-      throw new NavigatorService.HvNavigatorError(
-        `No selected route defined for '${id}'`,
-      );
-    }
 
     const selectedId: string | undefined = selected
-      .getAttribute('id')
-      ?.toString();
+      ? selected.getAttribute('id')?.toString()
+      : undefined;
 
     const { buildScreens } = this;
     switch (type) {

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -189,7 +189,6 @@ export default class HvNavigator extends PureComponent<Types.Props> {
         return (
           <Stack.Navigator
             id={id}
-            initialRouteName={selectedId}
             screenOptions={({ route }: Types.NavigatorParams) => ({
               header: undefined,
               headerMode: 'screen',

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -348,31 +348,15 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
 const getRouteUrl = (
   props: Types.Props,
   navigationContext: Types.NavigationContextProps,
-  navigatorMapContext: Types.NavigatorMapContextProps,
 ) => {
   // The initial hv-route element will use the entrypoint url
   if (props.navigation === undefined) {
     return navigationContext.entrypointUrl;
   }
 
-  // Use the passed url
-  if (props.route?.params?.url) {
-    if (NavigatorService.isUrlFragment(props.route?.params?.url)) {
-      // Look up the url from the route map where it would have been
-      //  stored from the initial <nav-route> definition
-      return navigatorMapContext.getRoute(
-        NavigatorService.cleanHrefFragment(props.route?.params?.url),
-      );
-    }
-    return props.route?.params?.url;
-  }
-
-  // Look up by route id
-  if (props.route?.params?.id) {
-    return navigatorMapContext.getRoute(props.route?.params?.id);
-  }
-
-  return undefined;
+  return props.route?.params?.url
+    ? NavigatorService.cleanHrefFragment(props.route?.params?.url)
+    : undefined;
 };
 
 /**
@@ -422,7 +406,7 @@ export default function HvRoute(props: Types.Props) {
     RouteDocContext.Context,
   );
 
-  const url = getRouteUrl(props, navigationContext, navigatorMapContext);
+  const url = getRouteUrl(props, navigationContext);
 
   // Get the navigator element from the context
   const element: TypesLegacy.Element | undefined = getNestedNavigator(

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -386,15 +386,7 @@ const getNestedNavigator = (
     return undefined;
   }
 
-  const routes = doc
-    .getElementsByTagNameNS(
-      Namespaces.HYPERVIEW,
-      TypesLegacy.LOCAL_NAME.NAV_ROUTE,
-    )
-    .filter((n: TypesLegacy.Element) => {
-      return n.getAttribute('id') === id;
-    });
-  const route = routes && routes.length > 0 ? routes[0] : undefined;
+  const route = NavigatorService.getRouteById(doc, id);
   if (route) {
     return (
       Helpers.getFirstChildTag<TypesLegacy.Element>(

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -430,6 +430,17 @@ export default function HvRoute(props: Types.Props) {
     routeDocContext,
   );
 
+  React.useEffect(() => {
+    if (props.navigation) {
+      const unsubscribe = props.navigation.addListener('focus', () => {
+        NavigatorService.setSelected(routeDocContext, props.route?.params?.id);
+      });
+
+      return unsubscribe;
+    }
+    return undefined;
+  }, [props.navigation, props.route?.params?.id, routeDocContext]);
+
   return (
     <HvRouteInner
       // eslint-disable-next-line react/jsx-props-no-spreading

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -39,7 +39,6 @@ export type NavigationContextProps = {
 };
 
 export type NavigatorMapContextProps = {
-  getRoute: (key: string) => string | undefined;
   setPreload: (key: number, element: TypesLegacy.Element) => void;
   getPreload: (key: number) => TypesLegacy.Element | undefined;
 };
@@ -75,7 +74,6 @@ export type InnerRouteProps = {
   errorScreen?: ComponentType<ErrorProps>;
   loadingScreen?: ComponentType<LoadingProps>;
   handleBack?: ComponentType<{ children: ReactNode }>;
-  getRoute: (key: string) => string | undefined;
   setPreload: (key: number, element: TypesLegacy.Element) => void;
   getPreload: (key: number) => TypesLegacy.Element | undefined;
   element?: TypesLegacy.Element;

--- a/src/services/navigator/helpers.test.ts
+++ b/src/services/navigator/helpers.test.ts
@@ -207,14 +207,14 @@ describe('getSelectedNavRouteElement', () => {
     const selected = getSelectedNavRouteElement(navigators[0]);
     expect(selected?.getAttribute('id')).toEqual('route2');
   });
-  it('should find route1 as selected', () => {
+  it('should find nothing as selected', () => {
     const doc = parser.parseFromString(navDocSourceAlt);
     const navigators = doc.getElementsByTagNameNS(
       Namespaces.HYPERVIEW,
       'navigator',
     );
     const selected = getSelectedNavRouteElement(navigators[0]);
-    expect(selected?.getAttribute('id')).toEqual('route1');
+    expect(selected).toBeUndefined();
   });
   it('should not find an selected route', () => {
     const doc = parser.parseFromString(
@@ -451,17 +451,45 @@ describe('buildParams', () => {
 });
 
 describe('getRouteId', () => {
-  const urls = ['url', '/url', '#url', '', '#', undefined];
-  describe('simple', () => {
+  describe('fragment', () => {
+    const urls = ['#url', '#'];
     describe('action:push', () => {
       urls.forEach(url => {
-        it(`should return type 'dynamic' from url with static: ${url}`, () => {
-          expect(getRouteId(TypesLegacy.NAV_ACTIONS.PUSH, url, true)).toEqual(
+        it(`should not return route 'dynamic' from url with fragment: ${url}`, () => {
+          expect(getRouteId(TypesLegacy.NAV_ACTIONS.PUSH, url)).not.toEqual(
             ID_DYNAMIC,
           );
         });
-        it(`should return type 'dynamic' from url with non-static: ${url}`, () => {
-          expect(getRouteId(TypesLegacy.NAV_ACTIONS.PUSH, url, false)).toEqual(
+        it(`should return route id with fragment: ${url}`, () => {
+          expect(getRouteId(TypesLegacy.NAV_ACTIONS.PUSH, url)).toEqual(
+            cleanHrefFragment(url),
+          );
+        });
+      });
+    });
+
+    describe('action:new', () => {
+      urls.forEach(url => {
+        it(`should not return type 'modal' from url with fragment: ${url}`, () => {
+          expect(getRouteId(TypesLegacy.NAV_ACTIONS.NEW, url)).not.toEqual(
+            ID_MODAL,
+          );
+        });
+        it(`should return route id with fragment: ${url}`, () => {
+          expect(getRouteId(TypesLegacy.NAV_ACTIONS.NEW, url)).toEqual(
+            cleanHrefFragment(url),
+          );
+        });
+      });
+    });
+  });
+
+  describe('non-fragment', () => {
+    const urls = ['url', '/url', '', undefined];
+    describe('action:push', () => {
+      urls.forEach(url => {
+        it(`should return type 'dynamic' from url with non-fragment: ${url}`, () => {
+          expect(getRouteId(TypesLegacy.NAV_ACTIONS.PUSH, url)).toEqual(
             ID_DYNAMIC,
           );
         });
@@ -470,13 +498,8 @@ describe('getRouteId', () => {
 
     describe('action:new', () => {
       urls.forEach(url => {
-        it(`should return type 'modal' from url with static: ${url}`, () => {
-          expect(getRouteId(TypesLegacy.NAV_ACTIONS.NEW, url, true)).toEqual(
-            ID_MODAL,
-          );
-        });
-        it(`should return type 'modal' from url with non-static: ${url}`, () => {
-          expect(getRouteId(TypesLegacy.NAV_ACTIONS.NEW, url, false)).toEqual(
+        it(`should return type 'modal' from url with non-fragment: ${url}`, () => {
+          expect(getRouteId(TypesLegacy.NAV_ACTIONS.NEW, url)).toEqual(
             ID_MODAL,
           );
         });
@@ -492,19 +515,19 @@ describe('getRouteId', () => {
     ].forEach(action => {
       describe(`action:${action}`, () => {
         ['#url', '#'].forEach(url => {
-          it(`should return cleaned url with static: ${url}`, () => {
-            expect(getRouteId(action, url, true)).toEqual(url.slice(1));
+          it(`should return cleaned url with fragment: ${url}`, () => {
+            expect(getRouteId(action, url)).toEqual(url.slice(1));
           });
-          it(`should return type 'dynamic' from url with non-static: ${url}`, () => {
-            expect(getRouteId(action, url, false)).toEqual(ID_DYNAMIC);
+          it(`should not return type 'dynamic' from url with fragment: ${url}`, () => {
+            expect(getRouteId(action, url)).not.toEqual(ID_DYNAMIC);
           });
         });
         ['url', '/url', '', undefined].forEach(url => {
-          it(`should return cleaned url with static: ${url}`, () => {
-            expect(getRouteId(action, url, true)).toEqual(ID_DYNAMIC);
+          it(`should return cleaned url with non-fragment: ${url}`, () => {
+            expect(getRouteId(action, url)).toEqual(ID_DYNAMIC);
           });
-          it(`should return type 'dynamic' from url with non-static: ${url}`, () => {
-            expect(getRouteId(action, url, false)).toEqual(ID_DYNAMIC);
+          it(`should return type 'dynamic' from url with non-fragment: ${url}`, () => {
+            expect(getRouteId(action, url)).toEqual(ID_DYNAMIC);
           });
         });
       });

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -447,3 +447,31 @@ export const mergeDocument = (
   mergeNodes(currentRoot, newRoot.childNodes);
   return composite;
 };
+
+export const setSelected = (
+  routeDocContext: TypesLegacy.Document | undefined,
+  id: string | undefined,
+) => {
+  if (!routeDocContext || !id) {
+    return;
+  }
+  const route = getRouteById(routeDocContext, id);
+  if (route) {
+    // Reset all siblings
+    if (route.parentNode && route.parentNode.childNodes) {
+      Array.from(route.parentNode.childNodes).forEach(
+        (sibling: TypesLegacy.Node) => {
+          if (sibling.localName === TypesLegacy.LOCAL_NAME.NAV_ROUTE) {
+            (sibling as TypesLegacy.Element)?.setAttribute(
+              Types.KEY_SELECTED,
+              'false',
+            );
+          }
+        },
+      );
+    }
+
+    // Set the selected route
+    route.setAttribute(Types.KEY_SELECTED, 'true');
+  }
+};

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -15,13 +15,6 @@ import * as UrlService from 'hyperview/src/services/url';
 import { ANCHOR_ID_SEPARATOR } from './types';
 
 /**
- * Type defining a map of <id, element>
- */
-type RouteMap = {
-  [key: string]: TypesLegacy.Element;
-};
-
-/**
  * Get an array of all child elements of a node
  */
 export const getChildElements = (
@@ -231,6 +224,24 @@ export const getRouteId = (
 };
 
 /**
+ * Search for a route with the given id
+ */
+export const getRouteById = (
+  doc: TypesLegacy.Document,
+  id: string,
+): TypesLegacy.Element | undefined => {
+  const routes = doc
+    .getElementsByTagNameNS(
+      Namespaces.HYPERVIEW,
+      TypesLegacy.LOCAL_NAME.NAV_ROUTE,
+    )
+    .filter((n: TypesLegacy.Element) => {
+      return n.getAttribute('id') === id;
+    });
+  return routes && routes.length > 0 ? routes[0] : undefined;
+};
+
+/**
  * Determine the action to perform based on the route params
  * Correct for a push action being introduced in
  * `this.getRouteKey(url);` in `hyperview/src/services/navigation`
@@ -317,8 +328,8 @@ export const buildRequest = (
  */
 const nodesToMap = (
   nodes: TypesLegacy.NodeList<TypesLegacy.Node>,
-): RouteMap => {
-  const map: RouteMap = {};
+): Types.RouteMap => {
+  const map: Types.RouteMap = {};
   if (!nodes) {
     return map;
   }
@@ -335,9 +346,6 @@ const nodesToMap = (
   });
   return map;
 };
-
-const KEY_MERGE = 'merge';
-const KEY_SELECTED = 'selected';
 
 /**
  * Merge the nodes from the new document into the current
@@ -359,14 +367,14 @@ const mergeNodes = (
     const element = node as TypesLegacy.Element;
     if (isNavigationElement(element)) {
       if (element.localName === TypesLegacy.LOCAL_NAME.NAVIGATOR) {
-        element.setAttribute(KEY_MERGE, 'false');
+        element.setAttribute(Types.KEY_MERGE, 'false');
       } else if (element.localName === TypesLegacy.LOCAL_NAME.NAV_ROUTE) {
-        element.setAttribute(KEY_SELECTED, 'false');
+        element.setAttribute(Types.KEY_SELECTED, 'false');
       }
     }
   });
 
-  const currentMap: RouteMap = nodesToMap(current.childNodes);
+  const currentMap: Types.RouteMap = nodesToMap(current.childNodes);
 
   Array.from(newNodes).forEach(node => {
     if (node.nodeType === TypesLegacy.NODE_TYPE.ELEMENT_NODE) {
@@ -379,7 +387,7 @@ const mergeNodes = (
             if (newElement.localName === TypesLegacy.LOCAL_NAME.NAVIGATOR) {
               const isMergeable = newElement.getAttribute('merge') === 'true';
               if (isMergeable) {
-                currentElement.setAttribute(KEY_MERGE, 'true');
+                currentElement.setAttribute(Types.KEY_MERGE, 'true');
                 mergeNodes(currentElement, newElement.childNodes);
               } else {
                 current.replaceChild(newElement, currentElement);
@@ -389,8 +397,8 @@ const mergeNodes = (
             ) {
               // Update the selected route
               currentElement.setAttribute(
-                KEY_SELECTED,
-                newElement.getAttribute(KEY_SELECTED) || 'false',
+                Types.KEY_SELECTED,
+                newElement.getAttribute(Types.KEY_SELECTED) || 'false',
               );
               mergeNodes(currentElement, newElement.childNodes);
             }

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -130,5 +130,6 @@ export {
   getSelectedNavRouteElement,
   getUrlFromHref,
   mergeDocument,
+  setSelected,
 } from './helpers';
 export { ID_DYNAMIC, ID_MODAL, NAVIGATOR_TYPE } from './types';

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -132,4 +132,4 @@ export {
   mergeDocument,
   setSelected,
 } from './helpers';
-export { ID_DYNAMIC, ID_MODAL, NAVIGATOR_TYPE } from './types';
+export { ID_DYNAMIC, ID_MODAL, KEY_MODAL, NAVIGATOR_TYPE } from './types';

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -126,6 +126,7 @@ export {
   isUrlFragment,
   cleanHrefFragment,
   getChildElements,
+  getRouteById,
   getSelectedNavRouteElement,
   getUrlFromHref,
   mergeDocument,

--- a/src/services/navigator/types.ts
+++ b/src/services/navigator/types.ts
@@ -11,6 +11,8 @@ import * as TypesLegacy from 'hyperview/src/types-legacy';
 export const ANCHOR_ID_SEPARATOR = '#';
 export const ID_DYNAMIC = 'dynamic';
 export const ID_MODAL = 'modal';
+export const KEY_MERGE = 'merge';
+export const KEY_SELECTED = 'selected';
 
 /**
  * Definition of the available navigator types
@@ -63,4 +65,11 @@ export type NavigationState = {
   stale: false;
   type: string;
   history?: unknown[];
+};
+
+/**
+ * Type defining a map of <id, element>
+ */
+export type RouteMap = {
+  [key: string]: TypesLegacy.Element;
 };

--- a/src/services/navigator/types.ts
+++ b/src/services/navigator/types.ts
@@ -13,6 +13,7 @@ export const ID_DYNAMIC = 'dynamic';
 export const ID_MODAL = 'modal';
 export const KEY_MERGE = 'merge';
 export const KEY_SELECTED = 'selected';
+export const KEY_MODAL = 'modal';
 
 /**
  * Definition of the available navigator types

--- a/src/services/navigator/types.ts
+++ b/src/services/navigator/types.ts
@@ -39,6 +39,7 @@ export type NavigationProp = {
   goBack: () => void;
   getState: () => NavigationState;
   getParent: (id?: string) => NavigationProp | undefined;
+  addListener: (event: string, callback: () => void) => void;
 };
 
 /**

--- a/src/types-legacy.ts
+++ b/src/types-legacy.ts
@@ -93,6 +93,7 @@ export type Node = {
   readonly namespaceURI: NamespaceURI | null | undefined;
   readonly nextSibling: Node | null | undefined;
   readonly nodeType: NodeType;
+  parentNode: Node | null | undefined;
   appendChild: (newChild: Node) => Node;
   hasChildNodes: () => boolean;
   replaceChild: (newChild: Node, oldChild: Node) => Node;


### PR DESCRIPTION
Previous implementation used 'dynamic' and 'modal' routes as the only two children of `stack` navigators. The urls were cached into a context and retrieved by id.
This update allows each defined `\<nav-route\>` to be added to its navigator. These known routes can retain their original url and presentation and reduce the complexity of navigating between them.

One note about the implementation: the 'initialParams' passed into each route contain their actual url. When we navigate to a route through a behavior, the new params are merged with the existing. The url had to explicitly be deleted from the object as passing a url:undefined would overwrite the initial url value with an 'undefined' value.

Asana: https://app.asana.com/0/0/1205197138955012/f