### PR TITLE
fix(ios): bring back `getLabelForValue`

### DIFF
--- a/src/components/hv-picker-field/index.ios.js
+++ b/src/components/hv-picker-field/index.ios.js
@@ -68,6 +68,7 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
    * If the value doesn't have a picker item, returns null.
    */
   getLabelForValue = (value: DOMString): ?string => {
+    // $FlowFixMe: flow thinks `element` is a `Node` instead of an `Element`
     const pickerItemElements: NodeList<Element> = this.props.element.getElementsByTagNameNS(
       Namespaces.HYPERVIEW,
       LOCAL_NAME.PICKER_ITEM,

--- a/src/components/hv-picker-field/index.ios.js
+++ b/src/components/hv-picker-field/index.ios.js
@@ -64,6 +64,30 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
   getValue = (): string => this.props.element.getAttribute('value') || '';
 
   /**
+   * Gets the label from the picker items for the given value.
+   * If the value doesn't have a picker item, returns null.
+   */
+  getLabelForValue = (value: DOMString): ?string => {
+    const pickerItemElements: NodeList<Element> = this.props.element.getElementsByTagNameNS(
+      Namespaces.HYPERVIEW,
+      LOCAL_NAME.PICKER_ITEM,
+    );
+
+    let item: ?Element = null;
+    for (let i = 0; i < pickerItemElements.length; i += 1) {
+      const pickerItemElement: ?Element = pickerItemElements.item(i);
+      if (
+        pickerItemElement &&
+        pickerItemElement.getAttribute('value') === value
+      ) {
+        item = pickerItemElement;
+        break;
+      }
+    }
+    return item ? item.getAttribute('label') : null;
+  };
+
+  /**
    * Returns a string representing the value in the picker.
    */
   getPickerValue = (): string =>
@@ -180,7 +204,7 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
         onPress={this.onFieldPress}
         options={this.props.options}
         stylesheets={this.props.stylesheets}
-        value={this.getValue()}
+        value={this.getLabelForValue(this.getValue())}
       >
         {this.isFocused() ? (
           <Modal


### PR DESCRIPTION
[This method](https://github.com/Instawork/hyperview/blob/master/src/components/hv-picker-field/index.js#L116C3-L134C5) got lost in the few previous refactors, and caused a regression in the formatting of the label on iOS.

| Before | After |
|-----|-----|
| ![before](https://github.com/Instawork/hyperview/assets/309515/4d175a34-2c46-4b12-9af0-a592af8d5450) | ![after](https://github.com/Instawork/hyperview/assets/309515/23fc9cc2-6690-4a97-8f8b-3594cda8b399) |
