### PR TITLE
fix(reload) - Reload should not require an href value

### DIFF
--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -242,7 +242,12 @@ export default class HvScreen extends React.Component {
    * the screen's current URL will be used.
    */
   reload = (optHref, opts) => {
-    const url = (optHref === undefined || optHref === '#')
+    const isBlankHref =
+      optHref === null ||
+      optHref === undefined ||
+      optHref === '#' ||
+      optHref === '';
+    const url = isBlankHref
       ? this.state.url // eslint-disable-line react/no-access-state-in-setstate
       : UrlService.getUrlFromHref(optHref, this.state.url); // eslint-disable-line react/no-access-state-in-setstate
 


### PR DESCRIPTION
I found the following functionality:
- dom (level 1-3) will return an empty string if the attribute is missing or has no value: https://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-666EE0F9
- dom (level 4) will return null if the attribute is not present: https://dom.spec.whatwg.org/#dom-element-getattribute

The definition in dom v4 appears as
  [DOMString](https://webidl.spec.whatwg.org/#idl-DOMString)? [getAttribute](https://dom.spec.whatwg.org/#dom-element-getattribute)([DOMString](https://webidl.spec.whatwg.org/#idl-DOMString) [qualifiedName](https://dom.spec.whatwg.org/#dom-element-getattribute-qualifiedname-qualifiedname));

It seems most prudent to check for
- null, undefined (level 4)
- empty string (level 1-3)
- hash (Hyperview)


Closes https://github.com/Instawork/hyperview/issues/299

Asana: https://app.asana.com/0/1204008699308084/1205327866013617/f