### PR TITLE
feat(lists): `scroll` behavior action

### DIFF
--- a/docs/reference_behavior_scroll.md
+++ b/docs/reference_behavior_scroll.md
@@ -1,0 +1,101 @@
+---
+id: reference_behavior_scroll
+title: Scrolling lists
+sidebar_label: Scroll
+---
+
+Scrolling to a specific item in a list can be triggered via behaviors. The `scroll` action can be used in `<list>` and `<section-list>`. It is paired with a `target` attribute, that defines where the scroll position should be set to, and it accepts a couple optional attributes that help configuring the behavior.
+
+Here's an example of a button that will cause a list to scroll back to the top, with an animation:
+
+```xml
+<list>
+  <item id="top"><text>Item 1</text></item>
+  <item><text>Item 1</text></item>
+  <item><text>Item 1</text></item>
+  ...
+  <item>
+    <text>Item 100</text>
+    <view style="Button">
+      <behavior
+        xmlns:scroll="https://hyperview.org/hyperview-scroll"
+        action="scroll"
+        trigger="press"
+        target="top"
+        scroll:animated="true"
+      />
+      <text style="Button__Label">Scroll to top</text>
+    </view>
+  </item>
+</list>
+```
+
+# Structure
+
+Scroll behaviors are created using the standard [`<behavior>`](/docs/reference_behavior) element. To trigger a scroll behavior, just set the `action` attribute to `"scroll"`, and set a `target` to an element that exists and is nested under the list you're targetting.
+
+NOTES:
+
+- The behavior should also be defined as a nested child of the list.
+- The `target` element can either be set with the `id` attribute value of an `<item>` element of the list, or a child element of an `<item>`. When the target is a child of an `<item>`, Hyperview will perform the scroll to the parent `<item>`. You can further refine the scroll position by using one of the configuring attributes (see below).
+
+Attributes that configure the scroll behavior require their own namespace:
+
+```html
+https://hyperview.org/hyperview-scroll
+```
+
+It's usually convenient to define the XML namespace on the `<behavior>` element too:
+
+```xml
+<behavior
+  xmlns:scroll="https://hyperview.org/hyperview-scroll"
+  trigger="longPress"
+  action="scroll"
+  target="some-id"
+/>
+```
+
+Note that any standard trigger can be used, as long as it's supported by the element containing the `<behavior>`.
+
+The shared message and url are defined as namespaced attributes on the `<behavior>` element:
+
+```xml
+<behavior
+  xmlns:scroll="https://hyperview.org/hyperview-scroll"
+  trigger="longPress"
+  action="scroll"
+  target="some-id"
+  scroll:animated="true"
+  scroll:offset="100"
+  scroll:position="0.5"
+/>
+```
+
+## Scroll attributes
+
+The following attributes are part of the `https://hyperview.org/hyperview-scroll` namespace.
+
+### animated
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
+
+This will condition whether the scrolling should be animated or not.
+
+### offset
+
+| Type    | Required |
+| ------- | -------- |
+| integer | **No**   |
+
+A fixed number of pixels to offset the final target position.
+
+### position
+
+| Type                                | Required |
+| ----------------------------------- | -------- |
+| float between **0** (default) and 1 | **No**   |
+
+A value of 0 places the item specified by index at the top, 1 at the bottom, and 0.5 centered in the middle.

--- a/examples/advanced_behaviors/scroll/index.xml.njk
+++ b/examples/advanced_behaviors/scroll/index.xml.njk
@@ -1,0 +1,12 @@
+---
+title: "Scroll"
+permalink: "/advanced_behaviors/scroll/index.xml"
+tags: advanced_behaviors
+list_tag: "advanced_behaviors_scroll"
+list_href: "/advanced_behaviors/scroll/list.xml"
+---
+
+{% extends 'base.xml.njk' %}
+{% block container %}
+  {% include "../../list.xml.njk" %}
+{% endblock %}

--- a/examples/advanced_behaviors/scroll/list.xml.njk
+++ b/examples/advanced_behaviors/scroll/list.xml.njk
@@ -11,8 +11,8 @@ tags: advanced_behaviors_scroll
 {% endblock %}
 {% block container %}
   <list xmlns:scroll="https://hyperview.org/hyperview-scroll">
-    <item key="top" style="TopItem"  id="top">
-      <view>
+    <item key="top" style="TopItem">
+      <view id="top">
         <view>
           <behavior action="scroll" target="item-15" />
           <text style="TopItem__Link">Scroll to item 15</text>

--- a/examples/advanced_behaviors/scroll/list.xml.njk
+++ b/examples/advanced_behaviors/scroll/list.xml.njk
@@ -1,0 +1,205 @@
+---
+title: "List"
+permalink: "/advanced_behaviors/scroll/list.xml"
+tags: advanced_behaviors_scroll
+---
+
+{% extends 'base.xml.njk' %}
+{% block styles %}
+  <style id="TopItem" backgroundColor="#ffffff" padding="24" borderBottomColor="#eee" borderBottomWidth="1" />
+  <style id="TopItem__Link" color="#4778FF" fontWeight="bold" marginTop="8" marginRight="16" alignSelf="flex-end" />
+{% endblock %}
+{% block container %}
+  <list xmlns:scroll="https://hyperview.org/hyperview-scroll">
+    <item key="top" style="TopItem"  id="top">
+      <view>
+        <view>
+          <behavior action="scroll" target="item-15" />
+          <text style="TopItem__Link">Scroll to item 15</text>
+        </view>
+        <view>
+          <behavior action="scroll" target="item-25" scroll:offset="24" />
+          <text style="TopItem__Link">Scroll to item 25 with offset</text>
+        </view>
+        <view>
+          <behavior action="scroll" target="item-35" scroll:position="0.5" />
+          <text style="TopItem__Link">Scroll to item 35 with position</text>
+        </view>
+        <view>
+          <behavior action="scroll" target="bottom" scroll:animated="true" />
+          <text style="TopItem__Link">Scroll to bottom, animated</text>
+        </view>
+      </view>
+    </item>
+    <item key="1" style="Item">
+      <behavior action="scroll" target="bottom" />
+      <text style="Item__Label">Item 1</text>
+    </item>
+    <item key="2" style="Item">
+      <text style="Item__Label">Item 2</text>
+    </item>
+    <item key="3" style="Item">
+      <text style="Item__Label">Item 3</text>
+    </item>
+    <item key="4" style="Item">
+      <text style="Item__Label">Item 4</text>
+    </item>
+    <item key="5" style="Item">
+      <text style="Item__Label">Item 5</text>
+    </item>
+    <item key="6" style="Item">
+      <text style="Item__Label">Item 6</text>
+    </item>
+    <item key="7" style="Item">
+      <text style="Item__Label">Item 7</text>
+    </item>
+    <item key="8" style="Item">
+      <text style="Item__Label">Item 8</text>
+    </item>
+    <item key="9" style="Item">
+      <text style="Item__Label">Item 9</text>
+    </item>
+    <item key="10" style="Item">
+      <text style="Item__Label">Item 10</text>
+    </item>
+    <item key="11" style="Item">
+      <text style="Item__Label">Item 11</text>
+    </item>
+    <item key="12" style="Item">
+      <text style="Item__Label">Item 12</text>
+    </item>
+    <item key="13" style="Item">
+      <text style="Item__Label">Item 13</text>
+    </item>
+    <item key="14" style="Item">
+      <text style="Item__Label">Item 14</text>
+    </item>
+    <item key="15" style="Item" id="item-15">
+      <text style="Item__Label">Item 15</text>
+      <view>
+        <behavior action="scroll" target="top" scroll:animated="true" />
+        <text style="TopItem__Link">Scroll to top</text>
+      </view>
+    </item>
+    <item key="16" style="Item">
+      <text style="Item__Label">Item 16</text>
+    </item>
+    <item key="17" style="Item">
+      <text style="Item__Label">Item 17</text>
+    </item>
+    <item key="18" style="Item">
+      <text style="Item__Label">Item 18</text>
+    </item>
+    <item key="19" style="Item">
+      <text style="Item__Label">Item 19</text>
+    </item>
+    <item key="20" style="Item">
+      <text style="Item__Label">Item 20</text>
+    </item>
+    <item key="21" style="Item">
+      <text style="Item__Label">Item 21</text>
+    </item>
+    <item key="22" style="Item">
+      <text style="Item__Label">Item 22</text>
+    </item>
+    <item key="23" style="Item">
+      <text style="Item__Label">Item 23</text>
+    </item>
+    <item key="24" style="Item">
+      <text style="Item__Label">Item 24</text>
+    </item>
+    <item key="25" style="Item" id="item-25">
+      <text style="Item__Label">Item 25</text>
+      <view>
+        <behavior action="scroll" target="top" scroll:animated="true" />
+        <text style="TopItem__Link">Scroll to top</text>
+      </view>
+    </item>
+    <item key="26" style="Item">
+      <text style="Item__Label">Item 26</text>
+    </item>
+    <item key="27" style="Item">
+      <text style="Item__Label">Item 27</text>
+    </item>
+    <item key="28" style="Item">
+      <text style="Item__Label">Item 28</text>
+    </item>
+    <item key="29" style="Item">
+      <text style="Item__Label">Item 29</text>
+    </item>
+    <item key="30" style="Item">
+      <text style="Item__Label">Item 30</text>
+    </item>
+    <item key="31" style="Item">
+      <text style="Item__Label">Item 31</text>
+    </item>
+    <item key="32" style="Item">
+      <text style="Item__Label">Item 32</text>
+    </item>
+    <item key="33" style="Item">
+      <text style="Item__Label">Item 33</text>
+    </item>
+    <item key="34" style="Item">
+      <text style="Item__Label">Item 34</text>
+    </item>
+    <item key="35" style="Item" id="item-35">
+      <text style="Item__Label">Item 35</text>
+      <view>
+        <behavior action="scroll" target="top" scroll:animated="true" />
+        <text style="TopItem__Link">Scroll to top</text>
+      </view>
+    </item>
+    <item key="36" style="Item">
+      <text style="Item__Label">Item 36</text>
+    </item>
+    <item key="37" style="Item">
+      <text style="Item__Label">Item 37</text>
+    </item>
+    <item key="38" style="Item">
+      <text style="Item__Label">Item 38</text>
+    </item>
+    <item key="39" style="Item">
+      <text style="Item__Label">Item 39</text>
+    </item>
+    <item key="40" style="Item">
+      <text style="Item__Label">Item 40</text>
+    </item>
+    <item key="41" style="Item">
+      <text style="Item__Label">Item 41</text>
+    </item>
+    <item key="42" style="Item">
+      <text style="Item__Label">Item 42</text>
+    </item>
+    <item key="43" style="Item">
+      <text style="Item__Label">Item 43</text>
+    </item>
+    <item key="44" style="Item">
+      <text style="Item__Label">Item 44</text>
+    </item>
+    <item key="45" style="Item">
+      <text style="Item__Label">Item 45</text>
+    </item>
+    <item key="46" style="Item">
+      <text style="Item__Label">Item 46</text>
+    </item>
+    <item key="47" style="Item">
+      <text style="Item__Label">Item 47</text>
+    </item>
+    <item key="48" style="Item">
+      <text style="Item__Label">Item 48</text>
+    </item>
+    <item key="49" style="Item">
+      <text style="Item__Label">Item 49</text>
+    </item>
+    <item key="50" style="Item">
+      <text style="Item__Label">Item 50</text>
+    </item>
+    <item key="bottom" style="Item" id="bottom">
+      <view />
+      <view>
+        <behavior action="scroll" target="top" scroll:animated="true" />
+        <text style="TopItem__Link">Scroll to top</text>
+      </view>
+    </item>
+  </list>
+{% endblock %}

--- a/examples/advanced_behaviors/scroll/section_list.xml.njk
+++ b/examples/advanced_behaviors/scroll/section_list.xml.njk
@@ -22,8 +22,8 @@ tags: advanced_behaviors_scroll
 {% endblock %}
 {% block container %}
   <section-list xmlns:scroll="https://hyperview.org/hyperview-scroll">
-    <item key="top" style="TopItem" id="top">
-      <view>
+    <item key="top" style="TopItem">
+      <view id="top">
         <view>
           <behavior action="scroll" target="item-15" />
           <text style="TopItem__Link">Scroll to item 15</text>

--- a/examples/advanced_behaviors/scroll/section_list.xml.njk
+++ b/examples/advanced_behaviors/scroll/section_list.xml.njk
@@ -1,0 +1,231 @@
+---
+title: "Section List"
+permalink: "/advanced_behaviors/scroll/section_list.xml"
+tags: advanced_behaviors_scroll
+---
+
+{% extends 'base.xml.njk' %}
+{% block styles %}
+  <style id="List__HeaderText" fontSize="18" fontWeight="bold"/>
+  <style
+    id="List__Header"
+    alignItems="center"
+    backgroundColor="#eee"
+    flex="1"
+    flexDirection="row"
+    height="48"
+    paddingLeft="24"
+    paddingRight="24"
+  />
+  <style id="TopItem" backgroundColor="#ffffff" padding="24" borderBottomColor="#eee" borderBottomWidth="1" />
+  <style id="TopItem__Link" color="#4778FF" fontWeight="bold" marginTop="8" marginRight="16" alignSelf="flex-end" />
+{% endblock %}
+{% block container %}
+  <section-list xmlns:scroll="https://hyperview.org/hyperview-scroll">
+    <item key="top" style="TopItem" id="top">
+      <view>
+        <view>
+          <behavior action="scroll" target="item-15" />
+          <text style="TopItem__Link">Scroll to item 15</text>
+        </view>
+        <view>
+          <behavior action="scroll" target="item-25" scroll:offset="24" />
+          <text style="TopItem__Link">Scroll to item 25 with offset</text>
+        </view>
+        <view>
+          <behavior action="scroll" target="item-35" scroll:position="0.5" />
+          <text style="TopItem__Link">Scroll to item 35 with position</text>
+        </view>
+        <view>
+          <behavior action="scroll" target="bottom" scroll:animated="true" />
+          <text style="TopItem__Link">Scroll to bottom, animated</text>
+        </view>
+      </view>
+    </item>
+    <section-title style="List__Header">
+      <text style="List__HeaderText">-</text>
+    </section-title>
+    <item key="1" style="Item">
+      <behavior action="scroll" target="bottom" />
+      <text style="Item__Label">Item 1</text>
+    </item>
+    <item key="2" style="Item">
+      <text style="Item__Label">Item 2</text>
+    </item>
+    <item key="3" style="Item">
+      <text style="Item__Label">Item 3</text>
+    </item>
+    <item key="4" style="Item">
+      <text style="Item__Label">Item 4</text>
+    </item>
+    <item key="5" style="Item">
+      <text style="Item__Label">Item 5</text>
+    </item>
+    <item key="6" style="Item">
+      <text style="Item__Label">Item 6</text>
+    </item>
+    <item key="7" style="Item">
+      <text style="Item__Label">Item 7</text>
+    </item>
+    <item key="8" style="Item">
+      <text style="Item__Label">Item 8</text>
+    </item>
+    <item key="9" style="Item">
+      <text style="Item__Label">Item 9</text>
+    </item>
+    <section-title style="List__Header">
+      <text style="List__HeaderText">1-</text>
+    </section-title>
+    <item key="10" style="Item">
+      <text style="Item__Label">Item 10</text>
+    </item>
+    <item key="11" style="Item">
+      <text style="Item__Label">Item 11</text>
+    </item>
+    <item key="12" style="Item">
+      <text style="Item__Label">Item 12</text>
+    </item>
+    <item key="13" style="Item">
+      <text style="Item__Label">Item 13</text>
+    </item>
+    <item key="14" style="Item">
+      <text style="Item__Label">Item 14</text>
+    </item>
+    <item key="15" style="Item" id="item-15">
+      <text style="Item__Label">Item 15</text>
+      <view>
+        <behavior action="scroll" target="top" scroll:animated="true" />
+        <text style="TopItem__Link">Scroll to top</text>
+      </view>
+    </item>
+    <item key="16" style="Item">
+      <text style="Item__Label">Item 16</text>
+    </item>
+    <item key="17" style="Item">
+      <text style="Item__Label">Item 17</text>
+    </item>
+    <item key="18" style="Item">
+      <text style="Item__Label">Item 18</text>
+    </item>
+    <item key="19" style="Item">
+      <text style="Item__Label">Item 19</text>
+    </item>
+    <section-title style="List__Header">
+      <text style="List__HeaderText">2-</text>
+    </section-title>
+    <item key="20" style="Item">
+      <text style="Item__Label">Item 20</text>
+    </item>
+    <item key="21" style="Item">
+      <text style="Item__Label">Item 21</text>
+    </item>
+    <item key="22" style="Item">
+      <text style="Item__Label">Item 22</text>
+    </item>
+    <item key="23" style="Item">
+      <text style="Item__Label">Item 23</text>
+    </item>
+    <item key="24" style="Item">
+      <text style="Item__Label">Item 24</text>
+    </item>
+    <item key="25" style="Item" id="item-25">
+      <text style="Item__Label">Item 25</text>
+      <view>
+        <behavior action="scroll" target="top" scroll:animated="true" />
+        <text style="TopItem__Link">Scroll to top</text>
+      </view>
+    </item>
+    <item key="26" style="Item">
+      <text style="Item__Label">Item 26</text>
+    </item>
+    <item key="27" style="Item">
+      <text style="Item__Label">Item 27</text>
+    </item>
+    <item key="28" style="Item">
+      <text style="Item__Label">Item 28</text>
+    </item>
+    <item key="29" style="Item">
+      <text style="Item__Label">Item 29</text>
+    </item>
+    <section-title style="List__Header">
+      <text style="List__HeaderText">3-</text>
+    </section-title>
+    <item key="30" style="Item">
+      <text style="Item__Label">Item 30</text>
+    </item>
+    <item key="31" style="Item">
+      <text style="Item__Label">Item 31</text>
+    </item>
+    <item key="32" style="Item">
+      <text style="Item__Label">Item 32</text>
+    </item>
+    <item key="33" style="Item">
+      <text style="Item__Label">Item 33</text>
+    </item>
+    <item key="34" style="Item">
+      <text style="Item__Label">Item 34</text>
+    </item>
+    <item key="35" style="Item" id="item-35">
+      <text style="Item__Label">Item 35</text>
+      <view>
+        <behavior action="scroll" target="top" scroll:animated="true" />
+        <text style="TopItem__Link">Scroll to top</text>
+      </view>
+    </item>
+    <item key="36" style="Item">
+      <text style="Item__Label">Item 36</text>
+    </item>
+    <item key="37" style="Item">
+      <text style="Item__Label">Item 37</text>
+    </item>
+    <item key="38" style="Item">
+      <text style="Item__Label">Item 38</text>
+    </item>
+    <item key="39" style="Item">
+      <text style="Item__Label">Item 39</text>
+    </item>
+    <section-title style="List__Header">
+      <text style="List__HeaderText">4-</text>
+    </section-title>
+    <item key="40" style="Item">
+      <text style="Item__Label">Item 40</text>
+    </item>
+    <item key="41" style="Item">
+      <text style="Item__Label">Item 41</text>
+    </item>
+    <item key="42" style="Item">
+      <text style="Item__Label">Item 42</text>
+    </item>
+    <item key="43" style="Item">
+      <text style="Item__Label">Item 43</text>
+    </item>
+    <item key="44" style="Item">
+      <text style="Item__Label">Item 44</text>
+    </item>
+    <item key="45" style="Item">
+      <text style="Item__Label">Item 45</text>
+    </item>
+    <item key="46" style="Item">
+      <text style="Item__Label">Item 46</text>
+    </item>
+    <item key="47" style="Item">
+      <text style="Item__Label">Item 47</text>
+    </item>
+    <item key="48" style="Item">
+      <text style="Item__Label">Item 48</text>
+    </item>
+    <item key="49" style="Item">
+      <text style="Item__Label">Item 49</text>
+    </item>
+    <item key="50" style="Item">
+      <text style="Item__Label">Item 50</text>
+    </item>
+    <item key="bottom" style="Item" id="bottom">
+      <view />
+      <view>
+        <behavior action="scroll" target="top" scroll:animated="true" />
+        <text style="TopItem__Link">Scroll to top</text>
+      </view>
+    </item>
+  </section-list>
+{% endblock %}

--- a/examples/advanced_behaviors/scroll/section_list_deprecated.xml.njk
+++ b/examples/advanced_behaviors/scroll/section_list_deprecated.xml.njk
@@ -1,0 +1,246 @@
+---
+title: "Section List (deprecated)"
+permalink: "/advanced_behaviors/scroll/section_list_deprecated.xml"
+tags: advanced_behaviors_scroll
+---
+
+{% extends 'base.xml.njk' %}
+{% block styles %}
+  <style id="List__HeaderText" fontSize="18" fontWeight="bold"/>
+  <style
+    id="List__Header"
+    alignItems="center"
+    backgroundColor="#eee"
+    flex="1"
+    flexDirection="row"
+    height="48"
+    paddingLeft="24"
+    paddingRight="24"
+  />
+  <style id="TopItem" backgroundColor="#ffffff" padding="24" borderBottomColor="#eee" borderBottomWidth="1" />
+  <style id="TopItem__Link" color="#4778FF" fontWeight="bold" marginTop="8" marginRight="16" alignSelf="flex-end" />
+{% endblock %}
+{% block container %}
+  <section-list xmlns:scroll="https://hyperview.org/hyperview-scroll">
+    <section>
+      <section-title style="List__Header">
+        <text style="List__HeaderText">Links</text>
+      </section-title>
+      <item key="top" style="TopItem" id="top">
+        <view>
+          <view>
+            <behavior action="scroll" target="item-15" />
+            <text style="TopItem__Link">Scroll to item 15</text>
+          </view>
+          <view>
+            <behavior action="scroll" target="item-25" scroll:offset="24" />
+            <text style="TopItem__Link">Scroll to item 25 with offset</text>
+          </view>
+          <view>
+            <behavior action="scroll" target="item-35" scroll:position="0.5" />
+            <text style="TopItem__Link">Scroll to item 35 with position</text>
+          </view>
+          <view>
+            <behavior action="scroll" target="bottom" scroll:animated="true" />
+            <text style="TopItem__Link">Scroll to bottom, animated</text>
+          </view>
+        </view>
+      </item>
+    </section>
+    <section>
+      <section-title style="List__Header">
+        <text style="List__HeaderText">-</text>
+      </section-title>
+      <item key="1" style="Item">
+        <behavior action="scroll" target="bottom" />
+        <text style="Item__Label">Item 1</text>
+      </item>
+      <item key="2" style="Item">
+        <text style="Item__Label">Item 2</text>
+      </item>
+      <item key="3" style="Item">
+        <text style="Item__Label">Item 3</text>
+      </item>
+      <item key="4" style="Item">
+        <text style="Item__Label">Item 4</text>
+      </item>
+      <item key="5" style="Item">
+        <text style="Item__Label">Item 5</text>
+      </item>
+      <item key="6" style="Item">
+        <text style="Item__Label">Item 6</text>
+      </item>
+      <item key="7" style="Item">
+        <text style="Item__Label">Item 7</text>
+      </item>
+      <item key="8" style="Item">
+        <text style="Item__Label">Item 8</text>
+      </item>
+      <item key="9" style="Item">
+        <text style="Item__Label">Item 9</text>
+      </item>
+    </section>
+    <section>
+      <section-title style="List__Header">
+        <text style="List__HeaderText">1-</text>
+      </section-title>
+      <item key="10" style="Item">
+        <text style="Item__Label">Item 10</text>
+      </item>
+      <item key="11" style="Item">
+        <text style="Item__Label">Item 11</text>
+      </item>
+      <item key="12" style="Item">
+        <text style="Item__Label">Item 12</text>
+      </item>
+      <item key="13" style="Item">
+        <text style="Item__Label">Item 13</text>
+      </item>
+      <item key="14" style="Item">
+        <text style="Item__Label">Item 14</text>
+      </item>
+      <item key="15" style="Item" id="item-15">
+        <text style="Item__Label">Item 15</text>
+        <view>
+          <behavior action="scroll" target="top" scroll:animated="true" />
+          <text style="TopItem__Link">Scroll to top</text>
+        </view>
+      </item>
+      <item key="16" style="Item">
+        <text style="Item__Label">Item 16</text>
+      </item>
+      <item key="17" style="Item">
+        <text style="Item__Label">Item 17</text>
+      </item>
+      <item key="18" style="Item">
+        <text style="Item__Label">Item 18</text>
+      </item>
+      <item key="19" style="Item">
+        <text style="Item__Label">Item 19</text>
+      </item>
+    </section>
+    <section>
+      <section-title style="List__Header">
+        <text style="List__HeaderText">2-</text>
+      </section-title>
+      <item key="20" style="Item">
+        <text style="Item__Label">Item 20</text>
+      </item>
+      <item key="21" style="Item">
+        <text style="Item__Label">Item 21</text>
+      </item>
+      <item key="22" style="Item">
+        <text style="Item__Label">Item 22</text>
+      </item>
+      <item key="23" style="Item">
+        <text style="Item__Label">Item 23</text>
+      </item>
+      <item key="24" style="Item">
+        <text style="Item__Label">Item 24</text>
+      </item>
+      <item key="25" style="Item" id="item-25">
+        <text style="Item__Label">Item 25</text>
+        <view>
+          <behavior action="scroll" target="top" scroll:animated="true" />
+          <text style="TopItem__Link">Scroll to top</text>
+        </view>
+      </item>
+      <item key="26" style="Item">
+        <text style="Item__Label">Item 26</text>
+      </item>
+      <item key="27" style="Item">
+        <text style="Item__Label">Item 27</text>
+      </item>
+      <item key="28" style="Item">
+        <text style="Item__Label">Item 28</text>
+      </item>
+      <item key="29" style="Item">
+        <text style="Item__Label">Item 29</text>
+      </item>
+    </section>
+    <section>
+      <section-title style="List__Header">
+        <text style="List__HeaderText">3-</text>
+      </section-title>
+      <item key="30" style="Item">
+        <text style="Item__Label">Item 30</text>
+      </item>
+      <item key="31" style="Item">
+        <text style="Item__Label">Item 31</text>
+      </item>
+      <item key="32" style="Item">
+        <text style="Item__Label">Item 32</text>
+      </item>
+      <item key="33" style="Item">
+        <text style="Item__Label">Item 33</text>
+      </item>
+      <item key="34" style="Item">
+        <text style="Item__Label">Item 34</text>
+      </item>
+      <item key="35" style="Item" id="item-35">
+        <text style="Item__Label">Item 35</text>
+        <view>
+          <behavior action="scroll" target="top" scroll:animated="true" />
+          <text style="TopItem__Link">Scroll to top</text>
+        </view>
+      </item>
+      <item key="36" style="Item">
+        <text style="Item__Label">Item 36</text>
+      </item>
+      <item key="37" style="Item">
+        <text style="Item__Label">Item 37</text>
+      </item>
+      <item key="38" style="Item">
+        <text style="Item__Label">Item 38</text>
+      </item>
+      <item key="39" style="Item">
+        <text style="Item__Label">Item 39</text>
+      </item>
+    </section>
+    <section>
+      <section-title style="List__Header">
+        <text style="List__HeaderText">4-</text>
+      </section-title>
+      <item key="40" style="Item">
+        <text style="Item__Label">Item 40</text>
+      </item>
+      <item key="41" style="Item">
+        <text style="Item__Label">Item 41</text>
+      </item>
+      <item key="42" style="Item">
+        <text style="Item__Label">Item 42</text>
+      </item>
+      <item key="43" style="Item">
+        <text style="Item__Label">Item 43</text>
+      </item>
+      <item key="44" style="Item">
+        <text style="Item__Label">Item 44</text>
+      </item>
+      <item key="45" style="Item">
+        <text style="Item__Label">Item 45</text>
+      </item>
+      <item key="46" style="Item">
+        <text style="Item__Label">Item 46</text>
+      </item>
+      <item key="47" style="Item">
+        <text style="Item__Label">Item 47</text>
+      </item>
+      <item key="48" style="Item">
+        <text style="Item__Label">Item 48</text>
+      </item>
+      <item key="49" style="Item">
+        <text style="Item__Label">Item 49</text>
+      </item>
+      <item key="50" style="Item">
+        <text style="Item__Label">Item 50</text>
+      </item>
+      <item key="bottom" style="Item" id="bottom">
+        <view />
+        <view>
+          <behavior action="scroll" target="top" scroll:animated="true" />
+          <text style="TopItem__Link">Scroll to top</text>
+        </view>
+      </item>
+    </section>
+  </section-list>
+{% endblock %}

--- a/examples/advanced_behaviors/scroll/section_list_deprecated.xml.njk
+++ b/examples/advanced_behaviors/scroll/section_list_deprecated.xml.njk
@@ -26,8 +26,8 @@ tags: advanced_behaviors_scroll
       <section-title style="List__Header">
         <text style="List__HeaderText">Links</text>
       </section-title>
-      <item key="top" style="TopItem" id="top">
-        <view>
+      <item key="top" style="TopItem">
+        <view id="top">
           <view>
             <behavior action="scroll" target="item-15" />
             <text style="TopItem__Link">Scroll to item 15</text>

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -5,11 +5,16 @@
   targetNamespace="https://hyperview.org/hyperview"
   xmlns:hv="https://hyperview.org/hyperview"
   xmlns:alert="https://hyperview.org/hyperview-alert"
+  xmlns:scroll="https://hyperview.org/hyperview-scroll"
 >
 
   <xs:import
     namespace="https://hyperview.org/hyperview-alert"
     schemaLocation="alert.xsd"
+  />
+  <xs:import
+    namespace="https://hyperview.org/hyperview-scroll"
+    schemaLocation="scroll.xsd"
   />
 
   <xs:simpleType name="action">
@@ -399,6 +404,7 @@
     <xs:attribute name="copy-to-clipboard-value" type="xs:string" />
     <xs:attribute name="immediate" type="xs:boolean" />
     <xs:attributeGroup ref="alert:alertAttributes" />
+    <xs:attributeGroup ref="scroll:scrollAttributes" />
   </xs:attributeGroup>
 
   <xs:attributeGroup name="scrollAttributes">

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -29,6 +29,7 @@
         <xs:enumeration value="copy-to-clipboard" />
         <xs:enumeration value="select-all" />
         <xs:enumeration value="unselect-all" />
+        <xs:enumeration value="scroll" />
       </xs:restriction>
     </xs:simpleType>
   </xs:redefine>

--- a/schema/scroll.xsd
+++ b/schema/scroll.xsd
@@ -1,0 +1,35 @@
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  attributeFormDefault="qualified"
+  elementFormDefault="qualified"
+  targetNamespace="https://hyperview.org/hyperview-scroll"
+  xmlns:hv="https://hyperview.org/hyperview"
+>
+  <xs:import
+    namespace="https://hyperview.org/hyperview"
+    schemaLocation="hyperview.xsd"
+  />
+
+  <xs:element name="option">
+    <xs:complexType>
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="hv:behavior" />
+      </xs:sequence>
+      <xs:attribute name="label" type="xs:string" use="required" />
+      <xs:attributeGroup ref="hv:behaviorAttributes" />
+    </xs:complexType>
+  </xs:element>
+
+  <xs:attributeGroup name="scrollAttributes">
+    <xs:attribute name="animated" type="xs:boolean" />
+    <xs:attribute name="offset" type="xs:integer" />
+    <xs:attribute name="position">
+      <xs:simpleType>
+        <xs:restriction base="xs:float">
+          <xs:minInclusive value="0" />
+          <xs:maxInclusive value="1" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+</xs:schema>

--- a/schema/scroll.xsd
+++ b/schema/scroll.xsd
@@ -9,17 +9,6 @@
     namespace="https://hyperview.org/hyperview"
     schemaLocation="hyperview.xsd"
   />
-
-  <xs:element name="option">
-    <xs:complexType>
-      <xs:sequence minOccurs="0" maxOccurs="unbounded">
-          <xs:element ref="hv:behavior" />
-      </xs:sequence>
-      <xs:attribute name="label" type="xs:string" use="required" />
-      <xs:attributeGroup ref="hv:behaviorAttributes" />
-    </xs:complexType>
-  </xs:element>
-
   <xs:attributeGroup name="scrollAttributes">
     <xs:attribute name="animated" type="xs:boolean" />
     <xs:attribute name="offset" type="xs:integer" />

--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -40,6 +40,8 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
 
   static localNameAliases = [];
 
+  static contextType = Contexts.DocContext;
+
   parser: DOMParser = new DOMParser();
 
   props: HvComponentProps;
@@ -73,7 +75,7 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
       console.warn('[behaviors/scroll]: missing "target" attribute');
       return;
     }
-    const doc: ?Document = this.props.element.ownerDocument;
+    const doc: ?Document = this.context();
     const targetElement: ?Element = doc?.getElementById(targetId);
     if (!targetElement) {
       return;

--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -235,6 +235,7 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
           const RefreshControl = ContextRefreshControl || DefaultRefreshControl;
           return (
             <FlatList
+              ref={this.onRef}
               data={this.getItems()}
               horizontal={horizontal}
               keyExtractor={item => item && item.getAttribute('key')}
@@ -250,7 +251,7 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
                 Render.renderElement(
                   item,
                   this.props.stylesheets,
-                  this.props.onUpdate,
+                  this.onUpdate,
                   this.props.options,
                 )
               }

--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -31,8 +31,6 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
 
   static localNameAliases = [];
 
-  static contextType = Contexts.RefreshControlComponentContext;
-
   parser: DOMParser = new DOMParser();
 
   props: HvComponentProps;
@@ -129,42 +127,40 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
         ? [...acc, index]
         : acc;
     }, []);
-    const listProps = {
-      data: this.getItems(),
-      horizontal,
-      keyExtractor: item => item && item.getAttribute('key'),
-      renderItem: ({ item }) =>
-        item &&
-        Render.renderElement(
-          item,
-          this.props.stylesheets,
-          this.props.onUpdate,
-          this.props.options,
-        ),
-      scrollIndicatorInsets,
-      showsHorizontalScrollIndicator: horizontal && showScrollIndicator,
-      showsVerticalScrollIndicator: !horizontal && showScrollIndicator,
-      stickyHeaderIndices,
-      style,
-    };
 
-    let refreshProps = {};
-    if (this.props.element.getAttribute('trigger') === 'refresh') {
-      const RefreshControl = this.context || DefaultRefreshControl;
-      refreshProps = {
-        refreshControl: (
-          <RefreshControl
-            onRefresh={this.refresh}
-            refreshing={this.state.refreshing}
-          />
-        ),
-      };
-    }
-
-    // $FlowFixMe
-    return React.createElement(FlatList, {
-      ...listProps,
-      ...refreshProps,
-    });
+    return (
+      <Contexts.RefreshControlComponentContext.Consumer>
+        {ContextRefreshControl => {
+          const RefreshControl = ContextRefreshControl || DefaultRefreshControl;
+          return (
+            <FlatList
+              data={this.getItems()}
+              horizontal={horizontal}
+              keyExtractor={item => item && item.getAttribute('key')}
+              refreshControl={
+                <RefreshControl
+                  onRefresh={this.refresh}
+                  refreshing={this.state.refreshing}
+                />
+              }
+              renderItem={({ item }) =>
+                item &&
+                Render.renderElement(
+                  item,
+                  this.props.stylesheets,
+                  this.props.onUpdate,
+                  this.props.options,
+                )
+              }
+              scrollIndicatorInsets={scrollIndicatorInsets}
+              showsHorizontalScrollIndicator={horizontal && showScrollIndicator}
+              showsVerticalScrollIndicator={!horizontal && showScrollIndicator}
+              stickyHeaderIndices={stickyHeaderIndices}
+              style={style}
+            />
+          );
+        }}
+      </Contexts.RefreshControlComponentContext.Consumer>
+    );
   }
 }

--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -13,16 +13,25 @@ import * as Contexts from 'hyperview/src/contexts';
 import * as Dom from 'hyperview/src/services/dom';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
+import type {
+  DOMString,
+  Document,
+  Element,
+  HvComponentOnUpdate,
+  HvComponentOptions,
+  HvComponentProps,
+} from 'hyperview/src/types';
 import {
   RefreshControl as DefaultRefreshControl,
   FlatList,
   Platform,
 } from 'react-native';
 import React, { PureComponent } from 'react';
+import type { ScrollParams, State } from './types';
 import { DOMParser } from '@instawork/xmldom';
-import type { HvComponentProps } from 'hyperview/src/types';
+import type { ElementRef } from 'react';
 import { LOCAL_NAME } from 'hyperview/src/types';
-import type { State } from './types';
+import { getAncestorByTagName } from 'hyperview/src/services';
 
 export default class HvList extends PureComponent<HvComponentProps, State> {
   static namespaceURI = Namespaces.HYPERVIEW;
@@ -35,8 +44,98 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
 
   props: HvComponentProps;
 
+  ref: ?ElementRef<typeof FlatList>;
+
   state: State = {
     refreshing: false,
+  };
+
+  onRef = (ref: ?ElementRef<typeof FlatList>) => {
+    this.ref = ref;
+  };
+
+  onUpdate: HvComponentOnUpdate = (
+    href: ?DOMString,
+    action: ?DOMString,
+    element: Element,
+    options: HvComponentOptions,
+  ) => {
+    if (action === 'scroll' && options.behaviorElement) {
+      this.handleScrollBehavior(options.behaviorElement);
+      return;
+    }
+    this.props.onUpdate(href, action, element, options);
+  };
+
+  handleScrollBehavior = (behaviorElement: Element) => {
+    const targetId: ?DOMString = behaviorElement?.getAttribute('target');
+    if (!targetId) {
+      console.warn('[behaviors/scroll]: missing "target" attribute');
+      return;
+    }
+    const doc: ?Document = this.props.element.ownerDocument;
+    const targetElement: ?Element = doc?.getElementById(targetId);
+    if (!targetElement) {
+      return;
+    }
+
+    const targetElementParentList = getAncestorByTagName(
+      targetElement,
+      LOCAL_NAME.LIST,
+    );
+    if (targetElementParentList === this.props.element) {
+      const listItems = Array.from(
+        this.props.element.getElementsByTagNameNS(
+          Namespaces.HYPERVIEW,
+          LOCAL_NAME.ITEM,
+        ),
+      );
+
+      // Target can either be an <item> or a child of an <item>
+      const targetListItem =
+        targetElement.localName === LOCAL_NAME.ITEM
+          ? targetElement
+          : getAncestorByTagName(targetElement, LOCAL_NAME.ITEM);
+
+      if (targetListItem) {
+        // find index of target in list
+        const index = listItems.indexOf(targetListItem);
+        if (index >= 0) {
+          const animated: boolean =
+            behaviorElement?.getAttributeNS(
+              Namespaces.HYPERVIEW_SCROLL,
+              'animated',
+            ) === 'true';
+          const params: ScrollParams = { animated, index };
+
+          const viewOffset: ?number =
+            parseInt(
+              behaviorElement?.getAttributeNS(
+                Namespaces.HYPERVIEW_SCROLL,
+                'offset',
+              ),
+              10,
+            ) || undefined;
+          if (typeof viewOffset === 'number') {
+            params.viewOffset = viewOffset;
+          }
+
+          const viewPosition: ?number =
+            parseFloat(
+              behaviorElement?.getAttributeNS(
+                Namespaces.HYPERVIEW_SCROLL,
+                'position',
+              ),
+            ) || undefined;
+
+          if (typeof viewPosition === 'number') {
+            params.viewPosition = viewPosition;
+          }
+
+          this.ref?.scrollToIndex(params);
+        }
+      }
+    }
   };
 
   refresh = () => {

--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -83,59 +83,61 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
       targetElement,
       LOCAL_NAME.LIST,
     );
-    if (targetElementParentList === this.props.element) {
-      const listItems = Array.from(
-        this.props.element.getElementsByTagNameNS(
-          Namespaces.HYPERVIEW,
-          LOCAL_NAME.ITEM,
-        ),
-      );
-
-      // Target can either be an <item> or a child of an <item>
-      const targetListItem =
-        targetElement.localName === LOCAL_NAME.ITEM
-          ? targetElement
-          : getAncestorByTagName(targetElement, LOCAL_NAME.ITEM);
-
-      if (targetListItem) {
-        // find index of target in list
-        const index = listItems.indexOf(targetListItem);
-        if (index >= 0) {
-          const animated: boolean =
-            behaviorElement?.getAttributeNS(
-              Namespaces.HYPERVIEW_SCROLL,
-              'animated',
-            ) === 'true';
-          const params: ScrollParams = { animated, index };
-
-          const viewOffset: ?number =
-            parseInt(
-              behaviorElement?.getAttributeNS(
-                Namespaces.HYPERVIEW_SCROLL,
-                'offset',
-              ),
-              10,
-            ) || undefined;
-          if (typeof viewOffset === 'number') {
-            params.viewOffset = viewOffset;
-          }
-
-          const viewPosition: ?number =
-            parseFloat(
-              behaviorElement?.getAttributeNS(
-                Namespaces.HYPERVIEW_SCROLL,
-                'position',
-              ),
-            ) || undefined;
-
-          if (typeof viewPosition === 'number') {
-            params.viewPosition = viewPosition;
-          }
-
-          this.ref?.scrollToIndex(params);
-        }
-      }
+    if (targetElementParentList !== this.props.element) {
+      return;
     }
+    const listItems = Array.from(
+      this.props.element.getElementsByTagNameNS(
+        Namespaces.HYPERVIEW,
+        LOCAL_NAME.ITEM,
+      ),
+    );
+
+    // Target can either be an <item> or a child of an <item>
+    const targetListItem =
+      targetElement.localName === LOCAL_NAME.ITEM
+        ? targetElement
+        : getAncestorByTagName(targetElement, LOCAL_NAME.ITEM);
+
+    if (!targetListItem) {
+      return;
+    }
+
+    // find index of target in list
+    const index = listItems.indexOf(targetListItem);
+    if (index < 0) {
+      return;
+    }
+
+    const animated: boolean =
+      behaviorElement?.getAttributeNS(
+        Namespaces.HYPERVIEW_SCROLL,
+        'animated',
+      ) === 'true';
+    const params: ScrollParams = { animated, index };
+
+    const viewOffset: ?number =
+      parseInt(
+        behaviorElement?.getAttributeNS(Namespaces.HYPERVIEW_SCROLL, 'offset'),
+        10,
+      ) || undefined;
+    if (typeof viewOffset === 'number') {
+      params.viewOffset = viewOffset;
+    }
+
+    const viewPosition: ?number =
+      parseFloat(
+        behaviorElement?.getAttributeNS(
+          Namespaces.HYPERVIEW_SCROLL,
+          'position',
+        ),
+      ) || undefined;
+
+    if (typeof viewPosition === 'number') {
+      params.viewPosition = viewPosition;
+    }
+
+    this.ref?.scrollToIndex(params);
   };
 
   refresh = () => {

--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -143,6 +143,7 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
                   refreshing={this.state.refreshing}
                 />
               }
+              removeClippedSubviews={false}
               renderItem={({ item }) =>
                 item &&
                 Render.renderElement(

--- a/src/components/hv-list/types.js
+++ b/src/components/hv-list/types.js
@@ -11,3 +11,11 @@
 export type State = {|
   refreshing: boolean,
 |};
+
+// https://reactnative.dev/docs/flatlist#scrolltoindex
+export type ScrollParams = {|
+  animated?: ?boolean,
+  index: number,
+  viewOffset?: number,
+  viewPosition?: number,
+|};

--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -351,6 +351,7 @@ export default class HvSectionList extends PureComponent<
           const RefreshControl = ContextRefreshControl || DefaultRefreshControl;
           return (
             <SectionList
+              ref={this.onRef}
               keyExtractor={item => item.getAttribute('key')}
               refreshControl={
                 <RefreshControl
@@ -364,7 +365,7 @@ export default class HvSectionList extends PureComponent<
                 Render.renderElement(
                   item,
                   this.props.stylesheets,
-                  this.props.onUpdate,
+                  this.onUpdate,
                   this.props.options,
                 )
               }
@@ -373,7 +374,7 @@ export default class HvSectionList extends PureComponent<
                 Render.renderElement(
                   title,
                   this.props.stylesheets,
-                  this.props.onUpdate,
+                  this.onUpdate,
                   this.props.options,
                 )
               }

--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -35,8 +35,6 @@ export default class HvSectionList extends PureComponent<
 
   static localNameAliases = [];
 
-  static contextType = Contexts.RefreshControlComponentContext;
-
   parser: DOMParser = new DOMParser();
 
   props: HvComponentProps;
@@ -45,7 +43,7 @@ export default class HvSectionList extends PureComponent<
     refreshing: false,
   };
 
-  getStickySectionHeadersEnabled = (): ?boolean => {
+  getStickySectionHeadersEnabled = (): boolean => {
     const stickySectionTitles = this.props.element.getAttribute(
       'sticky-section-titles',
     );
@@ -55,7 +53,12 @@ export default class HvSectionList extends PureComponent<
     if (stickySectionTitles === 'false') {
       return false;
     }
-    return undefined;
+    // Set platform default behavior
+    // https://reactnative.dev/docs/sectionlist#stickysectionheadersenabled
+    return Platform.select({
+      android: false,
+      ios: true,
+    });
   };
 
   refresh = () => {
@@ -147,46 +150,45 @@ export default class HvSectionList extends PureComponent<
         ? { right: 1 }
         : undefined;
 
-    const listProps = {
-      keyExtractor: item => item.getAttribute('key'),
-      renderItem: ({ item }) =>
-        Render.renderElement(
-          item,
-          this.props.stylesheets,
-          this.props.onUpdate,
-          this.props.options,
-        ),
-      renderSectionHeader: ({ section: { title } }) =>
-        Render.renderElement(
-          title,
-          this.props.stylesheets,
-          this.props.onUpdate,
-          this.props.options,
-        ),
-      scrollIndicatorInsets,
-      sections,
-      stickySectionHeadersEnabled: this.getStickySectionHeadersEnabled(),
-      style,
-    };
-
-    let refreshProps = {};
-    if (this.props.element.getAttribute('trigger') === 'refresh') {
-      const RefreshControl = this.context || DefaultRefreshControl;
-      refreshProps = {
-        refreshControl: (
-          <RefreshControl
-            onRefresh={this.refresh}
-            refreshing={this.state.refreshing}
-          />
-        ),
-      };
-    }
-
-    const props: any = {
-      ...listProps,
-      ...refreshProps,
-    };
-
-    return React.createElement(SectionList, props);
+    return (
+      <Contexts.RefreshControlComponentContext.Consumer>
+        {ContextRefreshControl => {
+          const RefreshControl = ContextRefreshControl || DefaultRefreshControl;
+          return (
+            <SectionList
+              keyExtractor={item => item.getAttribute('key')}
+              refreshControl={
+                <RefreshControl
+                  onRefresh={this.refresh}
+                  refreshing={this.state.refreshing}
+                />
+              }
+              renderItem={({ item }) =>
+                // $FlowFixMe: return type of renderElement is not compatible with expected type for renderItem
+                Render.renderElement(
+                  item,
+                  this.props.stylesheets,
+                  this.props.onUpdate,
+                  this.props.options,
+                )
+              }
+              renderSectionHeader={({ section: { title } }) =>
+                // $FlowFixMe: return type of renderElement is not compatible with expected type for renderSectionHeader
+                Render.renderElement(
+                  title,
+                  this.props.stylesheets,
+                  this.props.onUpdate,
+                  this.props.options,
+                )
+              }
+              scrollIndicatorInsets={scrollIndicatorInsets}
+              sections={sections}
+              stickySectionHeadersEnabled={this.getStickySectionHeadersEnabled()}
+              style={style}
+            />
+          );
+        }}
+      </Contexts.RefreshControlComponentContext.Consumer>
+    );
   }
 }

--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -163,6 +163,7 @@ export default class HvSectionList extends PureComponent<
                   refreshing={this.state.refreshing}
                 />
               }
+              removeClippedSubviews={false}
               renderItem={({ item }) =>
                 // $FlowFixMe: return type of renderElement is not compatible with expected type for renderItem
                 Render.renderElement(

--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -10,20 +10,66 @@
 
 // $FlowFixMe: importing code from TypeScript
 import * as Contexts from 'hyperview/src/contexts';
+import * as Dom from 'hyperview/src/services/dom';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
+import type {
+  DOMString,
+  Document,
+  Element,
+  HvComponentOnUpdate,
+  HvComponentOptions,
+  HvComponentProps,
+  Node,
+  NodeList,
+} from 'hyperview/src/types';
 import {
   RefreshControl as DefaultRefreshControl,
   Platform,
   SectionList,
 } from 'react-native';
-
+import { LOCAL_NAME, NODE_TYPE } from 'hyperview/src/types';
 import React, { PureComponent } from 'react';
-
+import type { ScrollParams, State } from './types';
 import { DOMParser } from '@instawork/xmldom';
-import type { HvComponentProps } from 'hyperview/src/types';
-import { LOCAL_NAME } from 'hyperview/src/types';
-import type { State } from './types';
+import type { ElementRef } from 'react';
+import { getAncestorByTagName } from 'hyperview/src/services';
+
+const getSectionIndex = (
+  sectionTitle: Node,
+  sectionTitles: NodeList<Element>,
+): number => {
+  const sectionIndex = Array.from(sectionTitles).indexOf(sectionTitle);
+
+  // If first section did not have an explicit title, we still need to account for it
+  const previousElement = Dom.getPreviousNodeOfType(
+    sectionTitles[0],
+    NODE_TYPE.ELEMENT_NODE,
+  );
+  if (previousElement?.localName === LOCAL_NAME.ITEM) {
+    return sectionIndex + 1;
+  }
+
+  return sectionIndex;
+};
+
+const getPreviousSectionTitle = (
+  element: Node,
+  itemIndex: number,
+): [?Node, number] => {
+  const { previousSibling } = element;
+  if (!previousSibling) {
+    return [null, itemIndex];
+  }
+  if (previousSibling.localName === LOCAL_NAME.SECTION_TITLE) {
+    return [previousSibling, itemIndex];
+  }
+  if (previousSibling.localName === LOCAL_NAME.ITEM) {
+    // eslint-disable-next-line no-param-reassign
+    itemIndex += 1;
+  }
+  return getPreviousSectionTitle(previousSibling, itemIndex);
+};
 
 export default class HvSectionList extends PureComponent<
   HvComponentProps,
@@ -39,8 +85,156 @@ export default class HvSectionList extends PureComponent<
 
   props: HvComponentProps;
 
+  ref: ?ElementRef<typeof SectionList>;
+
   state: State = {
     refreshing: false,
+  };
+
+  onRef = (ref: ?ElementRef<typeof SectionList>) => {
+    this.ref = ref;
+  };
+
+  onUpdate: HvComponentOnUpdate = (
+    href: ?DOMString,
+    action: ?DOMString,
+    element: Element,
+    options: HvComponentOptions,
+  ) => {
+    if (action === 'scroll' && options.behaviorElement) {
+      this.handleScrollBehavior(options.behaviorElement);
+      return;
+    }
+    this.props.onUpdate(href, action, element, options);
+  };
+
+  handleScrollBehavior = (behaviorElement: Element) => {
+    const targetId: ?DOMString = behaviorElement?.getAttribute('target');
+    if (!targetId) {
+      console.warn('[behaviors/scroll]: missing "target" attribute');
+      return;
+    }
+    const doc: ?Document = this.props.element.ownerDocument;
+    const targetElement: ?Element = doc?.getElementById(targetId);
+    if (!targetElement) {
+      return;
+    }
+
+    const targetElementParentList = getAncestorByTagName(
+      targetElement,
+      LOCAL_NAME.SECTION_LIST,
+    );
+    if (targetElementParentList === this.props.element) {
+      // Target can either be an <item> or a child of an <item>
+      const targetListItem =
+        targetElement.localName === LOCAL_NAME.ITEM
+          ? targetElement
+          : getAncestorByTagName(targetElement, LOCAL_NAME.ITEM);
+
+      const animated: boolean =
+        behaviorElement?.getAttributeNS(
+          Namespaces.HYPERVIEW_SCROLL,
+          'animated',
+        ) === 'true';
+
+      const viewOffset: ?number =
+        parseInt(
+          behaviorElement?.getAttributeNS(
+            Namespaces.HYPERVIEW_SCROLL,
+            'offset',
+          ),
+          10,
+        ) || undefined;
+
+      const viewPosition: ?number =
+        parseFloat(
+          behaviorElement?.getAttributeNS(
+            Namespaces.HYPERVIEW_SCROLL,
+            'position',
+          ),
+        ) || undefined;
+
+      if (targetListItem) {
+        // find index of target in section-list
+        // first, check legacy section-list format, where items are nested under a <section>
+        const targetElementParentSection = getAncestorByTagName(
+          targetElement,
+          LOCAL_NAME.SECTION,
+        );
+        if (targetElementParentSection) {
+          const sections = this.props.element.getElementsByTagNameNS(
+            Namespaces.HYPERVIEW,
+            LOCAL_NAME.SECTION,
+          );
+          const sectionIndex = Array.from(sections).indexOf(
+            targetElementParentSection,
+          );
+          if (sectionIndex === -1) {
+            return;
+          }
+          const itemsInSection = Array.from(
+            targetElementParentSection.getElementsByTagNameNS(
+              Namespaces.HYPERVIEW,
+              LOCAL_NAME.ITEM,
+            ),
+          );
+          const itemIndex = itemsInSection.indexOf(targetListItem);
+          if (itemIndex === -1) {
+            return;
+          }
+
+          const params: ScrollParams = {
+            animated,
+            itemIndex: itemIndex + 1,
+            sectionIndex,
+          };
+          if (typeof viewOffset === 'number') {
+            params.viewOffset = viewOffset;
+          }
+
+          if (typeof viewPosition === 'number') {
+            params.viewPosition = viewPosition;
+          }
+
+          this.ref?.scrollToLocation(params);
+        } else {
+          // No parent section? Check new section-list format, where items are nested under the section-list
+          const items = this.props.element.getElementsByTagNameNS(
+            Namespaces.HYPERVIEW,
+            LOCAL_NAME.ITEM,
+          );
+          if (Array.from(items).indexOf(targetListItem) === -1) {
+            return;
+          }
+          const [sectionTitle, itemIndex] = getPreviousSectionTitle(
+            targetListItem,
+            1, // 1 instead of 0 as it appears itemIndex is 1-based
+          );
+          const sectionTitles = this.props.element.getElementsByTagNameNS(
+            Namespaces.HYPERVIEW,
+            LOCAL_NAME.SECTION_TITLE,
+          );
+          const sectionIndex = sectionTitle
+            ? getSectionIndex(sectionTitle, sectionTitles)
+            : 0;
+          if (sectionIndex === -1) {
+            return;
+          }
+          const params: ScrollParams = {
+            animated,
+            itemIndex,
+            sectionIndex,
+          };
+          if (viewOffset) {
+            params.viewOffset = viewOffset;
+          }
+          if (viewPosition) {
+            params.viewPosition = viewPosition;
+          }
+          this.ref?.scrollToLocation(params);
+        }
+      }
+    }
   };
 
   getStickySectionHeadersEnabled = (): boolean => {

--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -81,6 +81,8 @@ export default class HvSectionList extends PureComponent<
 
   static localNameAliases = [];
 
+  static contextType = Contexts.DocContext;
+
   parser: DOMParser = new DOMParser();
 
   props: HvComponentProps;
@@ -114,7 +116,7 @@ export default class HvSectionList extends PureComponent<
       console.warn('[behaviors/scroll]: missing "target" attribute');
       return;
     }
-    const doc: ?Document = this.props.element.ownerDocument;
+    const doc: ?Document = this.context();
     const targetElement: ?Element = doc?.getElementById(targetId);
     if (!targetElement) {
       return;

--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -124,116 +124,117 @@ export default class HvSectionList extends PureComponent<
       targetElement,
       LOCAL_NAME.SECTION_LIST,
     );
-    if (targetElementParentList === this.props.element) {
-      // Target can either be an <item> or a child of an <item>
-      const targetListItem =
-        targetElement.localName === LOCAL_NAME.ITEM
-          ? targetElement
-          : getAncestorByTagName(targetElement, LOCAL_NAME.ITEM);
+    if (targetElementParentList !== this.props.element) {
+      return;
+    }
 
-      const animated: boolean =
+    // Target can either be an <item> or a child of an <item>
+    const targetListItem =
+      targetElement.localName === LOCAL_NAME.ITEM
+        ? targetElement
+        : getAncestorByTagName(targetElement, LOCAL_NAME.ITEM);
+
+    const animated: boolean =
+      behaviorElement?.getAttributeNS(
+        Namespaces.HYPERVIEW_SCROLL,
+        'animated',
+      ) === 'true';
+
+    const viewOffset: ?number =
+      parseInt(
+        behaviorElement?.getAttributeNS(Namespaces.HYPERVIEW_SCROLL, 'offset'),
+        10,
+      ) || undefined;
+
+    const viewPosition: ?number =
+      parseFloat(
         behaviorElement?.getAttributeNS(
           Namespaces.HYPERVIEW_SCROLL,
-          'animated',
-        ) === 'true';
+          'position',
+        ),
+      ) || undefined;
 
-      const viewOffset: ?number =
-        parseInt(
-          behaviorElement?.getAttributeNS(
-            Namespaces.HYPERVIEW_SCROLL,
-            'offset',
-          ),
-          10,
-        ) || undefined;
+    if (!targetListItem) {
+      return;
+    }
 
-      const viewPosition: ?number =
-        parseFloat(
-          behaviorElement?.getAttributeNS(
-            Namespaces.HYPERVIEW_SCROLL,
-            'position',
-          ),
-        ) || undefined;
-
-      if (targetListItem) {
-        // find index of target in section-list
-        // first, check legacy section-list format, where items are nested under a <section>
-        const targetElementParentSection = getAncestorByTagName(
-          targetElement,
-          LOCAL_NAME.SECTION,
-        );
-        if (targetElementParentSection) {
-          const sections = this.props.element.getElementsByTagNameNS(
-            Namespaces.HYPERVIEW,
-            LOCAL_NAME.SECTION,
-          );
-          const sectionIndex = Array.from(sections).indexOf(
-            targetElementParentSection,
-          );
-          if (sectionIndex === -1) {
-            return;
-          }
-          const itemsInSection = Array.from(
-            targetElementParentSection.getElementsByTagNameNS(
-              Namespaces.HYPERVIEW,
-              LOCAL_NAME.ITEM,
-            ),
-          );
-          const itemIndex = itemsInSection.indexOf(targetListItem);
-          if (itemIndex === -1) {
-            return;
-          }
-
-          const params: ScrollParams = {
-            animated,
-            itemIndex: itemIndex + 1,
-            sectionIndex,
-          };
-          if (typeof viewOffset === 'number') {
-            params.viewOffset = viewOffset;
-          }
-
-          if (typeof viewPosition === 'number') {
-            params.viewPosition = viewPosition;
-          }
-
-          this.ref?.scrollToLocation(params);
-        } else {
-          // No parent section? Check new section-list format, where items are nested under the section-list
-          const items = this.props.element.getElementsByTagNameNS(
-            Namespaces.HYPERVIEW,
-            LOCAL_NAME.ITEM,
-          );
-          if (Array.from(items).indexOf(targetListItem) === -1) {
-            return;
-          }
-          const [sectionTitle, itemIndex] = getPreviousSectionTitle(
-            targetListItem,
-            1, // 1 instead of 0 as it appears itemIndex is 1-based
-          );
-          const sectionTitles = this.props.element.getElementsByTagNameNS(
-            Namespaces.HYPERVIEW,
-            LOCAL_NAME.SECTION_TITLE,
-          );
-          const sectionIndex = sectionTitle
-            ? getSectionIndex(sectionTitle, sectionTitles)
-            : 0;
-          if (sectionIndex === -1) {
-            return;
-          }
-          const params: ScrollParams = {
-            animated,
-            itemIndex,
-            sectionIndex,
-          };
-          if (viewOffset) {
-            params.viewOffset = viewOffset;
-          }
-          if (viewPosition) {
-            params.viewPosition = viewPosition;
-          }
-          this.ref?.scrollToLocation(params);
-        }
+    // find index of target in section-list
+    // first, check legacy section-list format, where items are nested under a <section>
+    const targetElementParentSection = getAncestorByTagName(
+      targetElement,
+      LOCAL_NAME.SECTION,
+    );
+    if (targetElementParentSection) {
+      const sections = this.props.element.getElementsByTagNameNS(
+        Namespaces.HYPERVIEW,
+        LOCAL_NAME.SECTION,
+      );
+      const sectionIndex = Array.from(sections).indexOf(
+        targetElementParentSection,
+      );
+      if (sectionIndex === -1) {
+        return;
       }
+      const itemsInSection = Array.from(
+        targetElementParentSection.getElementsByTagNameNS(
+          Namespaces.HYPERVIEW,
+          LOCAL_NAME.ITEM,
+        ),
+      );
+      const itemIndex = itemsInSection.indexOf(targetListItem);
+      if (itemIndex === -1) {
+        return;
+      }
+
+      const params: ScrollParams = {
+        animated,
+        itemIndex: itemIndex + 1,
+        sectionIndex,
+      };
+      if (typeof viewOffset === 'number') {
+        params.viewOffset = viewOffset;
+      }
+
+      if (typeof viewPosition === 'number') {
+        params.viewPosition = viewPosition;
+      }
+
+      this.ref?.scrollToLocation(params);
+    } else {
+      // No parent section? Check new section-list format, where items are nested under the section-list
+      const items = this.props.element.getElementsByTagNameNS(
+        Namespaces.HYPERVIEW,
+        LOCAL_NAME.ITEM,
+      );
+      if (Array.from(items).indexOf(targetListItem) === -1) {
+        return;
+      }
+      const [sectionTitle, itemIndex] = getPreviousSectionTitle(
+        targetListItem,
+        1, // 1 instead of 0 as it appears itemIndex is 1-based
+      );
+      const sectionTitles = this.props.element.getElementsByTagNameNS(
+        Namespaces.HYPERVIEW,
+        LOCAL_NAME.SECTION_TITLE,
+      );
+      const sectionIndex = sectionTitle
+        ? getSectionIndex(sectionTitle, sectionTitles)
+        : 0;
+      if (sectionIndex === -1) {
+        return;
+      }
+      const params: ScrollParams = {
+        animated,
+        itemIndex,
+        sectionIndex,
+      };
+      if (viewOffset) {
+        params.viewOffset = viewOffset;
+      }
+      if (viewPosition) {
+        params.viewPosition = viewPosition;
+      }
+      this.ref?.scrollToLocation(params);
     }
   };
 

--- a/src/components/hv-section-list/types.js
+++ b/src/components/hv-section-list/types.js
@@ -11,3 +11,12 @@
 export type State = {|
   refreshing: boolean,
 |};
+
+// https://reactnative.dev/docs/sectionlist#scrolltolocation
+export type ScrollParams = {|
+  animated?: ?boolean,
+  itemIndex: number,
+  sectionIndex: number,
+  viewOffset?: number,
+  viewPosition?: number,
+|};

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import * as TypesLegacy from 'hyperview/src/types-legacy';
 import type { ComponentType } from 'react';
 import React from 'react';
 import type { RefreshControlProps } from 'react-native';
@@ -22,3 +23,7 @@ export const DateFormatContext = React.createContext<
 export const RefreshControlComponentContext = React.createContext<
   ComponentType<RefreshControlProps> | undefined
 >(undefined);
+
+export const DocContext = React.createContext<{
+  getDoc: () => TypesLegacy.Document;
+} | null>(null);

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -53,6 +53,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
             onParseBefore={this.props.onParseBefore}
             openModal={this.props.openModal}
             push={this.props.push}
+            refreshControl={this.props.refreshControl}
             route={this.props.route}
           />
         </Contexts.RefreshControlComponentContext.Provider>

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -321,12 +321,14 @@ export default class HvScreen extends React.Component {
     );
 
     return (
-      <Contexts.DateFormatContext.Provider value={this.props.formatDate}>
-        <Contexts.RefreshControlComponentContext.Provider value={this.props.refreshControl}>
-          {screenElement}
-          {elementErrorComponent ? (React.createElement(elementErrorComponent, { error: this.state.elementError, onPressReload: () => this.reload() })) : null}
-        </Contexts.RefreshControlComponentContext.Provider>
-      </Contexts.DateFormatContext.Provider>
+      <Contexts.DocContext.Provider value={() => this.doc}>
+        <Contexts.DateFormatContext.Provider value={this.props.formatDate}>
+          <Contexts.RefreshControlComponentContext.Provider value={this.props.refreshControl}>
+            {screenElement}
+            {elementErrorComponent ? (React.createElement(elementErrorComponent, { error: this.state.elementError, onPressReload: () => this.reload() })) : null}
+          </Contexts.RefreshControlComponentContext.Provider>
+        </Contexts.DateFormatContext.Provider>
+      </Contexts.DocContext.Provider>
     );
   }
 

--- a/src/services/dom/helpers.js
+++ b/src/services/dom/helpers.js
@@ -42,6 +42,16 @@ export const getFirstTag = (
   return null;
 };
 
+export const getPreviousNodeOfType = (node: ?Node, type: NodeType): ?Node => {
+  if (!node || !node.previousSibling) {
+    return null;
+  }
+  if (node.previousSibling?.nodeType === type) {
+    return node.previousSibling;
+  }
+  return getPreviousNodeOfType(node.previousSibling, type);
+};
+
 /**
  * N-ary Tree Preorder Traversal
  */

--- a/src/services/namespaces/index.js
+++ b/src/services/namespaces/index.js
@@ -11,6 +11,7 @@
 // Core Namespaces
 export const HYPERVIEW = 'https://hyperview.org/hyperview';
 export const HYPERVIEW_ALERT = 'https://hyperview.org/hyperview-alert';
+export const HYPERVIEW_SCROLL = 'https://hyperview.org/hyperview-scroll';
 
 // Custom namespaces
 export const SHARE = 'https://instawork.com/hyperview-share';


### PR DESCRIPTION
Add new behavior action `scroll`, that scrolls a `<list>` or `<section-list>` to desired `target`. Implementing the same support as part of scrollable views is a larger effort, so we'll postpone this until needed.

See included list and section list examples for usage.

TODO:
- [X] Add docs

| iOS | Android |
|-----|--------|
| ![iOS](https://github.com/Instawork/hyperview/assets/309515/8db0d69a-1b65-44fe-b5f0-f1f28431f96e) | ![android](https://github.com/Instawork/hyperview/assets/309515/abce676d-be61-4a18-a2ed-50943ccd441c) |


