### PR TITLE
chore(modal) - Change iOS presentation to use fullscreen

### DIFF
--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -50,7 +50,12 @@ export default class HvNavigator extends PureComponent<Types.Props> {
           component={this.props.routeComponent}
           initialParams={initialParams}
           name={id}
-          options={{ presentation: isModal ? 'modal' : 'card' }}
+          options={{
+            cardStyleInterpolator: isModal
+              ? NavigatorService.CardStyleInterpolators.forVerticalIOS
+              : undefined,
+            presentation: isModal ? 'modal' : 'card',
+          }}
         />
       );
     }
@@ -142,7 +147,11 @@ export default class HvNavigator extends PureComponent<Types.Props> {
           // empty object required because hv-screen doesn't check for undefined param
           initialParams={{}}
           name={NavigatorService.ID_MODAL}
-          options={{ presentation: 'modal' }}
+          options={{
+            cardStyleInterpolator:
+              NavigatorService.CardStyleInterpolators.forVerticalIOS,
+            presentation: 'modal',
+          }}
         />,
       );
     }

--- a/src/services/navigator/imports.ts
+++ b/src/services/navigator/imports.ts
@@ -11,5 +11,8 @@
  */
 
 export { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-export { createStackNavigator } from '@react-navigation/stack';
+export {
+  CardStyleInterpolators,
+  createStackNavigator,
+} from '@react-navigation/stack';
 export { CommonActions, StackActions } from '@react-navigation/native';

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -120,7 +120,11 @@ export class Navigator {
 }
 
 export type { NavigationProp, Route } from './types';
-export { createStackNavigator, createBottomTabNavigator } from './imports';
+export {
+  CardStyleInterpolators,
+  createStackNavigator,
+  createBottomTabNavigator,
+} from './imports';
 export { HvRouteError, HvNavigatorError, HvRenderError } from './errors';
 export {
   isUrlFragment,


### PR DESCRIPTION
Using the `cardStyleInterpolator` option to force iOS to render modals at full screen while retaining their intended animation.

| Default | Updated iOS | Updated Android |
| ------ | ----- | ----- |
| ![default](https://github.com/Instawork/hyperview/assets/127122858/d7a3d4c7-459b-453e-b454-37e1b56ec62f) | ![iOS](https://github.com/Instawork/hyperview/assets/127122858/239bad17-48fe-40e6-86d4-e4cb1bad4603) | ![android](https://github.com/Instawork/hyperview/assets/127122858/135dd21b-4725-4efa-94eb-5859ac983a94) |

Asana: https://app.asana.com/0/0/1205197143810575/f





