### PR TITLE
refactor: `RefreshControl` context

### DIFF
--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -31,8 +31,6 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
 
   static localNameAliases = [];
 
-  static contextType = Contexts.RefreshControlComponentContext;
-
   parser: DOMParser = new DOMParser();
 
   props: HvComponentProps;
@@ -129,42 +127,40 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
         ? [...acc, index]
         : acc;
     }, []);
-    const listProps = {
-      data: this.getItems(),
-      horizontal,
-      keyExtractor: item => item && item.getAttribute('key'),
-      renderItem: ({ item }) =>
-        item &&
-        Render.renderElement(
-          item,
-          this.props.stylesheets,
-          this.props.onUpdate,
-          this.props.options,
-        ),
-      scrollIndicatorInsets,
-      showsHorizontalScrollIndicator: horizontal && showScrollIndicator,
-      showsVerticalScrollIndicator: !horizontal && showScrollIndicator,
-      stickyHeaderIndices,
-      style,
-    };
 
-    let refreshProps = {};
-    if (this.props.element.getAttribute('trigger') === 'refresh') {
-      const RefreshControl = this.context || DefaultRefreshControl;
-      refreshProps = {
-        refreshControl: (
-          <RefreshControl
-            onRefresh={this.refresh}
-            refreshing={this.state.refreshing}
-          />
-        ),
-      };
-    }
-
-    // $FlowFixMe
-    return React.createElement(FlatList, {
-      ...listProps,
-      ...refreshProps,
-    });
+    return (
+      <Contexts.RefreshControlComponentContext.Consumer>
+        {ContextRefreshControl => {
+          const RefreshControl = ContextRefreshControl || DefaultRefreshControl;
+          return (
+            <FlatList
+              data={this.getItems()}
+              horizontal={horizontal}
+              keyExtractor={item => item && item.getAttribute('key')}
+              refreshControl={
+                <RefreshControl
+                  onRefresh={this.refresh}
+                  refreshing={this.state.refreshing}
+                />
+              }
+              renderItem={({ item }) =>
+                item &&
+                Render.renderElement(
+                  item,
+                  this.props.stylesheets,
+                  this.props.onUpdate,
+                  this.props.options,
+                )
+              }
+              scrollIndicatorInsets={scrollIndicatorInsets}
+              showsHorizontalScrollIndicator={horizontal && showScrollIndicator}
+              showsVerticalScrollIndicator={!horizontal && showScrollIndicator}
+              stickyHeaderIndices={stickyHeaderIndices}
+              style={style}
+            />
+          );
+        }}
+      </Contexts.RefreshControlComponentContext.Consumer>
+    );
   }
 }

--- a/src/components/hv-list/index.js
+++ b/src/components/hv-list/index.js
@@ -143,6 +143,7 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
                   refreshing={this.state.refreshing}
                 />
               }
+              removeClippedSubviews={false}
               renderItem={({ item }) =>
                 item &&
                 Render.renderElement(

--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -35,8 +35,6 @@ export default class HvSectionList extends PureComponent<
 
   static localNameAliases = [];
 
-  static contextType = Contexts.RefreshControlComponentContext;
-
   parser: DOMParser = new DOMParser();
 
   props: HvComponentProps;
@@ -45,7 +43,7 @@ export default class HvSectionList extends PureComponent<
     refreshing: false,
   };
 
-  getStickySectionHeadersEnabled = (): ?boolean => {
+  getStickySectionHeadersEnabled = (): boolean => {
     const stickySectionTitles = this.props.element.getAttribute(
       'sticky-section-titles',
     );
@@ -55,7 +53,12 @@ export default class HvSectionList extends PureComponent<
     if (stickySectionTitles === 'false') {
       return false;
     }
-    return undefined;
+    // Set platform default behavior
+    // https://reactnative.dev/docs/sectionlist#stickysectionheadersenabled
+    return Platform.select({
+      android: false,
+      ios: true,
+    });
   };
 
   refresh = () => {
@@ -147,46 +150,45 @@ export default class HvSectionList extends PureComponent<
         ? { right: 1 }
         : undefined;
 
-    const listProps = {
-      keyExtractor: item => item.getAttribute('key'),
-      renderItem: ({ item }) =>
-        Render.renderElement(
-          item,
-          this.props.stylesheets,
-          this.props.onUpdate,
-          this.props.options,
-        ),
-      renderSectionHeader: ({ section: { title } }) =>
-        Render.renderElement(
-          title,
-          this.props.stylesheets,
-          this.props.onUpdate,
-          this.props.options,
-        ),
-      scrollIndicatorInsets,
-      sections,
-      stickySectionHeadersEnabled: this.getStickySectionHeadersEnabled(),
-      style,
-    };
-
-    let refreshProps = {};
-    if (this.props.element.getAttribute('trigger') === 'refresh') {
-      const RefreshControl = this.context || DefaultRefreshControl;
-      refreshProps = {
-        refreshControl: (
-          <RefreshControl
-            onRefresh={this.refresh}
-            refreshing={this.state.refreshing}
-          />
-        ),
-      };
-    }
-
-    const props: any = {
-      ...listProps,
-      ...refreshProps,
-    };
-
-    return React.createElement(SectionList, props);
+    return (
+      <Contexts.RefreshControlComponentContext.Consumer>
+        {ContextRefreshControl => {
+          const RefreshControl = ContextRefreshControl || DefaultRefreshControl;
+          return (
+            <SectionList
+              keyExtractor={item => item.getAttribute('key')}
+              refreshControl={
+                <RefreshControl
+                  onRefresh={this.refresh}
+                  refreshing={this.state.refreshing}
+                />
+              }
+              renderItem={({ item }) =>
+                // $FlowFixMe: return type of renderElement is not compatible with expected type for renderItem
+                Render.renderElement(
+                  item,
+                  this.props.stylesheets,
+                  this.props.onUpdate,
+                  this.props.options,
+                )
+              }
+              renderSectionHeader={({ section: { title } }) =>
+                // $FlowFixMe: return type of renderElement is not compatible with expected type for renderSectionHeader
+                Render.renderElement(
+                  title,
+                  this.props.stylesheets,
+                  this.props.onUpdate,
+                  this.props.options,
+                )
+              }
+              scrollIndicatorInsets={scrollIndicatorInsets}
+              sections={sections}
+              stickySectionHeadersEnabled={this.getStickySectionHeadersEnabled()}
+              style={style}
+            />
+          );
+        }}
+      </Contexts.RefreshControlComponentContext.Consumer>
+    );
   }
 }

--- a/src/components/hv-section-list/index.js
+++ b/src/components/hv-section-list/index.js
@@ -163,6 +163,7 @@ export default class HvSectionList extends PureComponent<
                   refreshing={this.state.refreshing}
                 />
               }
+              removeClippedSubviews={false}
               renderItem={({ item }) =>
                 // $FlowFixMe: return type of renderElement is not compatible with expected type for renderItem
                 Render.renderElement(

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -53,7 +53,6 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
             onParseBefore={this.props.onParseBefore}
             openModal={this.props.openModal}
             push={this.props.push}
-            refreshControl={this.props.refreshControl}
             route={this.props.route}
           />
         </Contexts.RefreshControlComponentContext.Provider>

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -53,6 +53,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
             onParseBefore={this.props.onParseBefore}
             openModal={this.props.openModal}
             push={this.props.push}
+            refreshControl={this.props.refreshControl}
             route={this.props.route}
           />
         </Contexts.RefreshControlComponentContext.Provider>

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -322,10 +322,8 @@ export default class HvScreen extends React.Component {
 
     return (
       <Contexts.DateFormatContext.Provider value={this.props.formatDate}>
-        <Contexts.RefreshControlComponentContext.Provider value={this.props.refreshControl}>
-          {screenElement}
-          {elementErrorComponent ? (React.createElement(elementErrorComponent, { error: this.state.elementError, onPressReload: () => this.reload() })) : null}
-        </Contexts.RefreshControlComponentContext.Provider>
+        {screenElement}
+        {elementErrorComponent ? (React.createElement(elementErrorComponent, { error: this.state.elementError, onPressReload: () => this.reload() })) : null}
       </Contexts.DateFormatContext.Provider>
     );
   }


### PR DESCRIPTION
`RefreshControl` context allows for customizing the refresh control in `<list>` and `<section-list>`. Consumers were setup in a React class component fashion, using the static `contextType` property. This approach is limiting, as only one context can be set on a given class component, but is necessary when the context needs to be accessed outside the render method. Since this is not the case for either of these classes, refactor to use the JSX consumer style in the render methods, which now leaves room for introducing another context (future PR coming soon) that does need to be accessed outside the render method. Additionally, this re-adds the missing `refreshControl` property being passed down from `hv-root` to `hv-screen`.

| `<list>` | `<section-list>` |
|-------|-----------|
| ![list](https://github.com/Instawork/hyperview/assets/309515/6f81f420-0195-49de-b183-b36ad5b89127) | ![sectionlist](https://github.com/Instawork/hyperview/assets/309515/0f184448-3af3-4e6e-ac3f-1c4db6fd0766) |

Captures above tested in the demo app with the following local changes:

<details>

```diff
diff --git a/demo/src/HyperviewScreen.js b/demo/src/HyperviewScreen.js
index e91c8f9..7669382 100644
--- a/demo/src/HyperviewScreen.js
+++ b/demo/src/HyperviewScreen.js
@@ -9,6 +9,7 @@
 import React, { PureComponent } from 'react';
 import HandleBack from './HandleBack';
 import Hyperview from 'hyperview';
+import { RefreshControl } from 'react-native';
 import moment from 'moment';
 import { MAIN_STACK_NAME, MODAL_STACK_NAME } from './constants';

@@ -63,6 +64,10 @@ export default class HyperviewScreen extends PureComponent {
     });
   }

+  Refresh = () => (
+    <RefreshControl tintColor="red" />
+  )
+
   render() {
     const entrypointUrl = this.props.route.params?.url;

@@ -79,6 +84,7 @@ export default class HyperviewScreen extends PureComponent {
           openModal={this.openModal}
           push={this.push}
           route={this.props.route}
+          refreshControl={this.Refresh}
         />
       </HandleBack>
     );
```
</details>
