### PR TITLE
refactor: de-dup behavior trigger logic

### DIFF
--- a/src/components/hv-date-field/index.js
+++ b/src/components/hv-date-field/index.js
@@ -8,7 +8,7 @@
  *
  */
 
-import * as Dom from 'hyperview/src/services/dom';
+import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import type { DOMString, Element, HvComponentProps } from 'hyperview/src/types';
 import React, { PureComponent } from 'react';
@@ -79,7 +79,7 @@ export default class HvDateField extends PureComponent<HvComponentProps> {
     newElement.setAttribute('focused', 'true');
     newElement.setAttribute('picker-value', value);
     this.props.onUpdate(null, 'swap', this.props.element, { newElement });
-    this.triggerBehaviors(newElement, 'focus');
+    Behaviors.trigger('focus', newElement, this.props.onUpdate);
   };
 
   /**
@@ -90,7 +90,7 @@ export default class HvDateField extends PureComponent<HvComponentProps> {
     newElement.setAttribute('focused', 'false');
     newElement.removeAttribute('picker-value');
     this.props.onUpdate(null, 'swap', this.props.element, { newElement });
-    this.triggerBehaviors(newElement, 'blur');
+    Behaviors.trigger('blur', newElement, this.props.onUpdate);
   };
 
   /**
@@ -107,35 +107,9 @@ export default class HvDateField extends PureComponent<HvComponentProps> {
     newElement.setAttribute('focused', 'false');
     this.props.onUpdate(null, 'swap', this.props.element, { newElement });
     if (hasChanged) {
-      this.triggerBehaviors(newElement, 'change');
+      Behaviors.trigger('change', newElement, this.props.onUpdate);
     }
-    this.triggerBehaviors(newElement, 'blur');
-  };
-
-  triggerBehaviors = (newElement: Element, triggerName: string) => {
-    const behaviorElements = Dom.getBehaviorElements(newElement);
-    const matchingBehaviors = behaviorElements.filter(
-      e => e.getAttribute('trigger') === triggerName,
-    );
-    matchingBehaviors.forEach(behaviorElement => {
-      const href = behaviorElement.getAttribute('href');
-      const action = behaviorElement.getAttribute('action');
-      const verb = behaviorElement.getAttribute('verb');
-      const targetId = behaviorElement.getAttribute('target');
-      const showIndicatorIds = behaviorElement.getAttribute('show-during-load');
-      const hideIndicatorIds = behaviorElement.getAttribute('hide-during-load');
-      const delay = behaviorElement.getAttribute('delay');
-      const once = behaviorElement.getAttribute('once');
-      this.props.onUpdate(href, action, newElement, {
-        behaviorElement,
-        delay,
-        hideIndicatorIds,
-        once,
-        showIndicatorIds,
-        targetId,
-        verb,
-      });
-    });
+    Behaviors.trigger('blur', newElement, this.props.onUpdate);
   };
 
   /**

--- a/src/components/hv-option/index.js
+++ b/src/components/hv-option/index.js
@@ -8,7 +8,7 @@
  *
  */
 
-import * as Dom from 'hyperview/src/services/dom';
+import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
 import React, { PureComponent } from 'react';
@@ -40,65 +40,13 @@ export default class HvOption extends PureComponent<HvComponentProps, State> {
     const selected = this.props.element.getAttribute('selected') === 'true';
     const prevSelected = prevProps.element.getAttribute('selected') === 'true';
     if (selected && !prevSelected) {
-      this.triggerSelectBehaviors();
+      Behaviors.trigger('select', this.props.element, this.props.onUpdate);
     }
 
     if (!selected && prevSelected) {
-      this.triggerDeselectBehaviors();
+      Behaviors.trigger('deselect', this.props.element, this.props.onUpdate);
     }
   }
-
-  triggerSelectBehaviors = () => {
-    const behaviorElements = Dom.getBehaviorElements(this.props.element);
-    const selectBehaviors = behaviorElements.filter(
-      e => e.getAttribute('trigger') === 'select',
-    );
-    selectBehaviors.forEach(behaviorElement => {
-      const href = behaviorElement.getAttribute('href');
-      const action = behaviorElement.getAttribute('action');
-      const verb = behaviorElement.getAttribute('verb');
-      const targetId = behaviorElement.getAttribute('target');
-      const showIndicatorIds = behaviorElement.getAttribute('show-during-load');
-      const hideIndicatorIds = behaviorElement.getAttribute('hide-during-load');
-      const delay = behaviorElement.getAttribute('delay');
-      const once = behaviorElement.getAttribute('once');
-      this.props.onUpdate(href, action, this.props.element, {
-        behaviorElement,
-        delay,
-        hideIndicatorIds,
-        once,
-        showIndicatorIds,
-        targetId,
-        verb,
-      });
-    });
-  };
-
-  triggerDeselectBehaviors = () => {
-    const behaviorElements = Dom.getBehaviorElements(this.props.element);
-    const deselectBehaviors = behaviorElements.filter(
-      e => e.getAttribute('trigger') === 'deselect',
-    );
-    deselectBehaviors.forEach(behaviorElement => {
-      const href = behaviorElement.getAttribute('href');
-      const action = behaviorElement.getAttribute('action');
-      const verb = behaviorElement.getAttribute('verb');
-      const targetId = behaviorElement.getAttribute('target');
-      const showIndicatorIds = behaviorElement.getAttribute('show-during-load');
-      const hideIndicatorIds = behaviorElement.getAttribute('hide-during-load');
-      const delay = behaviorElement.getAttribute('delay');
-      const once = behaviorElement.getAttribute('once');
-      this.props.onUpdate(href, action, this.props.element, {
-        behaviorElement,
-        delay,
-        hideIndicatorIds,
-        once,
-        showIndicatorIds,
-        targetId,
-        verb,
-      });
-    });
-  };
 
   render() {
     const { onSelect, onToggle } = this.props.options;

--- a/src/components/hv-switch/index.js
+++ b/src/components/hv-switch/index.js
@@ -8,7 +8,7 @@
  *
  */
 
-import * as Dom from 'hyperview/src/services/dom';
+import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import type { Element, HvComponentProps } from 'hyperview/src/types';
 import { Platform, StyleSheet, Switch } from 'react-native';
@@ -76,7 +76,7 @@ export default class HvSwitch extends PureComponent<HvComponentProps> {
         : null,
       onChange: () => {
         const newElement = this.props.element.cloneNode(true);
-        Dom.triggerBehaviors(newElement, 'change', this.props.onUpdate);
+        Behaviors.trigger('change', newElement, this.props.onUpdate);
       },
       onValueChange: value => {
         const newElement = this.props.element.cloneNode(true);

--- a/src/components/hv-text-field/index.js
+++ b/src/components/hv-text-field/index.js
@@ -8,7 +8,7 @@
  *
  */
 
-import * as Dom from 'hyperview/src/services/dom';
+import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import type { Element, HvComponentProps } from 'hyperview/src/types';
 import React, { PureComponent } from 'react';
@@ -41,44 +41,6 @@ export default class HvTextField extends PureComponent<HvComponentProps> {
     }
   }
 
-  triggerFocusBehaviors = (newElement: Element) => {
-    this.triggerBehaviors(newElement, 'focus');
-  };
-
-  triggerBlurBehaviors = (newElement: Element) => {
-    this.triggerBehaviors(newElement, 'blur');
-  };
-
-  triggerChangeBehaviors = (newElement: Element) => {
-    this.triggerBehaviors(newElement, 'change');
-  };
-
-  triggerBehaviors = (newElement: Element, triggerName: string) => {
-    const behaviorElements = Dom.getBehaviorElements(this.props.element);
-    const matchingBehaviors = behaviorElements.filter(
-      e => e.getAttribute('trigger') === triggerName,
-    );
-    matchingBehaviors.forEach(behaviorElement => {
-      const href = behaviorElement.getAttribute('href');
-      const action = behaviorElement.getAttribute('action');
-      const verb = behaviorElement.getAttribute('verb');
-      const targetId = behaviorElement.getAttribute('target');
-      const showIndicatorIds = behaviorElement.getAttribute('show-during-load');
-      const hideIndicatorIds = behaviorElement.getAttribute('hide-during-load');
-      const delay = behaviorElement.getAttribute('delay');
-      const once = behaviorElement.getAttribute('once');
-      this.props.onUpdate(href, action, newElement, {
-        behaviorElement,
-        delay,
-        hideIndicatorIds,
-        once,
-        showIndicatorIds,
-        targetId,
-        verb,
-      });
-    });
-  };
-
   /**
    * Formats the user's input based on element attributes.
    * Currently supports the "mask" attribute, which will be applied
@@ -101,9 +63,9 @@ export default class HvTextField extends PureComponent<HvComponentProps> {
     this.props.onUpdate(null, 'swap', this.props.element, { newElement });
 
     if (focused) {
-      this.triggerFocusBehaviors(newElement);
+      Behaviors.trigger('focus', newElement, this.props.onUpdate);
     } else {
-      this.triggerBlurBehaviors(newElement);
+      Behaviors.trigger('blur', newElement, this.props.onUpdate);
     }
   };
 
@@ -139,7 +101,7 @@ export default class HvTextField extends PureComponent<HvComponentProps> {
         const newElement = this.props.element.cloneNode(true);
         newElement.setAttribute('value', formattedValue);
         this.props.onUpdate(null, 'swap', this.props.element, { newElement });
-        this.triggerChangeBehaviors(newElement);
+        Behaviors.trigger('change', newElement, this.props.onUpdate);
       },
       onFocus: () => this.setFocus(true),
       ref: this.props.options.registerInputHandler,

--- a/src/services/dom/helpers.js
+++ b/src/services/dom/helpers.js
@@ -11,8 +11,6 @@
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import type {
   Document,
-  Element,
-  HvComponentOnUpdate,
   LocalName,
   NamespaceURI,
   Node,
@@ -42,41 +40,6 @@ export const getFirstTag = (
     return elements[0];
   }
   return null;
-};
-
-export const triggerBehaviors = (
-  targetElement: Element,
-  triggerName: string,
-  onUpdate: HvComponentOnUpdate,
-) => {
-  /*
-  Triggers all events in `targetElement` with trigger `triggerName`
-  */
-  const behaviorElements = getBehaviorElements(targetElement);
-  const matchingBehaviors = behaviorElements.filter(
-    e => e.getAttribute('trigger') === triggerName,
-  );
-
-  matchingBehaviors.forEach(behaviorElement => {
-    const href = behaviorElement.getAttribute('href');
-    const action = behaviorElement.getAttribute('action');
-    const verb = behaviorElement.getAttribute('verb');
-    const targetId = behaviorElement.getAttribute('target');
-    const showIndicatorIds = behaviorElement.getAttribute('show-during-load');
-    const hideIndicatorIds = behaviorElement.getAttribute('hide-during-load');
-    const delay = behaviorElement.getAttribute('delay');
-    const once = behaviorElement.getAttribute('once');
-
-    onUpdate(href, action, targetElement, {
-      behaviorElement,
-      delay,
-      hideIndicatorIds,
-      once,
-      showIndicatorIds,
-      targetId,
-      verb,
-    });
-  });
 };
 
 /**


### PR DESCRIPTION
Remove duplicated/identical implementations of logic triggering certain behaviors on elements.

Note: hv-alert, hv-list and `hyper-ref` still have their own custom implementation of selecting/executing behaviors. 