### PR TITLE
fix(`hv-field-picker`): First option not selectable on Android

### DIFF
--- a/src/components/hv-picker-field/index.ios.js
+++ b/src/components/hv-picker-field/index.ios.js
@@ -28,6 +28,7 @@ import Modal from 'hyperview/src/core/components/modal';
 import type { Node } from 'react';
 import Picker from 'hyperview/src/core/components/picker';
 import { View } from 'react-native';
+
 /**
  * A picker field renders a form field with values that come from a pre-defined list.
  * - On iOS, pressing the field brings up a custom bottom sheet with a picker and action buttons.


### PR DESCRIPTION
Note: This PR is one in a series of refactors, see #633 for other related changes.

When the field does not have an empty first value, generate one during rendering to allow the first option to become selectable.

| Before | After |
|--------|-------|
| ![before](https://github.com/Instawork/hyperview/assets/309515/11d9625b-9bcb-467f-bc93-ecd7ceb84e0a) | ![after](https://github.com/Instawork/hyperview/assets/309515/4575bdc4-1ab0-4f0b-a94a-22a6b7b518c1) |




