### PR TITLE
fix: `visible` behavior missing detections

### DIFF
--- a/examples/case_studies/tabs/groups.xml
+++ b/examples/case_studies/tabs/groups.xml
@@ -1,3 +1,0 @@
-<view xmlns="https://hyperview.org/hyperview">
-  <text>This is the groups tab.</text>
-</view>

--- a/examples/case_studies/tabs/index.xml
+++ b/examples/case_studies/tabs/index.xml
@@ -1,66 +1,102 @@
 <doc xmlns="https://hyperview.org/hyperview">
   <screen>
     <styles>
-      <style id="Main" backgroundColor="white" flex="1" paddingTop="48" />
       <style
-        id="TabContent"
-        alignItems="center"
-        flex="1"
-        justifyContent="flex-start"
-        paddingTop="24"
-      />
-      <style id="Tabs" flexDirection="row" height="40" />
-      <style
-        id="Tab"
+        id="Header"
         alignItems="center"
         backgroundColor="white"
-        flex="1"
+        borderBottomColor="#eee"
+        borderBottomWidth="1"
         flexDirection="row"
+        paddingLeft="24"
+        paddingRight="24"
+        paddingBottom="16"
+      />
+      <style
+        id="Header__Back"
+        color="blue"
+        fontSize="16"
+        fontWeight="600"
+        paddingRight="16"
+      />
+      <style id="Header__Title" color="black" fontSize="24" fontWeight="600" />
+      <style id="Body" backgroundColor="white" flex="1" />
+      <style id="row" flexDirection="row" justifyContent="space-between" />
+      <style
+        id="tab"
+        flex="1"
+        height="48"
+        alignItems="center"
         justifyContent="center"
+        borderColor="red"
+        borderWidth="1"
       >
+        <modifier pressed="true">
+          <style backgroundColor="pink" />
+        </modifier>
         <modifier selected="true">
-          <style backgroundColor="#ddd" />
+          <style backgroundColor="red" />
         </modifier>
       </style>
-      <style id="Tab__Label" fontSize="18" fontWeight="normal">
-        <modifier selected="true">
-          <style fontWeight="bold" />
-        </modifier>
-      </style>
+      <style id="green" backgroundColor="lightgreen" />
+      <style id="blue" backgroundColor="lightblue" />
+      <style id="yellow" backgroundColor="lightyellow" />
+      <style id="flex" flex="1" />
+      <style id="centered" alignItems="center" justifyContent="center" />
     </styles>
-    <body style="Main">
-      <select-single name="tab" style="Tabs">
-        <option
-          action="replace-inner"
-          delay="300"
-          hide-during-load="tabContent"
-          href="/case_studies/tabs/users.xml"
-          show-during-load="spinner"
-          style="Tab"
-          target="tabContent"
-          trigger="select"
-          value="users"
-        >
-          <text style="Tab__Label">Users</text>
+    <body style="Body" safe-area="true">
+      <header style="Header">
+        <text action="back" href="#" style="Header__Back">Back</text>
+        <text style="Header__Title">Tabs</text>
+      </header>
+      <select-single id="tabs" name="tabs" style="row">
+        <option value="1" style="tab">
+          <behavior trigger="deselect" action="hide" target="tab-1" />
+          <behavior trigger="select" action="show" target="tab-1" />
+          <text>Tab 1</text>
         </option>
-        <option
-          action="replace-inner"
-          delay="300"
-          hide-during-load="tabContent"
-          href="/case_studies/tabs/groups.xml"
-          show-during-load="spinner"
-          style="Tab"
-          target="tabContent"
-          trigger="select"
-          value="groups"
-        >
-          <text style="Tab__Label">Groups</text>
+        <option value="2" style="tab">
+          <behavior trigger="deselect" action="hide" target="tab-2" />
+          <behavior trigger="select" action="show" target="tab-2" />
+          <text>Tab 2</text>
+        </option>
+        <option value="3" style="tab">
+          <behavior trigger="deselect" action="hide" target="tab-3" />
+          <behavior trigger="select" action="show" target="tab-3" />
+          <text>Tab 3</text>
         </option>
       </select-single>
-      <view id="spinner" hide="true" style="TabContent">
-        <spinner />
+      <view id="tab-1" style="flex centered green" hide="true">
+        <view
+          trigger="visible"
+          action="dispatch-event"
+          event-name="tab-1-visible"
+        />
+        <text>TAB 1 CONTENT</text>
       </view>
-      <view id="tabContent" style="TabContent" />
+      <view id="tab-2" style="flex centered blue" hide="true">
+        <view
+          trigger="visible"
+          action="dispatch-event"
+          event-name="tab-2-visible"
+        />
+        <text>TAB 2 CONTENT</text>
+      </view>
+      <view id="tab-3" style="flex centered yellow" hide="true">
+        <view
+          trigger="visible"
+          action="dispatch-event"
+          event-name="tab-3-visible"
+        />
+        <text>TAB 3 CONTENT</text>
+      </view>
+      <behavior
+        once="true"
+        trigger="load"
+        action="set-value"
+        target="tabs"
+        new-value="2"
+      />
     </body>
   </screen>
 </doc>

--- a/examples/case_studies/tabs/users.xml
+++ b/examples/case_studies/tabs/users.xml
@@ -1,3 +1,0 @@
-<view xmlns="https://hyperview.org/hyperview">
-  <text>This is the users tab.</text>
-</view>

--- a/src/VisibilityDetectingView.js
+++ b/src/VisibilityDetectingView.js
@@ -9,6 +9,7 @@ const TICK_INTERVAL = 100;
 
 type Props = {|
   children: any,
+  id: string,
   onInvisible: ?() => void,
   onVisible: ?() => void,
   style: ?ViewStyleProp,
@@ -72,15 +73,31 @@ export default class VisibilityDetectingView extends PureComponent<Props> {
       this.previouslyVisible = visible;
     }
 
-  componentDidMount() {
+  start = () => {
     this.tickInterval = setInterval(this.onTick, TICK_INTERVAL);
   }
 
-  componentWillUnmount() {
+  stop = () => {
     if (this.tickInterval) {
       clearInterval(this.tickInterval);
     }
+  }
+
+  componentDidMount() {
+    this.start();
+  }
+
+  componentWillUnmount() {
+    this.stop();
     this.unmounted = true;
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.id !== this.props.id) {
+      this.stop();
+      this.previouslyVisible = false;
+      this.start();
+    }
   }
 
   render() {

--- a/src/core/hyper-ref/types.js
+++ b/src/core/hyper-ref/types.js
@@ -32,10 +32,12 @@ export type State = {|
 export const ATTRIBUTES = {
   ACTION: 'action',
   DELAY: 'delay',
+  EVENT_NAME: 'event-name',
   HIDE_DURING_LOAD: 'hide-during-load',
   HREF: 'href',
   HREF_STYLE: 'href-style',
   IMMEDIATE: 'immediate',
+  NEW_VALUE: 'new-value',
   ONCE: 'once',
   SHOW_DURING_LOAD: 'show-during-load',
   TARGET: 'target',


### PR DESCRIPTION
When toggling views with `show`/`hide` behaviors, if the layout is identical enough (i.e. same elements structure), then React does not unmount the instances of `VisibilityDetectingView`, which in turn cause the previous "visible" state to not be reset. The code change here works around the issue, by adding an `id` prop to `VisibilityDetectingView`, which is then used to decide internally to reset the "visible" state. The `id` prop is either set from an existing `id` attribute on the element targeted by the `visible` behavior, or generated, using every behavior attributes available on the element (which means if all attributes are identical, the observed issue will remain - however unlikely to happen).

The fix also addresses another bug that was uncovered after the first resolution: we were relying on an older version of the DOM when triggering the "visible" callbacks. Instead, query the DOM in the callback.

Note: the use case "Tabs" in example has also been reworked to help diagnose the issue.


| Before | After |
|-------|------|
| ![before](https://github.com/Instawork/hyperview/assets/309515/3febfad5-8a19-465d-8efa-805168a68078) | ![after](https://github.com/Instawork/hyperview/assets/309515/fbffb58b-0d8b-44d4-bd11-94207477ee57) |
