### PR TITLE
fix(picker-field): Unwanted style

### DIFF
--- a/src/components/hv-picker-field/index.ios.js
+++ b/src/components/hv-picker-field/index.ios.js
@@ -176,15 +176,6 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
       style.push({ color: placeholderTextColor });
     }
 
-    const fieldStyle: Array<StyleSheet> = createStyleProp(
-      this.props.element,
-      this.props.stylesheets,
-      {
-        ...this.props.options,
-        styleAttr: 'field-style',
-      },
-    );
-
     // Gets all of the <picker-item> elements. All picker item elements
     // with a value and label are turned into options for the picker.
     const children = this.getPickerItems()
@@ -217,11 +208,7 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
             options={this.props.options}
             stylesheets={this.props.stylesheets}
           >
-            <View
-              accessibilityLabel={accessibilityLabel}
-              style={fieldStyle}
-              testID={testID}
-            >
+            <View accessibilityLabel={accessibilityLabel} testID={testID}>
               <Picker
                 onValueChange={this.setPickerValue}
                 selectedValue={this.getPickerValue()}


### PR DESCRIPTION
Remove `field-style` stylesheet that was applied to the intermediate view wrapping the picker - this style is already applied to the actual field UI (see src/components/hv-picker-field/field/index.js), and its presence is causing improper rendering in Instawork mobile app.

This issue was introduced by recent refactor in #633 

| Before | After | Sanity check with Demo app |
|-------|--------|----------|
| ![before](https://github.com/Instawork/hyperview/assets/309515/a785ef6e-6bd0-4557-808d-7d1c641426fd) | ![after](https://github.com/Instawork/hyperview/assets/309515/1918604a-5e37-4e5a-96a6-3a93865b3692) | ![demo](https://github.com/Instawork/hyperview/assets/309515/20f977e1-b7dd-4c2f-bdea-f193fc76dcae) |