### PR TITLE
chore(demo) - fixed navigation/reload load indicator

### DIFF
--- a/examples/navigation/reload.xml.njk
+++ b/examples/navigation/reload.xml.njk
@@ -55,8 +55,12 @@ tags: navigation
         <text style="Description">
           Tapping the button below will reload this entire screen. Modifications to the file will appear without navigation.
         </text>
-        <view action="reload" href="#" show-during-load="loadingScreen" style="Button">
+        <view action="reload" href="#" show-during-load="loadingElement" style="Button">
           <text style="Button__Label">Reload!</text>
+        </view>
+        <view id="loadingElement" hide="true">
+          <spinner id="myIndicator"/>
+          <text style="Item">Loading...</text>
         </view>
         <text style="Description">
           Tapping the button below will reload this screen with a new URL


### PR DESCRIPTION
The current functionality doesn't support using <screen> elements for show-during-load. The demo was trying to illustrate this feature.

For now, I have not removed the <screen> but have added a small <view> element with message and spinner to illustrate the feature.

More work to be done separately to add support for <screen> loaders: https://app.asana.com/0/1204323441804469/1205320418809826/f


https://github.com/Instawork/hyperview/assets/127122858/57dac9f0-0c01-441a-bf96-16eb5fb8c910

