### PR TITLE
fix(state) - override the state.doc

### DIFF
--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -50,7 +50,12 @@ export default class HvNavigator extends PureComponent<Types.Props> {
           component={this.props.routeComponent}
           initialParams={initialParams}
           name={id}
-          options={{ presentation: isModal ? 'modal' : 'card' }}
+          options={{
+            cardStyleInterpolator: isModal
+              ? NavigatorService.CardStyleInterpolators.forVerticalIOS
+              : undefined,
+            presentation: isModal ? 'modal' : 'card',
+          }}
         />
       );
     }
@@ -142,7 +147,11 @@ export default class HvNavigator extends PureComponent<Types.Props> {
           // empty object required because hv-screen doesn't check for undefined param
           initialParams={{}}
           name={NavigatorService.ID_MODAL}
-          options={{ presentation: 'modal' }}
+          options={{
+            cardStyleInterpolator:
+              NavigatorService.CardStyleInterpolators.forVerticalIOS,
+            presentation: 'modal',
+          }}
         />,
       );
     }

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -57,6 +57,19 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     this.componentRegistry = Components.getRegistry(this.props.components);
   }
 
+  /**
+   * Override the state to clear the doc when an element is passed
+   */
+  static getDerivedStateFromProps(
+    props: Types.InnerRouteProps,
+    state: Types.State,
+  ) {
+    if (props.element) {
+      return { ...state, doc: undefined };
+    }
+    return state;
+  }
+
   componentDidMount() {
     this.parser = new DomService.Parser(
       this.props.fetch,
@@ -231,11 +244,6 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
       },
     };
 
-    // If an element is passed, do not pass the doc
-    const doc = this.props.element
-      ? undefined
-      : this.state.doc?.cloneNode(true);
-
     return (
       <Contexts.DateFormatContext.Consumer>
         {formatter => (
@@ -244,7 +252,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
             behaviors={this.props.behaviors}
             closeModal={this.navLogic.closeModal}
             components={this.props.components}
-            doc={doc}
+            doc={this.state.doc?.cloneNode(true)}
             elementErrorComponent={this.props.elementErrorComponent}
             entrypointUrl={this.props.entrypointUrl}
             errorScreen={this.props.errorScreen}
@@ -284,7 +292,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     }
 
     if (renderElement.localName === TypesLegacy.LOCAL_NAME.NAVIGATOR) {
-      if (!this.props.element && this.state.doc) {
+      if (this.state.doc) {
         // The <RouteDocContext> provides doc access to nested navigators
         // only pass it when the doc is available and is not being overridden by an element
         return (

--- a/src/services/navigator/imports.ts
+++ b/src/services/navigator/imports.ts
@@ -11,5 +11,8 @@
  */
 
 export { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-export { createStackNavigator } from '@react-navigation/stack';
+export {
+  CardStyleInterpolators,
+  createStackNavigator,
+} from '@react-navigation/stack';
 export { CommonActions, StackActions } from '@react-navigation/native';

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -120,7 +120,11 @@ export class Navigator {
 }
 
 export type { NavigationProp, Route } from './types';
-export { createStackNavigator, createBottomTabNavigator } from './imports';
+export {
+  CardStyleInterpolators,
+  createStackNavigator,
+  createBottomTabNavigator,
+} from './imports';
 export { HvRouteError, HvNavigatorError, HvRenderError } from './errors';
 export {
   isUrlFragment,


### PR DESCRIPTION
Changed approach to use `getDerivedStateFromProps` to drive the state.doc value