### PR TITLE
chore(dynamic) - refactor 'dynamic' to 'card'

### DIFF
--- a/src/services/navigator/helpers.test.ts
+++ b/src/services/navigator/helpers.test.ts
@@ -3,7 +3,7 @@ import * as Errors from './errors';
 import * as Namespaces from '../namespaces';
 import * as Types from './types';
 import * as TypesLegacy from '../../types-legacy';
-import { ID_DYNAMIC, ID_MODAL } from './types';
+import { ID_CARD, ID_MODAL } from './types';
 import {
   buildParams,
   buildRequest,
@@ -455,9 +455,9 @@ describe('getRouteId', () => {
     const urls = ['#url', '#'];
     describe('action:push', () => {
       urls.forEach(url => {
-        it(`should not return route 'dynamic' from url with fragment: ${url}`, () => {
+        it(`should not return route 'card' from url with fragment: ${url}`, () => {
           expect(getRouteId(TypesLegacy.NAV_ACTIONS.PUSH, url)).not.toEqual(
-            ID_DYNAMIC,
+            ID_CARD,
           );
         });
         it(`should return route id with fragment: ${url}`, () => {
@@ -488,9 +488,9 @@ describe('getRouteId', () => {
     const urls = ['url', '/url', '', undefined];
     describe('action:push', () => {
       urls.forEach(url => {
-        it(`should return type 'dynamic' from url with non-fragment: ${url}`, () => {
+        it(`should return type 'card' from url with non-fragment: ${url}`, () => {
           expect(getRouteId(TypesLegacy.NAV_ACTIONS.PUSH, url)).toEqual(
-            ID_DYNAMIC,
+            ID_CARD,
           );
         });
       });
@@ -518,16 +518,16 @@ describe('getRouteId', () => {
           it(`should return cleaned url with fragment: ${url}`, () => {
             expect(getRouteId(action, url)).toEqual(url.slice(1));
           });
-          it(`should not return type 'dynamic' from url with fragment: ${url}`, () => {
-            expect(getRouteId(action, url)).not.toEqual(ID_DYNAMIC);
+          it(`should not return type 'card' from url with fragment: ${url}`, () => {
+            expect(getRouteId(action, url)).not.toEqual(ID_CARD);
           });
         });
         ['url', '/url', '', undefined].forEach(url => {
           it(`should return cleaned url with non-fragment: ${url}`, () => {
-            expect(getRouteId(action, url)).toEqual(ID_DYNAMIC);
+            expect(getRouteId(action, url)).toEqual(ID_CARD);
           });
-          it(`should return type 'dynamic' from url with non-fragment: ${url}`, () => {
-            expect(getRouteId(action, url)).toEqual(ID_DYNAMIC);
+          it(`should return type 'card' from url with non-fragment: ${url}`, () => {
+            expect(getRouteId(action, url)).toEqual(ID_CARD);
           });
         });
       });

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -15,10 +15,10 @@ import * as UrlService from 'hyperview/src/services/url';
 import { ANCHOR_ID_SEPARATOR } from './types';
 
 /**
- * Dynamic and modal routes are not defined in the document
+ * Card and modal routes are not defined in the document
  */
-export const isDynamicId = (id: string): boolean => {
-  return id === Types.ID_DYNAMIC || id === Types.ID_MODAL;
+export const isDynamicRoute = (id: string): boolean => {
+  return id === Types.ID_CARD || id === Types.ID_MODAL;
 };
 
 /**
@@ -209,7 +209,7 @@ export const buildParams = (
 };
 
 /**
- * Use the dynamic or modal route for dynamic actions, otherwise use the given id
+ * Use the card or modal route for dynamic actions, otherwise use the given id
  */
 export const getRouteId = (
   action: TypesLegacy.NavAction,
@@ -221,7 +221,7 @@ export const getRouteId = (
 
   return action === TypesLegacy.NAV_ACTIONS.NEW
     ? Types.ID_MODAL
-    : Types.ID_DYNAMIC;
+    : Types.ID_CARD;
 };
 
 /**

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -127,7 +127,7 @@ export {
 } from './imports';
 export { HvRouteError, HvNavigatorError, HvRenderError } from './errors';
 export {
-  isDynamicId,
+  isDynamicRoute,
   isUrlFragment,
   cleanHrefFragment,
   getChildElements,
@@ -137,4 +137,4 @@ export {
   mergeDocument,
   setSelected,
 } from './helpers';
-export { ID_DYNAMIC, ID_MODAL, KEY_MODAL, NAVIGATOR_TYPE } from './types';
+export { ID_CARD, ID_MODAL, KEY_MODAL, NAVIGATOR_TYPE } from './types';

--- a/src/services/navigator/types.ts
+++ b/src/services/navigator/types.ts
@@ -9,7 +9,7 @@
 import * as TypesLegacy from 'hyperview/src/types-legacy';
 
 export const ANCHOR_ID_SEPARATOR = '#';
-export const ID_DYNAMIC = 'dynamic';
+export const ID_CARD = 'card';
 export const ID_MODAL = 'modal';
 export const KEY_MERGE = 'merge';
 export const KEY_SELECTED = 'selected';


### PR DESCRIPTION
Replaced all uses of 'dynamic' as a type of route to 'card' to better reflect the implementation details.