### PR TITLE
chore(modal) - add a stack navigator to modals

### DIFF
--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -62,7 +62,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
   ): React.ReactElement => {
     const initialParams = NavigatorService.isDynamicId(id)
       ? {}
-      : { id, url: href };
+      : { id, isModal, url: href };
     if (type === NavigatorService.NAVIGATOR_TYPE.TAB) {
       return (
         <BottomTab.Screen

--- a/src/core/components/hv-navigator/types.ts
+++ b/src/core/components/hv-navigator/types.ts
@@ -29,7 +29,8 @@ export type NavigatorParams = {
  * All of the props used by hv-navigator
  */
 export type Props = {
-  element: TypesLegacy.Element;
+  element?: TypesLegacy.Element;
+  params?: RouteParams;
   routeComponent: FC;
 };
 

--- a/src/core/components/hv-navigator/types.ts
+++ b/src/core/components/hv-navigator/types.ts
@@ -12,6 +12,7 @@ import { FC } from 'react';
 export type RouteParams = {
   id?: string;
   url: string;
+  isModal?: boolean;
 };
 
 export type ParamTypes = Record<string, RouteParams>;

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -19,6 +19,7 @@ type RouteParams = {
   id?: string;
   url: string;
   preloadScreen?: number;
+  isModal?: boolean;
 };
 
 export type NavigationContextProps = {


### PR DESCRIPTION
When a modal is opened, there may be additional navigation which happens within its content. If the modal implements its own stack, those navigation actions can occur within the view of the modal. They can be closed without having to back out of all the screens.

In the following videos, the 'company' view is defined as a modal. Without the stack navigator, the 'edit' action replaces the 'company' view and the user has to go back before closing the modal. With the stack navigator, the user can close the modal at any point.

Note: default react-navigation UI is being used in these videos to simplify the navigation.

| No stack | With stack |
| ---- | ---- |
| ![nostack](https://github.com/Instawork/hyperview/assets/127122858/8fbf265d-2720-4879-812b-7579205291c5) | ![withstack](https://github.com/Instawork/hyperview/assets/127122858/fadd5271-02f0-412c-9a48-051830ec0957) |

Asana: https://app.asana.com/0/1204008699308084/1205225573228523/f

