### PR TITLE
fix(android): `DateField` selection visual bug

### DIFF
--- a/src/components/hv-date-field/index.js
+++ b/src/components/hv-date-field/index.js
@@ -96,8 +96,9 @@ export default class HvDateField extends PureComponent<HvComponentProps> {
   /**
    * Hides the picker and applies the chosen value to the field.
    */
-  onDone = () => {
-    const pickerValue = this.getPickerValue();
+  onDone = (newValue?: Date) => {
+    const pickerValue =
+      newValue !== undefined ? newValue : this.getPickerValue();
     const value = HvDateField.createStringFromDate(pickerValue);
     const hasChanged = this.props.element.getAttribute('value') !== value;
     const newElement = this.props.element.cloneNode(true);
@@ -230,8 +231,7 @@ export default class HvDateField extends PureComponent<HvComponentProps> {
       if (date === undefined) {
         this.onCancel();
       } else {
-        this.setPickerValue(date);
-        this.onDone();
+        this.onDone(date);
       }
     };
     return <Picker onChange={onChange} />;


### PR DESCRIPTION
Refactor in #634 led to DOM being updated twice, causing the UI to glitch upon selecting a date in Android date field. This combines the date selection with the dimsissal of the picker (much like the way done for picker field).

| Before | After |
|-----|------|
| ![before](https://github.com/Instawork/hyperview/assets/309515/427b39e4-b366-4b90-8648-c12f95b22ef5) | ![after](https://github.com/Instawork/hyperview/assets/309515/d3fcdcab-2c1c-4146-952c-22a0a4186804) |