### PR TITLE
chore(dom) - reflect navigation state in dom

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -452,10 +452,26 @@ export default function HvRoute(props: Types.Props) {
     routeDocContext,
   );
 
+  // Use the focus event to set the selected route
   React.useEffect(() => {
     if (props.navigation) {
       const unsubscribe = props.navigation.addListener('focus', () => {
         NavigatorService.setSelected(routeDocContext, props.route?.params?.id);
+      });
+
+      return unsubscribe;
+    }
+    return undefined;
+  }, [props.navigation, props.route?.params?.id, routeDocContext]);
+
+  // Use the beforeRemove to remove stack routes
+  React.useEffect(() => {
+    if (props.navigation) {
+      const unsubscribe = props.navigation.addListener('beforeRemove', () => {
+        NavigatorService.removeStackRoute(
+          routeDocContext,
+          props.route?.params?.id,
+        );
       });
 
       return unsubscribe;

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -455,26 +455,30 @@ export default function HvRoute(props: Types.Props) {
   // Use the focus event to set the selected route
   React.useEffect(() => {
     if (props.navigation) {
-      const unsubscribe = props.navigation.addListener('focus', () => {
-        NavigatorService.setSelected(routeDocContext, props.route?.params?.id);
-      });
+      const unsubscribeFocus: () => void = props.navigation.addListener(
+        'focus',
+        () => {
+          NavigatorService.setSelected(
+            routeDocContext,
+            props.route?.params?.id,
+          );
+        },
+      );
 
-      return unsubscribe;
-    }
-    return undefined;
-  }, [props.navigation, props.route?.params?.id, routeDocContext]);
+      const unsubscribeRemove: () => void = props.navigation.addListener(
+        'beforeRemove',
+        () => {
+          NavigatorService.removeStackRoute(
+            routeDocContext,
+            props.route?.params?.id,
+          );
+        },
+      );
 
-  // Use the beforeRemove to remove stack routes
-  React.useEffect(() => {
-    if (props.navigation) {
-      const unsubscribe = props.navigation.addListener('beforeRemove', () => {
-        NavigatorService.removeStackRoute(
-          routeDocContext,
-          props.route?.params?.id,
-        );
-      });
-
-      return unsubscribe;
+      return () => {
+        unsubscribeFocus();
+        unsubscribeRemove();
+      };
     }
     return undefined;
   }, [props.navigation, props.route?.params?.id, routeDocContext]);

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -480,3 +480,23 @@ export const setSelected = (
     route.setAttribute(Types.KEY_SELECTED, 'true');
   }
 };
+
+/**
+ * Remove a stack route from the document
+ */
+export const removeStackRoute = (
+  doc: TypesLegacy.Document | undefined,
+  id: string | undefined,
+) => {
+  if (!doc || !id) {
+    return;
+  }
+  const route = getRouteById(doc, id);
+  if (route && route.parentNode) {
+    const parentNode = route.parentNode as TypesLegacy.Element;
+    const type = parentNode.getAttribute('type');
+    if (type === Types.NAVIGATOR_TYPE.STACK) {
+      route.parentNode.removeChild(route);
+    }
+  }
+};

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -135,6 +135,7 @@ export {
   getSelectedNavRouteElement,
   getUrlFromHref,
   mergeDocument,
+  removeStackRoute,
   setSelected,
 } from './helpers';
 export { ID_CARD, ID_MODAL, KEY_MODAL, NAVIGATOR_TYPE } from './types';

--- a/src/services/navigator/types.ts
+++ b/src/services/navigator/types.ts
@@ -40,7 +40,7 @@ export type NavigationProp = {
   goBack: () => void;
   getState: () => NavigationState;
   getParent: (id?: string) => NavigationProp | undefined;
-  addListener: (event: string, callback: () => void) => void;
+  addListener: (event: string, callback: () => void) => () => void;
 };
 
 /**

--- a/src/types-legacy.ts
+++ b/src/types-legacy.ts
@@ -96,6 +96,7 @@ export type Node = {
   parentNode: Node | null | undefined;
   appendChild: (newChild: Node) => Node;
   hasChildNodes: () => boolean;
+  removeChild: (oldChild: Node) => Node;
   replaceChild: (newChild: Node, oldChild: Node) => Node;
 };
 


### PR DESCRIPTION
The initial document may contain multiple <nav-route> elements in a stack. These will be pushed onto the stack immediately. As they are closed they should be removed from the dom to reflect the current state.

Note: card and modal routes pushed onto the stack by user activity will not be added to the dom to reflect state.

Asana: https://app.asana.com/0/0/1205225573228534/f

---
Example: closing the 'company' modal.

Before:
```XML
<doc ...>
  <navigator id="root-navigator" type="stack">
    <nav-route id="tabs-route" selected="false">
      <navigator id="tabs-navigator" type="tab">
        <nav-route id="live-shifts-route" href="/biz_app/gigs/live_shifts" selected="false"/>
        <nav-route id="shifts-route" href="/biz_app/sub-navigator" selected="true"/>
        <nav-route id="account-route" href="/biz_app/account" selected="false"/>
      </navigator>
    </nav-route>
    <nav-route id="company" href="/biz_app/account/company" modal="true" selected="true"/>
  </navigator>
</doc>
```

After:
```XML
<doc ...>
  <navigator id="root-navigator" type="stack">
    <nav-route id="tabs-route" selected="false">
      <navigator id="tabs-navigator" type="tab">
        <nav-route id="live-shifts-route" href="/biz_app/gigs/live_shifts" selected="false"/>
        <nav-route id="shifts-route" href="/biz_app/sub-navigator" selected="true"/>
        <nav-route id="account-route" href="/biz_app/account" selected="false"/>
      </navigator>
    </nav-route>
  </navigator>
</doc>
```