### PR TITLE
refactor(`HyperRef`): Remove unnecessary render cycles

### DIFF
--- a/src/components/hv-image/index.js
+++ b/src/components/hv-image/index.js
@@ -11,9 +11,9 @@
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import React, { PureComponent } from 'react';
 import type { HvComponentProps } from 'hyperview/src/types';
+import HyperRef from 'hyperview/src/core/hyper-ref';
 import { Image } from 'react-native';
 import { LOCAL_NAME } from 'hyperview/src/types';
-import { addHref } from 'hyperview/src/core/hyper-ref';
 import { createProps } from 'hyperview/src/services';
 import urlParse from 'url-parse';
 
@@ -29,12 +29,13 @@ export default class HvImage extends PureComponent<HvComponentProps> {
   render() {
     const { skipHref } = this.props.options || {};
     if (!skipHref) {
-      return addHref(
-        HvImage,
-        this.props.element,
-        this.props.stylesheets,
-        this.props.onUpdate,
-        this.props.options,
+      return (
+        <HyperRef
+          element={this.props.element}
+          onUpdate={this.props.onUpdate}
+          options={this.props.options}
+          stylesheets={this.props.stylesheets}
+        />
       );
     }
     const imageProps = {};

--- a/src/components/hv-image/index.js
+++ b/src/components/hv-image/index.js
@@ -28,6 +28,15 @@ export default class HvImage extends PureComponent<HvComponentProps> {
 
   render() {
     const { skipHref } = this.props.options || {};
+    if (!skipHref) {
+      return addHref(
+        HvImage,
+        this.props.element,
+        this.props.stylesheets,
+        this.props.onUpdate,
+        this.props.options,
+      );
+    }
     const imageProps = {};
     if (this.props.element.getAttribute('source')) {
       let source = this.props.element.getAttribute('source');
@@ -42,15 +51,6 @@ export default class HvImage extends PureComponent<HvComponentProps> {
       ),
       ...imageProps,
     };
-    const component = React.createElement(Image, props);
-    return skipHref
-      ? component
-      : addHref(
-          component,
-          this.props.element,
-          this.props.stylesheets,
-          this.props.onUpdate,
-          this.props.options,
-        );
+    return React.createElement(Image, props);
   }
 }

--- a/src/components/hv-text/index.js
+++ b/src/components/hv-text/index.js
@@ -12,9 +12,9 @@ import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
 import React, { PureComponent } from 'react';
 import type { HvComponentProps } from 'hyperview/src/types';
+import HyperRef from 'hyperview/src/core/hyper-ref';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import { Text } from 'react-native';
-import { addHref } from 'hyperview/src/core/hyper-ref';
 import { createProps } from 'hyperview/src/services';
 
 export default class HvText extends PureComponent<HvComponentProps> {
@@ -29,12 +29,13 @@ export default class HvText extends PureComponent<HvComponentProps> {
   render() {
     const { skipHref } = this.props.options || {};
     if (!skipHref) {
-      return addHref(
-        HvText,
-        this.props.element,
-        this.props.stylesheets,
-        this.props.onUpdate,
-        this.props.options,
+      return (
+        <HyperRef
+          element={this.props.element}
+          onUpdate={this.props.onUpdate}
+          options={this.props.options}
+          stylesheets={this.props.stylesheets}
+        />
       );
     }
     const props = createProps(

--- a/src/components/hv-text/index.js
+++ b/src/components/hv-text/index.js
@@ -28,12 +28,21 @@ export default class HvText extends PureComponent<HvComponentProps> {
 
   render() {
     const { skipHref } = this.props.options || {};
+    if (!skipHref) {
+      return addHref(
+        HvText,
+        this.props.element,
+        this.props.stylesheets,
+        this.props.onUpdate,
+        this.props.options,
+      );
+    }
     const props = createProps(
       this.props.element,
       this.props.stylesheets,
       this.props.options,
     );
-    const component = React.createElement(
+    return React.createElement(
       Text,
       props,
       ...Render.renderChildren(
@@ -47,15 +56,5 @@ export default class HvText extends PureComponent<HvComponentProps> {
         },
       ),
     );
-
-    return skipHref
-      ? component
-      : addHref(
-          component,
-          this.props.element,
-          this.props.stylesheets,
-          this.props.onUpdate,
-          this.props.options,
-        );
   }
 }

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -26,9 +26,9 @@ import {
 import React, { PureComponent } from 'react';
 import { ATTRIBUTES } from './types';
 import type { HvComponentProps } from 'hyperview/src/types';
+import HyperRef from 'hyperview/src/core/hyper-ref';
 import KeyboardAwareScrollView from 'hyperview/src/core/components/keyboard-aware-scroll-view';
 import { LOCAL_NAME } from 'hyperview/src/types';
-import { addHref } from 'hyperview/src/core/hyper-ref';
 import { createStyleProp } from 'hyperview/src/services';
 
 export default class HvView extends PureComponent<HvComponentProps> {
@@ -232,13 +232,12 @@ export default class HvView extends PureComponent<HvComponentProps> {
     return this.props.options?.skipHref ? (
       <Content />
     ) : (
-      addHref(
-        HvView,
-        this.props.element,
-        this.props.stylesheets,
-        this.props.onUpdate,
-        this.props.options,
-      )
+      <HyperRef
+        element={this.props.element}
+        onUpdate={this.props.onUpdate}
+        options={this.props.options}
+        stylesheets={this.props.stylesheets}
+      />
     );
   }
 }

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -233,7 +233,7 @@ export default class HvView extends PureComponent<HvComponentProps> {
       <Content />
     ) : (
       addHref(
-        <Content />,
+        HvView,
         this.props.element,
         this.props.stylesheets,
         this.props.onUpdate,

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -21,6 +21,7 @@ import {
   UPDATE_ACTIONS,
 } from 'hyperview/src/types';
 import { ATTRIBUTES, PRESS_TRIGGERS_PROP_NAMES } from './types';
+import type { ComponentType, Node } from 'react';
 import type {
   Element,
   HvComponentOnUpdate,
@@ -38,7 +39,6 @@ import {
   Text,
   TouchableOpacity,
 } from 'react-native';
-import type { Node } from 'react';
 import VisibilityDetectingView from 'hyperview/src/VisibilityDetectingView';
 import { XMLSerializer } from '@instawork/xmldom';
 import { X_RESPONSE_STALE_REASON } from 'hyperview/src/services/dom/types';
@@ -400,7 +400,11 @@ export default class HyperRef extends PureComponent<Props, State> {
 
     return React.createElement(
       VisibilityDetectingView,
-      { onInvisible: null, onVisible, style: this.getStyle() },
+      {
+        onInvisible: null,
+        onVisible,
+        style: this.getStyle(),
+      },
       children,
     );
   };
@@ -428,7 +432,7 @@ export default class HyperRef extends PureComponent<Props, State> {
 }
 
 export const addHref = (
-  component: any,
+  Component: ComponentType<any>,
   element: Element,
   stylesheets: StyleSheets,
   onUpdate: HvComponentOnUpdate,
@@ -440,14 +444,24 @@ export const addHref = (
   const behaviorElements = childNodes.filter(
     n => n && n.nodeType === 1 && n.tagName === 'behavior',
   );
+
   const hasBehaviors = href || action || behaviorElements.length > 0;
   if (!hasBehaviors) {
-    return component;
+    return (
+      <Component
+        element={element}
+        onUpdate={onUpdate}
+        options={{ ...options, skipHref: true }}
+        stylesheets={stylesheets}
+      />
+    );
   }
-
-  return React.createElement(
-    HyperRef,
-    { element, onUpdate, options, stylesheets },
-    ...Render.renderChildren(element, stylesheets, onUpdate, options),
+  return (
+    <HyperRef
+      element={element}
+      onUpdate={onUpdate}
+      options={options}
+      stylesheets={stylesheets}
+    />
   );
 };

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -21,14 +21,11 @@ import {
   UPDATE_ACTIONS,
 } from 'hyperview/src/types';
 import { ATTRIBUTES, PRESS_TRIGGERS_PROP_NAMES } from './types';
-import type { ComponentType, Node } from 'react';
 import type {
   Element,
   HvComponentOnUpdate,
-  HvComponentOptions,
   PressTrigger,
   StyleSheet,
-  StyleSheets,
   Trigger,
 } from 'hyperview/src/types';
 import type { PressHandlers, Props, State } from './types';
@@ -39,6 +36,7 @@ import {
   Text,
   TouchableOpacity,
 } from 'react-native';
+import type { Node } from 'react';
 import VisibilityDetectingView from 'hyperview/src/VisibilityDetectingView';
 import { XMLSerializer } from '@instawork/xmldom';
 import { X_RESPONSE_STALE_REASON } from 'hyperview/src/services/dom/types';
@@ -430,38 +428,3 @@ export default class HyperRef extends PureComponent<Props, State> {
     );
   }
 }
-
-export const addHref = (
-  Component: ComponentType<any>,
-  element: Element,
-  stylesheets: StyleSheets,
-  onUpdate: HvComponentOnUpdate,
-  options: HvComponentOptions,
-) => {
-  const href = element.getAttribute('href');
-  const action = element.getAttribute('action');
-  const childNodes = element.childNodes ? Array.from(element.childNodes) : [];
-  const behaviorElements = childNodes.filter(
-    n => n && n.nodeType === 1 && n.tagName === 'behavior',
-  );
-
-  const hasBehaviors = href || action || behaviorElements.length > 0;
-  if (!hasBehaviors) {
-    return (
-      <Component
-        element={element}
-        onUpdate={onUpdate}
-        options={{ ...options, skipHref: true }}
-        stylesheets={stylesheets}
-      />
-    );
-  }
-  return (
-    <HyperRef
-      element={element}
-      onUpdate={onUpdate}
-      options={options}
-      stylesheets={stylesheets}
-    />
-  );
-};


### PR DESCRIPTION
With previous code, we would first render the Hyperview element and its children (example: [HvText](https://github.com/Instawork/hyperview/blob/25d1633ca92fd2d87a8c504a1b61245a50ab6a2f/src/components/hv-text/index.js#L36-L49)) before [delegating to addHref](https://github.com/Instawork/hyperview/blob/25d1633ca92fd2d87a8c504a1b61245a50ab6a2f/src/components/hv-text/index.js#L53), which would then check for presence of behavior, and when some found, would [render element's children again](https://github.com/Instawork/hyperview/blob/25d1633ca92fd2d87a8c504a1b61245a50ab6a2f/src/core/hyper-ref/index.js#L451), before rendering `HyperRef`, which internally would [render the element again](https://github.com/Instawork/hyperview/blob/25d1633ca92fd2d87a8c504a1b61245a50ab6a2f/src/core/hyper-ref/index.js#L411-L416).

This change skips the initial rendering of element and children and delegate immediately to HyperRef.