### PR TITLE
chore(refactor) - small improvements to navigator code organization

### DIFF
--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -204,15 +204,6 @@ export default class HvNavigator extends PureComponent<Types.Props> {
       throw new NavigatorService.HvNavigatorError('No id found for navigator');
     }
 
-    const navigationContext: NavigationContext.NavigationContextProps | null = useContext(
-      NavigationContext.Context,
-    );
-    const navigatorMapContext: NavigatorMapContext.NavigatorMapContextProps | null = useContext(
-      NavigatorMapContext.NavigatorMapContext,
-    );
-    if (!navigationContext || !navigatorMapContext) {
-      throw new NavigatorService.HvRouteError('No context found');
-    }
 
     const type:
       | TypesLegacy.DOMString

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -27,7 +27,6 @@ export default class HvNavigator extends PureComponent<Types.Props> {
    * Encapsulated options for the stack screenOptions
    */
   stackScreenOptions = (
-    id: string,
     route: Types.ScreenParams,
   ): {
     headerMode: 'float' | 'screen' | undefined;
@@ -36,7 +35,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
   } => ({
     headerMode: 'screen',
     headerShown: SHOW_NAVIGATION_UI,
-    title: route.params?.url || id,
+    title: this.getId(route.params),
   });
 
   /**
@@ -226,7 +225,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
           <Stack.Navigator
             id={id}
             screenOptions={({ route }: Types.NavigatorParams) => ({
-              ...this.stackScreenOptions(id, route),
+              ...this.stackScreenOptions(route),
             })}
           >
             {buildScreens(props.element, type)}

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -24,6 +24,39 @@ const BottomTab = NavigatorService.createBottomTabNavigator();
 
 export default class HvNavigator extends PureComponent<Types.Props> {
   /**
+   * Encapsulated options for the stack screenOptions
+   */
+  stackScreenOptions = (
+    id: string,
+    route: Types.ScreenParams,
+  ): {
+    headerMode: 'float' | 'screen' | undefined;
+    headerShown: boolean;
+    title: string | undefined;
+  } => ({
+    headerMode: 'screen',
+    headerShown: SHOW_NAVIGATION_UI,
+    title: route.params?.url || id,
+  });
+
+  /**
+   * Logic to determine the nav route id
+   */
+  getId = (params: Types.RouteParams): string => {
+    if (!params) {
+      throw new NavigatorService.HvNavigatorError('No params found for route');
+    }
+    if (params.id) {
+      if (NavigatorService.isDynamicId(params.id)) {
+        // Dynamic screens use their url as id
+        return params.url || params.id;
+      }
+      return params.id;
+    }
+    return params.url;
+  };
+
+  /**
    * Build an individual tab screen
    */
   buildScreen = (
@@ -48,6 +81,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
         <Stack.Screen
           key={id}
           component={this.props.routeComponent}
+          getId={({ params }: Types.ScreenParams) => this.getId(params)}
           initialParams={initialParams}
           name={id}
           options={{
@@ -199,10 +233,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
           <Stack.Navigator
             id={id}
             screenOptions={({ route }: Types.NavigatorParams) => ({
-              header: undefined,
-              headerMode: 'screen',
-              headerShown: SHOW_NAVIGATION_UI,
-              title: route.params?.url || id,
+              ...this.stackScreenOptions(id, route),
             })}
           >
             {buildScreens(props.element, type)}

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -65,7 +65,9 @@ export default class HvNavigator extends PureComponent<Types.Props> {
     href: TypesLegacy.DOMString | undefined,
     isModal: boolean,
   ): React.ReactElement => {
-    const initialParams = { id, url: href };
+    const initialParams = NavigatorService.isDynamicId(id)
+      ? {}
+      : { id, url: href };
     if (type === NavigatorService.NAVIGATOR_TYPE.TAB) {
       return (
         <BottomTab.Screen
@@ -96,6 +98,33 @@ export default class HvNavigator extends PureComponent<Types.Props> {
     throw new NavigatorService.HvNavigatorError(
       `No navigator found for type '${type}'`,
     );
+  };
+
+  /**
+   * Build the dynamic and modal screens for a stack navigator
+   */
+  buildDynamics = (): React.ReactElement[] => {
+    const screens: React.ReactElement[] = [];
+    // Dynamic is used to display all routes in stack which are presented as cards
+    screens.push(
+      this.buildScreen(
+        NavigatorService.ID_DYNAMIC,
+        NavigatorService.NAVIGATOR_TYPE.STACK,
+        undefined,
+        false,
+      ),
+    );
+
+    // Modal is used to display all routes in stack which are presented as modals
+    screens.push(
+      this.buildScreen(
+        NavigatorService.ID_MODAL,
+        NavigatorService.NAVIGATOR_TYPE.STACK,
+        undefined,
+        true,
+      ),
+    );
+    return screens;
   };
 
   /**
@@ -160,34 +189,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
 
     // Add the dynamic stack screens
     if (type === NavigatorService.NAVIGATOR_TYPE.STACK) {
-      // Dynamic is used to display all routes in stack which are presented as cards
-      screens.push(
-        <Stack.Screen
-          key={NavigatorService.ID_DYNAMIC}
-          component={this.props.routeComponent}
-          getId={({ params }: Types.ScreenParams) => params.url}
-          // empty object required because hv-screen doesn't check for undefined param
-          initialParams={{}}
-          name={NavigatorService.ID_DYNAMIC}
-        />,
-      );
-
-      // Modal is used to display all routes in stack which are presented as modals
-      screens.push(
-        <Stack.Screen
-          key={NavigatorService.ID_MODAL}
-          component={this.props.routeComponent}
-          getId={({ params }: Types.ScreenParams) => params.url}
-          // empty object required because hv-screen doesn't check for undefined param
-          initialParams={{}}
-          name={NavigatorService.ID_MODAL}
-          options={{
-            cardStyleInterpolator:
-              NavigatorService.CardStyleInterpolators.forVerticalIOS,
-            presentation: 'modal',
-          }}
-        />,
-      );
+      screens.push(...this.buildDynamics());
     }
     return screens;
   };

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -205,7 +205,6 @@ export default class HvNavigator extends PureComponent<Types.Props> {
       throw new NavigatorService.HvNavigatorError('No id found for navigator');
     }
 
-
     const type:
       | TypesLegacy.DOMString
       | null

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -28,11 +28,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
    */
   stackScreenOptions = (
     route: Types.ScreenParams,
-  ): {
-    headerMode: 'float' | 'screen' | undefined;
-    headerShown: boolean;
-    title: string | undefined;
-  } => ({
+  ): Types.StackScreenOptions => ({
     headerMode: 'screen',
     headerShown: SHOW_NAVIGATION_UI,
     title: this.getId(route.params),
@@ -223,9 +219,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
         return (
           <Stack.Navigator
             id={id}
-            screenOptions={({ route }: Types.NavigatorParams) => ({
-              ...this.stackScreenOptions(route),
-            })}
+            screenOptions={({ route }) => this.stackScreenOptions(route)}
           >
             {buildScreens(props.element, type)}
           </Stack.Navigator>

--- a/src/core/components/hv-navigator/types.ts
+++ b/src/core/components/hv-navigator/types.ts
@@ -31,3 +31,12 @@ export type Props = {
   element: TypesLegacy.Element;
   routeComponent: FC;
 };
+
+/**
+ * Options used for a stack navigator's screenOptions
+ */
+export type StackScreenOptions = {
+  headerMode: 'float' | 'screen' | undefined;
+  headerShown: boolean;
+  title: string | undefined;
+};

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -110,7 +110,10 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
       // Set the state with the merged document
       this.setState(state => {
         const merged = NavigatorService.mergeDocument(doc, state.doc);
-        const root = Helpers.getFirstTag(merged, TypesLegacy.LOCAL_NAME.DOC);
+        const root = Helpers.getFirstChildTag(
+          merged,
+          TypesLegacy.LOCAL_NAME.DOC,
+        );
         if (!root) {
           return {
             doc: undefined,
@@ -142,7 +145,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     }
 
     // Get the <doc> element
-    const root: TypesLegacy.Element | null = Helpers.getFirstTag(
+    const root: TypesLegacy.Element | null = Helpers.getFirstChildTag(
       this.state.doc,
       TypesLegacy.LOCAL_NAME.DOC,
     );
@@ -151,7 +154,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     }
 
     // Get the first child as <screen> or <navigator>
-    const screenElement: TypesLegacy.Element | null = Helpers.getFirstTag(
+    const screenElement: TypesLegacy.Element | null = Helpers.getFirstChildTag(
       root,
       TypesLegacy.LOCAL_NAME.SCREEN,
     );
@@ -159,7 +162,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
       return screenElement;
     }
 
-    const navigatorElement: TypesLegacy.Element | null = Helpers.getFirstTag(
+    const navigatorElement: TypesLegacy.Element | null = Helpers.getFirstChildTag(
       root,
       TypesLegacy.LOCAL_NAME.NAVIGATOR,
     );

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -20,13 +20,7 @@ import * as Stylesheets from 'hyperview/src/services/stylesheets';
 import * as Types from './types';
 import * as TypesLegacy from 'hyperview/src/types-legacy';
 import * as UrlService from 'hyperview/src/services/url';
-import React, {
-  ComponentType,
-  JSXElementConstructor,
-  PureComponent,
-  ReactNode,
-  useContext,
-} from 'react';
+import React, { JSXElementConstructor, PureComponent, useContext } from 'react';
 import HvNavigator from 'hyperview/src/core/components/hv-navigator';
 import HvScreen from 'hyperview/src/core/components/hv-screen';
 import LoadError from 'hyperview/src/core/components/load-error';
@@ -278,9 +272,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
   /**
    * Evaluate the <doc> element and render the appropriate component
    */
-  Route = (props: {
-    handleBack?: ComponentType<{ children: ReactNode }>;
-  }): React.ReactElement => {
+  Route = (): React.ReactElement => {
     const renderElement: TypesLegacy.Element | null = this.getRenderElement();
 
     if (!renderElement) {
@@ -307,11 +299,11 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     const { Screen } = this;
 
     if (renderElement.localName === TypesLegacy.LOCAL_NAME.SCREEN) {
-      if (props.handleBack) {
+      if (this.props.handleBack) {
         return (
-          <props.handleBack>
+          <this.props.handleBack>
             <Screen />
-          </props.handleBack>
+          </this.props.handleBack>
         );
       }
       return <Screen />;
@@ -334,7 +326,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     }
 
     const { Route } = this;
-    return <Route handleBack={this.props.handleBack} />;
+    return <Route />;
   };
 
   render() {

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -15,6 +15,13 @@ import * as UrlService from 'hyperview/src/services/url';
 import { ANCHOR_ID_SEPARATOR } from './types';
 
 /**
+ * Dynamic and modal routes are not defined in the document
+ */
+export const isDynamicId = (id: string): boolean => {
+  return id === Types.ID_DYNAMIC || id === Types.ID_MODAL;
+};
+
+/**
  * Get an array of all child elements of a node
  */
 export const getChildElements = (

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -127,6 +127,7 @@ export {
 } from './imports';
 export { HvRouteError, HvNavigatorError, HvRenderError } from './errors';
 export {
+  isDynamicId,
   isUrlFragment,
   cleanHrefFragment,
   getChildElements,


### PR DESCRIPTION
A few code refactors which will help the next step:
1. Created a helper to determine if a route id is one of the generated 'dynamic/modal' routes
2. Centralized the `screenOptions` for stack navigators to reduce redundant code
3. Created a better `getId` function for getting the id of dynamic and defined routes
4. Moved the creation of dynamic routes into its own function
5. Re-use `buildScreen` when building dynamic routes to avoid redundant code