### PR TITLE
refactor(hv-date-field): Add modal overlay

### DIFF
--- a/docs/reference_datefield.md
+++ b/docs/reference_datefield.md
@@ -13,6 +13,7 @@ The `<date-field>` element renders a date picker. The value of the `<date-field>
     field-text-style="Input__Text"
     label-format="MMMM D, YYYY"
     modal-style="PickerModal"
+    modal-overlay-style="PickerModal__overlay"
     modal-text-style="PickerModal__text"
     placeholder="Select date"
     placeholderTextColor="#8D9494"
@@ -36,6 +37,7 @@ A `<date-field>` element can appear anywhere within a `<form>` element.
 - [`field-style`](#field-style)
 - [`field-text-style`](#field-text-style)
 - [`modal-style`](#modal-style)
+- [`modal-overlay-style`](#modal-overlay-style)
 - [`modal-text-style`](#modal-text-style)
 - [`id`](#id)
 - [`hide`](#hide)
@@ -128,6 +130,14 @@ A space-separated list of styles to apply to the date field input label. See [St
 
 A space-separated list of styles to apply to the date selection modal on IOS (Android uses a [system style date picker](https://facebook.github.io/react-native/docs/datepickerandroid)). See [Styles](/docs/reference_style).
 
+#### `modal-overlay-style`
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
+
+A space-separated list of styles to apply to the overlay on date selection modal for IOS (Android uses a [system style date picker](https://facebook.github.io/react-native/docs/datepickerandroid)). See [Styles](/docs/reference_style).
+
 #### `modal-text-style`
 
 | Type   | Required |
@@ -135,6 +145,14 @@ A space-separated list of styles to apply to the date selection modal on IOS (An
 | string | No       |
 
 A space-separated list of styles to apply to the text on date selection modal for IOS (Android uses a [system style date picker](https://facebook.github.io/react-native/docs/datepickerandroid)). See [Styles](/docs/reference_style).
+
+#### `modal-animation-duration`
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+The duration in milliseconds that the open and close animation of the date selection modal for IOS takes. Defaults to 250ms
 
 #### `id`
 

--- a/examples/advanced_behaviors/set_value/index.xml.njk
+++ b/examples/advanced_behaviors/set_value/index.xml.njk
@@ -75,6 +75,10 @@ tags: advanced_behaviors
         shadowOffsetY="-5"
         shadowOpacity="0.2"
         shadowRadius="5"/>
+      <style
+        id="PickerModal_overlay"
+        backgroundColor="#1f1f1fa0"
+      />
       <style id="PickerModal__text" color="blue" fontSize="16" fontWeight="600" marginBottom="16" padding="24">
         <modifier pressed="true">
           <style opacity="0.5"/>
@@ -249,6 +253,7 @@ tags: advanced_behaviors
             id="id_df"
             label-format="MMMM D, YYYY"
             modal-style="PickerModal"
+            modal-overlay-style="PickerModal__overlay"
             modal-text-style="PickerModal__text"
             name="df"
             placeholder="Select date"

--- a/examples/behaviors/blur.xml
+++ b/examples/behaviors/blur.xml
@@ -83,6 +83,7 @@
         shadowOpacity="0.2"
         shadowRadius="5"
       />
+      <style id="PickerModal_overlay" backgroundColor="#1f1f1fa0" />
       <style
         id="PickerModal__text"
         color="blue"
@@ -200,6 +201,7 @@
             field-text-style="Input__Text"
             label-format="MMMM D, YYYY"
             modal-style="PickerModal"
+            modal-overlay-style="PickerModal__overlay"
             modal-text-style="PickerModal__text"
             name="date1"
             mode="spinner"

--- a/examples/behaviors/change.xml
+++ b/examples/behaviors/change.xml
@@ -83,6 +83,7 @@
         shadowOpacity="0.2"
         shadowRadius="5"
       />
+      <style id="PickerModal_overlay" backgroundColor="#1f1f1fa0" />
       <style
         id="PickerModal__text"
         color="blue"
@@ -252,6 +253,7 @@
             field-text-style="Input__Text"
             label-format="MMMM D, YYYY"
             modal-style="PickerModal"
+            modal-overlay-style="PickerModal__overlay"
             modal-text-style="PickerModal__text"
             name="date1"
             mode="spinner"

--- a/examples/behaviors/focus.xml
+++ b/examples/behaviors/focus.xml
@@ -83,6 +83,7 @@
         shadowOpacity="0.2"
         shadowRadius="5"
       />
+      <style id="PickerModal_overlay" backgroundColor="#1f1f1fa0" />
       <style
         id="PickerModal__text"
         color="blue"
@@ -200,6 +201,7 @@
             field-text-style="Input__Text"
             label-format="MMMM D, YYYY"
             modal-style="PickerModal"
+            modal-overlay-style="PickerModal__overlay"
             modal-text-style="PickerModal__text"
             name="date1"
             mode="spinner"

--- a/examples/ui_elements/forms/date_field/index.xml.njk
+++ b/examples/ui_elements/forms/date_field/index.xml.njk
@@ -41,6 +41,10 @@ tags: forms
     shadowOffsetY="-5"
     shadowOpacity="0.2"
     shadowRadius="5"/>
+  <style
+    id="PickerModal_overlay"
+    backgroundColor="#1f1f1fa0"
+  />
   <style id="help--error" color="#FF4847"/>
   <style
     id="Input"
@@ -66,6 +70,7 @@ tags: forms
     </modifier>
   </style>
   <style id="PickerModalCustom" backgroundColor="purple" borderTopColor="#E1E1E1" borderTopWidth="1"/>
+  <style id="PickerModalCustom_overlay" backgroundColor="purple" opacity="0.4" />
   <style id="PickerModalCustom__text" color="white" fontSize="20" fontWeight="600" padding="24" paddingBottom="0">
     <modifier pressed="true">
       <style color="yellow"/>
@@ -91,6 +96,7 @@ tags: forms
           field-style="Input"
           field-text-style="Input__Text"
           label-format="MMMM D, YYYY"
+          modal-overlay-style="PickerModal_overlay"
           modal-style="PickerModal"
           modal-text-style="PickerModal__text"
           name="date"
@@ -104,6 +110,7 @@ tags: forms
           field-text-style="Input__Text"
           label-format="MMMM D, YYYY"
           modal-style="PickerModal"
+          modal-overlay-style="PickerModal_overlay"
           modal-text-style="PickerModal__text"
           mode="spinner"
           name="date"
@@ -116,6 +123,7 @@ tags: forms
           field-style="Input"
           field-text-style="Input__Text"
           label-format="MMMM D, YYYY"
+          modal-overlay-style="PickerModal_overlay"
           modal-style="PickerModal"
           modal-text-style="PickerModal__text"
           name="date"
@@ -129,6 +137,7 @@ tags: forms
           field-style="Input"
           field-text-style="Input__Text"
           label-format="MMMM D, YYYY"
+          modal-overlay-style="PickerModal_overlay"
           modal-style="PickerModal"
           modal-text-style="PickerModal__text"
           name="date"
@@ -139,6 +148,7 @@ tags: forms
           field-style="Input"
           field-text-style="Input__Text"
           label-format="L"
+          modal-overlay-style="PickerModal_overlay"
           modal-style="PickerModal"
           modal-text-style="PickerModal__text"
           name="date"
@@ -149,6 +159,7 @@ tags: forms
           field-style="Input"
           field-text-style="Input__Text"
           label-format="MMMM [the] Do, [`]YY"
+          modal-overlay-style="PickerModal_overlay"
           modal-style="PickerModal"
           modal-text-style="PickerModal__text"
           name="date"
@@ -163,6 +174,7 @@ tags: forms
           field-text-style="Input__Text"
           label-format="MMMM D, YYYY"
           min="2018-05-05"
+          modal-overlay-style="PickerModal_overlay"
           modal-style="PickerModal"
           modal-text-style="PickerModal__text"
           name="date"
@@ -174,6 +186,7 @@ tags: forms
           label-format="MMMM D, YYYY"
           min="2018-05-05"
           modal-style="PickerModal"
+          modal-overlay-style="PickerModal_overlay"
           modal-text-style="PickerModal__text"
           mode="spinner"
           name="date"
@@ -187,6 +200,7 @@ tags: forms
           field-text-style="Input__Text"
           label-format="MMMM D, YYYY"
           max="2024-05-05"
+          modal-overlay-style="PickerModal_overlay"
           modal-style="PickerModal"
           modal-text-style="PickerModal__text"
           name="date"
@@ -198,6 +212,7 @@ tags: forms
           label-format="MMMM D, YYYY"
           max="2024-05-05"
           modal-style="PickerModal"
+          modal-overlay-style="PickerModal_overlay"
           modal-text-style="PickerModal__text"
           mode="spinner"
           name="date"
@@ -212,6 +227,7 @@ tags: forms
           label-format="MMMM D, YYYY"
           max="2024-05-05"
           min="2018-05-05"
+          modal-overlay-style="PickerModal_overlay"
           modal-style="PickerModal"
           modal-text-style="PickerModal__text"
           name="date"
@@ -224,6 +240,7 @@ tags: forms
           max="2024-05-05"
           min="2018-05-05"
           modal-style="PickerModal"
+          modal-overlay-style="PickerModal_overlay"
           modal-text-style="PickerModal__text"
           mode="spinner"
           name="date"
@@ -236,6 +253,7 @@ tags: forms
           field-style="Input Input--Error"
           field-text-style="Input__Text Input__Text--Error"
           label-format="MMMM D, YYYY"
+          modal-overlay-style="PickerModal_overlay"
           modal-style="PickerModal"
           modal-text-style="PickerModal__text"
           name="date"
@@ -249,6 +267,7 @@ tags: forms
           field-style="Input Input--Error"
           field-text-style="Input__Text Input__Text--Error"
           label-format="MMMM D, YYYY"
+          modal-overlay-style="PickerModal_overlay"
           modal-style="PickerModal"
           modal-text-style="PickerModal__text"
           name="date"
@@ -263,6 +282,7 @@ tags: forms
           field-style="InputCustom"
           field-text-style="InputCustom__Text"
           label-format="MMMM D, YYYY"
+          modal-overlay-style="PickerModalCustom_overlay"
           modal-style="PickerModalCustom"
           modal-text-style="PickerModalCustom__text"
           name="date"

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -969,6 +969,8 @@
       <xs:attribute name="field-style" type="hv:styleList" />
       <xs:attribute name="field-text-style" type="hv:styleList" />
       <xs:attribute name="modal-style" type="hv:styleList" />
+      <xs:attribute name="modal-overlay-style" type="hv:styleList" />
+      <xs:attribute name="modal-animation-duration" type="xs:integer" />
       <xs:attribute name="modal-text-style" type="hv:styleList" />
       <xs:attribute name="id" type="hv:ID" />
       <xs:attribute name="key" type="hv:KEY" />

--- a/src/components/hv-date-field/modal/index.js
+++ b/src/components/hv-date-field/modal/index.js
@@ -8,11 +8,13 @@
  *
  */
 
-import { Modal, View } from 'react-native';
+import { Animated, Modal, View } from 'react-native';
+import React, { useRef, useState } from 'react';
+import type { LayoutEvent } from 'react-native/Libraries/Types/CoreEventTypes';
 import ModalButton from '../modal-button';
 import type { Node } from 'react';
+import Overlay from '../overlay';
 import type { Props } from './types';
-import React from 'react';
 import type { StyleSheet } from 'hyperview/src/types';
 import { createStyleProp } from 'hyperview/src/services';
 import styles from './styles';
@@ -23,7 +25,11 @@ import styles from './styles';
  * This is used on iOS only.
  */
 export default (props: Props): Node => {
-  const modalStyle: Array<StyleSheet> = createStyleProp(
+  const [visible, setVisible] = useState(props.isFocused());
+  const [height, setHeight] = useState(0);
+
+  const translateY = useRef(new Animated.Value(0)).current;
+  const style: Array<StyleSheet> = createStyleProp(
     props.element,
     props.stylesheets,
     {
@@ -43,34 +49,83 @@ export default (props: Props): Node => {
       styleAttr: 'modal-text-style',
     });
 
+  const overlayStyle: Array<StyleSheet> = createStyleProp(
+    props.element,
+    props.stylesheets,
+    {
+      ...props.options,
+      styleAttr: 'modal-overlay-style',
+    },
+  );
+
   const onChange = (evt: Event, date?: Date) => {
     props.setPickerValue(date);
   };
 
+  const onLayout = (event: LayoutEvent) => {
+    setHeight(event.nativeEvent.layout.height);
+  };
+
+  const animationDuration: number =
+    parseInt(props.element.getAttribute('modal-animation-duration'), 10) || 250;
+
+  const animate = (
+    fromValue: number,
+    toValue: number,
+    callback?: ({ finished: boolean }) => void,
+  ) => () => {
+    translateY.setValue(fromValue);
+    Animated.timing(translateY, {
+      duration: animationDuration,
+      toValue,
+      useNativeDriver: true,
+    }).start(callback);
+  };
+
+  const onShow = animate(height, 0);
+
+  const onDismiss = animate(0, height, ({ finished }) => {
+    if (finished) {
+      setVisible(false);
+      props.onModalCancel();
+    }
+  });
+
+  const onDone = animate(0, height, ({ finished }) => {
+    if (finished) {
+      setVisible(false);
+      props.onModalDone(props.getPickerValue());
+    }
+  });
+
   return (
     <Modal
-      animationType="slide"
       onRequestClose={props.onModalCancel}
+      onShow={onShow}
       transparent
-      visible={props.isFocused()}
+      visible={visible}
     >
-      <View style={styles.modalWrapper}>
-        <View style={modalStyle}>
-          <View style={styles.modalActions}>
+      <Overlay onPress={onDismiss} style={overlayStyle} />
+      <Animated.View
+        onLayout={onLayout}
+        style={[styles.wrapper, { transform: [{ translateY }] }]}
+      >
+        <View style={style}>
+          <View style={styles.actions}>
             <ModalButton
               getStyle={getTextStyle}
               label={cancelLabel}
-              onPress={props.onModalCancel}
+              onPress={onDismiss}
             />
             <ModalButton
               getStyle={getTextStyle}
               label={doneLabel}
-              onPress={() => props.onModalDone(props.getPickerValue())}
+              onPress={onDone}
             />
           </View>
           <props.PickerComponent onChange={onChange} />
         </View>
-      </View>
+      </Animated.View>
     </Modal>
   );
 };

--- a/src/components/hv-date-field/overlay/index.js
+++ b/src/components/hv-date-field/overlay/index.js
@@ -1,0 +1,20 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { TouchableWithoutFeedback, View } from 'react-native';
+import type { Props } from './types';
+import React from 'react';
+import styles from './styles';
+
+export default (props: Props) => (
+  <TouchableWithoutFeedback onPress={props.onPress}>
+    <View style={[styles.overlay, props.style]} />
+  </TouchableWithoutFeedback>
+);

--- a/src/components/hv-date-field/overlay/styles.js
+++ b/src/components/hv-date-field/overlay/styles.js
@@ -11,14 +11,11 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-  actions: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-  wrapper: {
+  overlay: {
     bottom: 0,
     left: 0,
     position: 'absolute',
     right: 0,
+    top: 0,
   },
 });

--- a/src/components/hv-date-field/overlay/types.js
+++ b/src/components/hv-date-field/overlay/types.js
@@ -1,0 +1,16 @@
+// @flow
+
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type { StyleSheet } from 'hyperview/src/types';
+
+export type Props = {|
+  onPress: () => void,
+  style: StyleSheet,
+|};

--- a/src/components/hv-date-field/stories/basic.xml
+++ b/src/components/hv-date-field/stories/basic.xml
@@ -29,6 +29,7 @@
         shadowOpacity="0.2"
         shadowRadius="5"
       />
+      <style id="PickerModal_overlay" backgroundColor="#1f1f1fa0" />
       <style
         id="PickerModal__text"
         color="blue"
@@ -48,6 +49,7 @@
         field-text-style="Input__Text"
         label-format="MMMM D, YYYY"
         modal-style="PickerModal"
+        modal-overlay-style="PickerModal__overlay"
         modal-text-style="PickerModal__text"
         placeholder="Select date"
         placeholderTextColor="#8D9494"

--- a/storybook/templates.gen.js
+++ b/storybook/templates.gen.js
@@ -32,6 +32,7 @@ export default {
         shadowOpacity="0.2"
         shadowRadius="5"
       />
+      <style id="PickerModal_overlay" backgroundColor="#1f1f1fa0" />
       <style
         id="PickerModal__text"
         color="blue"
@@ -51,6 +52,7 @@ export default {
         field-text-style="Input__Text"
         label-format="MMMM D, YYYY"
         modal-style="PickerModal"
+        modal-overlay-style="PickerModal__overlay"
         modal-text-style="PickerModal__text"
         placeholder="Select date"
         placeholderTextColor="#8D9494"


### PR DESCRIPTION
This updates the UX of the date field component, by adding an overlay / "scrim" element covering the screen under the modal. The overlay is tappable and dismiss the modal (same action as pressing the "cancel" button). Both opening and closing action cause the modal to slide up and down in an animated fashion.

Implementation details:
The slide up animation of the modal is recreated with an animated view - this is needed so that the overlay can be decoupled from this animation.

Another refactor will follow to pull out the modal + overlay components, in order to share/reuse these with the picker field.


https://github.com/Instawork/hyperview/assets/309515/f7f0ad93-a31c-417b-857e-b588512e99ca

