### PR TITLE
fix(`hv-text-field`): `focused` state

### DIFF
--- a/src/components/hv-text-field/index.js
+++ b/src/components/hv-text-field/index.js
@@ -11,11 +11,12 @@
 import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import type { Element, HvComponentProps } from 'hyperview/src/types';
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef } from 'react';
 import {
   createProps,
   getNameValueFormInputValues,
 } from 'hyperview/src/services';
+import type { ElementRef } from 'react';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import { TextInput } from 'react-native';
 import TinyMask from 'hyperview/src/mask.js';
@@ -49,7 +50,6 @@ const HvTextField = (props: HvComponentProps) => {
   // Handlers
   const setFocus = (focused: boolean) => {
     const newElement = props.element.cloneNode(true);
-    newElement.setAttribute('focused', focused.toString());
     props.onUpdate(null, 'swap', props.element, { newElement });
 
     if (focused) {
@@ -76,17 +76,24 @@ const HvTextField = (props: HvComponentProps) => {
     triggerChangeBehaviors(newElement);
   };
 
+  const textInputRef: ElementRef<typeof TextInput> = useRef(null);
+
   const p = {
     ...createProps(props.element, props.stylesheets, {
       ...props.options,
-      focused: props.element.getAttribute('focused') === 'true',
+      focused: textInputRef.current?.isFocused(),
     }),
   };
 
   return (
     <TextInput
       {...p}
-      ref={props.options.registerInputHandler}
+      ref={(ref: ?ElementRef<typeof TextInput>) => {
+        textInputRef.current = ref;
+        if (props.options?.registerInputHandler) {
+          props.options?.registerInputHandler(ref);
+        }
+      }}
       autoFocus={autoFocus}
       defaultValue={defaultValue}
       editable={editable}

--- a/src/components/hv-text-field/index.js
+++ b/src/components/hv-text-field/index.js
@@ -91,7 +91,7 @@ const HvTextField = (props: HvComponentProps) => {
       ref={(ref: ?ElementRef<typeof TextInput>) => {
         textInputRef.current = ref;
         if (props.options?.registerInputHandler) {
-          props.options?.registerInputHandler(ref);
+          props.options.registerInputHandler(ref);
         }
       }}
       autoFocus={autoFocus}


### PR DESCRIPTION
When the component backing the `<text-field>` element re-rendered with a new `element` prop, the state previously set locally is lost, causing the styles to no longer apply the `focused` modifier. This fix removes the local DOM state for `focused`, and instead reads the state from the actual RN component.


| Before | After |
|-------|-------|
| ![before](https://github.com/Instawork/hyperview/assets/309515/a65e5830-123b-41ad-a8da-28fbb6708dc1) | ![after](https://github.com/Instawork/hyperview/assets/309515/b2c848aa-ee9b-4709-9ac1-04a62f3094b7) |


