### PR TITLE
Revert "fix: stop usage of deprecated api"

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@babel/preset-env": "^7.22.9",
     "@react-native-community/datetimepicker": "7.2.0",
-    "@react-native-clipboard/clipboard": "^1.11.2",
     "@react-native-picker/picker": "2.4.10",
     "@react-navigation/bottom-tabs": "^6.5.8",
     "@react-navigation/native": "^6.1.7",

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -1732,11 +1732,6 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@react-native-clipboard/clipboard@^1.11.2":
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.11.2.tgz#e826d0336b34e67294aaffa6878308900bc7d197"
-  integrity sha512-bHyZVW62TuleiZsXNHS1Pv16fWc0fh8O9WvBzl4h2fykqZRW9a+Pv/RGTH56E3X2PqzHP38K5go8zmCZUoIsoQ==
-
 "@react-native-community/cli-clean@11.3.5":
   version "11.3.5"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-11.3.5.tgz#07c8a01e433ea6c6e32eb647908be48952888cdd"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   },
   "peerDependencies": {
     "@react-native-community/datetimepicker": "^3.0.3",
-    "@react-native-clipboard/clipboard": "^1.11.2",
     "@react-native-picker/picker": "^2.2.1",
     "@react-navigation/bottom-tabs": "^6.5.7",
     "@react-navigation/native": "^6.1.6",
@@ -73,7 +72,6 @@
     "@babel/runtime": "7.13.7",
     "@prettier/plugin-xml": "0.13.0",
     "@react-native-community/datetimepicker": "3.0.3",
-    "@react-native-clipboard/clipboard": "^1.11.2",
     "@react-native-picker/picker": "2.2.1",
     "@react-navigation/bottom-tabs": "6.5.7",
     "@react-navigation/native": "6.1.6",

--- a/src/behaviors/hv-copy-to-clipboard/index.js
+++ b/src/behaviors/hv-copy-to-clipboard/index.js
@@ -8,7 +8,7 @@
  *
  */
 
-import Clipboard from '@react-native-clipboard/clipboard';
+import { Clipboard } from 'react-native';
 import type { Element } from 'hyperview/src/types';
 
 export default {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1795,11 +1795,6 @@
     "@xml-tools/parser" "^1.0.2"
     prettier ">=1.10"
 
-"@react-native-clipboard/clipboard@^1.11.2":
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.11.2.tgz#e826d0336b34e67294aaffa6878308900bc7d197"
-  integrity sha512-bHyZVW62TuleiZsXNHS1Pv16fWc0fh8O9WvBzl4h2fykqZRW9a+Pv/RGTH56E3X2PqzHP38K5go8zmCZUoIsoQ==
-
 "@react-native-community/cli-debugger-ui@^4.13.1":
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.13.1.tgz#07de6d4dab80ec49231de1f1fbf658b4ad39b32c"


### PR DESCRIPTION
Reverts Instawork/hyperview#646

This library does not work "as-is" in the Expo demo app, forcing additional/manual work to append. We should instead use the library [expo-clipboard](https://docs.expo.dev/versions/v49.0.0/sdk/clipboard/).