### PR TITLE
fix: Change peer dependencies accepted versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,18 +50,18 @@
     "url-parse": "1.5.10"
   },
   "peerDependencies": {
-    "@react-native-community/datetimepicker": ">= 3.0.3",
-    "@react-native-picker/picker": ">= 2.2.1",
-    "@react-navigation/bottom-tabs": ">= 6.5.7",
-    "@react-navigation/native": ">= 6.1.6",
-    "@react-navigation/stack": ">= 6.3.16",
-    "@types/react": ">= 18.0.28",
-    "react": ">= 16.13.1",
-    "react-native": ">= 0.63.3",
-    "react-native-gesture-handler": ">= 2.11.0",
-    "react-native-keyboard-aware-scrollview": ">= 2.1.0",
-    "react-native-safe-area-context": ">= 4.2.4",
-    "react-native-webview": ">= 10.10.2"
+    "@react-native-community/datetimepicker": "^3.0.3",
+    "@react-native-picker/picker": "^2.2.1",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/stack": "^6.3.16",
+    "@types/react": "^18.0.28",
+    "react": "^16.13.1",
+    "react-native": "^0.63.3",
+    "react-native-gesture-handler": "^2.11.0",
+    "react-native-keyboard-aware-scrollview": "^2.1.0",
+    "react-native-safe-area-context": "^4.2.4",
+    "react-native-webview": "^10.10.2"
   },
   "devDependencies": {
     "@11ty/eleventy": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -52,15 +52,15 @@
   "peerDependencies": {
     "@react-native-community/datetimepicker": ">= 3.0.3",
     "@react-native-picker/picker": ">= 2.2.1",
-    "@react-navigation/bottom-tabs": "6.5.7",
-    "@react-navigation/native": "6.1.6",
-    "@react-navigation/stack": "6.3.16",
-    "@types/react": "18.0.28",
+    "@react-navigation/bottom-tabs": ">= 6.5.7",
+    "@react-navigation/native": ">= 6.1.6",
+    "@react-navigation/stack": ">= 6.3.16",
+    "@types/react": ">= 18.0.28",
     "react": ">= 16.13.1",
     "react-native": ">= 0.63.3",
-    "react-native-gesture-handler": "2.11.0",
+    "react-native-gesture-handler": ">= 2.11.0",
     "react-native-keyboard-aware-scrollview": ">= 2.1.0",
-    "react-native-safe-area-context": "4.2.4",
+    "react-native-safe-area-context": ">= 4.2.4",
     "react-native-webview": ">= 10.10.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Versions on peer dependencies no longer pinned, this will allow for updating these dependencies on target apps without having new NPM/Yarn warnings.