### PR TITLE
Revert "refactor(`HyperRef`): Remove unnecessary render cycles (#658)"

### DIFF
--- a/src/components/hv-image/index.js
+++ b/src/components/hv-image/index.js
@@ -11,9 +11,9 @@
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import React, { PureComponent } from 'react';
 import type { HvComponentProps } from 'hyperview/src/types';
-import HyperRef from 'hyperview/src/core/hyper-ref';
 import { Image } from 'react-native';
 import { LOCAL_NAME } from 'hyperview/src/types';
+import { addHref } from 'hyperview/src/core/hyper-ref';
 import { createProps } from 'hyperview/src/services';
 import urlParse from 'url-parse';
 
@@ -28,16 +28,6 @@ export default class HvImage extends PureComponent<HvComponentProps> {
 
   render() {
     const { skipHref } = this.props.options || {};
-    if (!skipHref) {
-      return (
-        <HyperRef
-          element={this.props.element}
-          onUpdate={this.props.onUpdate}
-          options={this.props.options}
-          stylesheets={this.props.stylesheets}
-        />
-      );
-    }
     const imageProps = {};
     if (this.props.element.getAttribute('source')) {
       let source = this.props.element.getAttribute('source');
@@ -52,6 +42,15 @@ export default class HvImage extends PureComponent<HvComponentProps> {
       ),
       ...imageProps,
     };
-    return React.createElement(Image, props);
+    const component = React.createElement(Image, props);
+    return skipHref
+      ? component
+      : addHref(
+          component,
+          this.props.element,
+          this.props.stylesheets,
+          this.props.onUpdate,
+          this.props.options,
+        );
   }
 }

--- a/src/components/hv-text/index.js
+++ b/src/components/hv-text/index.js
@@ -12,9 +12,9 @@ import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
 import React, { PureComponent } from 'react';
 import type { HvComponentProps } from 'hyperview/src/types';
-import HyperRef from 'hyperview/src/core/hyper-ref';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import { Text } from 'react-native';
+import { addHref } from 'hyperview/src/core/hyper-ref';
 import { createProps } from 'hyperview/src/services';
 
 export default class HvText extends PureComponent<HvComponentProps> {
@@ -28,22 +28,12 @@ export default class HvText extends PureComponent<HvComponentProps> {
 
   render() {
     const { skipHref } = this.props.options || {};
-    if (!skipHref) {
-      return (
-        <HyperRef
-          element={this.props.element}
-          onUpdate={this.props.onUpdate}
-          options={this.props.options}
-          stylesheets={this.props.stylesheets}
-        />
-      );
-    }
     const props = createProps(
       this.props.element,
       this.props.stylesheets,
       this.props.options,
     );
-    return React.createElement(
+    const component = React.createElement(
       Text,
       props,
       ...Render.renderChildren(
@@ -57,5 +47,15 @@ export default class HvText extends PureComponent<HvComponentProps> {
         },
       ),
     );
+
+    return skipHref
+      ? component
+      : addHref(
+          component,
+          this.props.element,
+          this.props.stylesheets,
+          this.props.onUpdate,
+          this.props.options,
+        );
   }
 }

--- a/src/components/hv-view/index.js
+++ b/src/components/hv-view/index.js
@@ -26,9 +26,9 @@ import {
 import React, { PureComponent } from 'react';
 import { ATTRIBUTES } from './types';
 import type { HvComponentProps } from 'hyperview/src/types';
-import HyperRef from 'hyperview/src/core/hyper-ref';
 import KeyboardAwareScrollView from 'hyperview/src/core/components/keyboard-aware-scroll-view';
 import { LOCAL_NAME } from 'hyperview/src/types';
+import { addHref } from 'hyperview/src/core/hyper-ref';
 import { createStyleProp } from 'hyperview/src/services';
 
 export default class HvView extends PureComponent<HvComponentProps> {
@@ -232,12 +232,13 @@ export default class HvView extends PureComponent<HvComponentProps> {
     return this.props.options?.skipHref ? (
       <Content />
     ) : (
-      <HyperRef
-        element={this.props.element}
-        onUpdate={this.props.onUpdate}
-        options={this.props.options}
-        stylesheets={this.props.stylesheets}
-      />
+      addHref(
+        <Content />,
+        this.props.element,
+        this.props.stylesheets,
+        this.props.onUpdate,
+        this.props.options,
+      )
     );
   }
 }

--- a/src/core/hyper-ref/index.js
+++ b/src/core/hyper-ref/index.js
@@ -24,8 +24,10 @@ import { ATTRIBUTES, PRESS_TRIGGERS_PROP_NAMES } from './types';
 import type {
   Element,
   HvComponentOnUpdate,
+  HvComponentOptions,
   PressTrigger,
   StyleSheet,
+  StyleSheets,
   Trigger,
 } from 'hyperview/src/types';
 import type { PressHandlers, Props, State } from './types';
@@ -441,3 +443,28 @@ export default class HyperRef extends PureComponent<Props, State> {
     );
   }
 }
+
+export const addHref = (
+  component: any,
+  element: Element,
+  stylesheets: StyleSheets,
+  onUpdate: HvComponentOnUpdate,
+  options: HvComponentOptions,
+) => {
+  const href = element.getAttribute('href');
+  const action = element.getAttribute('action');
+  const childNodes = element.childNodes ? Array.from(element.childNodes) : [];
+  const behaviorElements = childNodes.filter(
+    n => n && n.nodeType === 1 && n.tagName === 'behavior',
+  );
+  const hasBehaviors = href || action || behaviorElements.length > 0;
+  if (!hasBehaviors) {
+    return component;
+  }
+
+  return React.createElement(
+    HyperRef,
+    { element, onUpdate, options, stylesheets },
+    ...Render.renderChildren(element, stylesheets, onUpdate, options),
+  );
+};


### PR DESCRIPTION
This reverts commit dae263f4b7926ffe477024a0892ed374a8b93860, introduced in #658.

The change appears to cause regression in our mobile app. The change was a nice to have, but not a requirement for #659.