### PR TITLE
feat(pickers): Custom animation transitions of modal/overlay

### DIFF
--- a/docs/reference_datefield.md
+++ b/docs/reference_datefield.md
@@ -152,7 +152,31 @@ A space-separated list of styles to apply to the text on date selection modal fo
 | ------ | -------- |
 | number | No       |
 
-The duration in milliseconds that the open and close animation of the date selection modal for IOS takes. Defaults to 250ms
+The duration in milliseconds that the open and close animation (including the fading animation of the overlay) of the date selection modal for IOS takes. Defaults to 250ms.
+
+#### `modal-overlay-animation-duration`
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+The duration in milliseconds that the open and close animation of the date selection modal overlay for IOS takes. Defaults to value of `modal-animation-duration`.
+
+#### `modal-dismiss-animation-duration`
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+The duration in milliseconds that the close animation of the date selection modal for IOS takes. Defaults to value of `modal-animation-duration`.
+
+#### `modal-dimiss-overlay-animation-duration`
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+The duration in milliseconds that the close animation of the date selection modal overlay for IOS takes. Defaults to value of `modal-overlay-animation-duration`.
 
 #### `id`
 

--- a/docs/reference_pickerfield.md
+++ b/docs/reference_pickerfield.md
@@ -132,6 +132,38 @@ A space-separated list of styles to apply to the iOS bottom-sheet modal. You can
 
 A space-separated list of styles to apply to the buttons in the iOS bottom-sheet modal. You can use these styles to define the size, color, and weight of the buttons in the iOS modal. On Android, the system defines the look of the modal, so these styles will not be applied. See [Styles](/docs/reference_style). Note that text style rules cannot be applied to the modal.
 
+#### `modal-animation-duration`
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+The duration in milliseconds that the open and close animation (including the fading animation of the overlay) of the picker modal for IOS takes. Defaults to 250ms.
+
+#### `modal-overlay-animation-duration`
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+The duration in milliseconds that the open and close animation of the picker modal overlay for IOS takes. Defaults to value of `modal-animation-duration`.
+
+#### `modal-dismiss-animation-duration`
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+The duration in milliseconds that the close animation of the picker modal for IOS takes. Defaults to value of `modal-animation-duration`.
+
+#### `modal-dimiss-overlay-animation-duration`
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+The duration in milliseconds that the close animation of the picker modal overlay for IOS takes. Defaults to value of `modal-overlay-animation-duration`.
+
 #### `id`
 
 | Type   | Required |

--- a/examples/ui_elements/forms/date_field/index.xml.njk
+++ b/examples/ui_elements/forms/date_field/index.xml.njk
@@ -277,6 +277,24 @@ tags: forms
         <text style="help help--error">Please select a different date</text>
       </view>
       <view style="FormGroup">
+        <text style="label">Customized animation durations (iOS only)</text>
+        <date-field
+          field-style="Input"
+          field-text-style="Input__Text"
+          label-format="MMMM D, YYYY"
+          modal-overlay-style="PickerModal__overlay"
+          modal-style="PickerModal"
+          modal-text-style="PickerModal__text"
+          modal-animation-duration="400"
+          modal-overlay-animation-duration="400"
+          modal-dismiss-animation-duration="200"
+          modal-dismiss-overlay-animation-duration="200"
+          name="date"
+          placeholder="Select date"
+          placeholderTextColor="#8D9494"
+          value="2018-03-07"/>
+      </view>
+      <view style="FormGroup">
         <text style="label">Customized</text>
         <date-field
           field-style="InputCustom"

--- a/examples/ui_elements/forms/picker/index.xml.njk
+++ b/examples/ui_elements/forms/picker/index.xml.njk
@@ -193,6 +193,31 @@ tags: forms
         <text style="help help--error">Please select a different choice</text>
       </view>
       <view style="FormGroup">
+        <text style="label">Customized animation durations (iOS only)</text>
+        <picker-field
+          field-style="Input"
+          field-text-style="Input__Text"
+          modal-overlay-style="PickerModal__overlay"
+          modal-style="PickerModal"
+          modal-text-style="PickerModal__text"
+          modal-animation-duration="400"
+          modal-overlay-animation-duration="400"
+          modal-dismiss-animation-duration="200"
+          modal-dismiss-overlay-animation-duration="200"
+          name="picker5"
+          placeholder="Select choice"
+          placeholderTextColor="#8D9494"
+          value="3">
+          <picker-item label="Choice 0" value="0"/>
+          <picker-item label="Choice 1" value="1"/>
+          <picker-item label="Choice 2" value="2"/>
+          <picker-item label="Choice 3" value="3"/>
+          <picker-item label="Choice 4" value="4"/>
+          <picker-item label="Choice 5" value="5"/>
+          <picker-item label="Choice 6" value="6"/>
+        </picker-field>
+      </view>
+      <view style="FormGroup">
         <text style="label">Customized</text>
         <picker-field
           cancel-label="Nevermind"

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -971,6 +971,12 @@
       <xs:attribute name="modal-style" type="hv:styleList" />
       <xs:attribute name="modal-overlay-style" type="hv:styleList" />
       <xs:attribute name="modal-animation-duration" type="xs:integer" />
+      <xs:attribute name="modal-overlay-animation-duration" type="xs:integer" />
+      <xs:attribute name="modal-dismiss-animation-duration" type="xs:integer" />
+      <xs:attribute
+        name="modal-dismiss-overlay-animation-duration"
+        type="xs:integer"
+      />
       <xs:attribute name="modal-text-style" type="hv:styleList" />
       <xs:attribute name="id" type="hv:ID" />
       <xs:attribute name="key" type="hv:KEY" />
@@ -997,6 +1003,13 @@
       <xs:attribute name="field-text-style" type="hv:styleList" />
       <xs:attribute name="modal-style" type="hv:styleList" />
       <xs:attribute name="modal-overlay-style" type="hv:styleList" />
+      <xs:attribute name="modal-animation-duration" type="xs:integer" />
+      <xs:attribute name="modal-overlay-animation-duration" type="xs:integer" />
+      <xs:attribute name="modal-dismiss-animation-duration" type="xs:integer" />
+      <xs:attribute
+        name="modal-dismiss-overlay-animation-duration"
+        type="xs:integer"
+      />
       <xs:attribute name="modal-text-style" type="hv:styleList" />
       <xs:attribute name="id" type="hv:ID" />
       <xs:attribute name="key" type="hv:KEY" />

--- a/src/core/components/modal/index.js
+++ b/src/core/components/modal/index.js
@@ -64,6 +64,21 @@ export default (props: Props): Node => {
 
   const animationDuration: number =
     parseInt(props.element.getAttribute('modal-animation-duration'), 10) || 250;
+  const overlayAnimationDuration: number =
+    parseInt(
+      props.element.getAttribute('modal-overlay-animation-duration'),
+      10,
+    ) || animationDuration;
+  const dismissAnimationDuration: number =
+    parseInt(
+      props.element.getAttribute('modal-dismiss-animation-duration'),
+      10,
+    ) || animationDuration;
+  const dismissOverlayAnimationDuration: number =
+    parseInt(
+      props.element.getAttribute('modal-dismiss-overlay-animation-duration'),
+      10,
+    ) || overlayAnimationDuration;
 
   // $FlowFixMe: casting with Number() causes crashes
   const targetOpacity: number = overlayStyle?.opacity ?? 1;
@@ -76,7 +91,7 @@ export default (props: Props): Node => {
       useNativeDriver: true,
     }).start();
     Animated.timing(opacity, {
-      duration: animationDuration,
+      duration: overlayAnimationDuration,
       toValue: targetOpacity,
       useNativeDriver: true,
     }).start();
@@ -84,7 +99,7 @@ export default (props: Props): Node => {
 
   const dismissModal = (callback: () => void) => () => {
     Animated.timing(translateY, {
-      duration: 150,
+      duration: dismissAnimationDuration,
       toValue: height,
       useNativeDriver: true,
     }).start(({ finished }) => {
@@ -94,7 +109,7 @@ export default (props: Props): Node => {
       }
     });
     Animated.timing(opacity, {
-      duration: 150,
+      duration: dismissOverlayAnimationDuration,
       toValue: 0,
       useNativeDriver: true,
     }).start();


### PR DESCRIPTION
Add parameters to customize duration of opening and closing animations of both modal and overlay for date field and picker field.

https://github.com/Instawork/hyperview/assets/309515/4d265bf1-13a6-44e2-a9df-149dff02d566



