### PR TITLE
chore(docs): Additional keyboard types

### DIFF
--- a/docs/reference_textfield.md
+++ b/docs/reference_textfield.md
@@ -88,7 +88,13 @@ Sets the type of keybaord to show when the user focuses the input. Supported opt
 - **number-pad**: Keyboard restricted to 0-9 digits plus decimals
 - **decimal-pad**: Keyboard restricted to 0-9 digits with no decimals
 - **phone-pad**: Keyboard restricted to digits and symbols that appear in phone numbers
-- **email-address**: Keyboard adapted for easier email address input (handy @ symbol)
+- **email-address**: Keyboard adapted for easier email address input (handy `@` symbol)
+- **url**: Keyboard adapted for easier URL input (`.`, `/` and `.com` in place of space bar)
+- **ascii-capable**(iOS only): Similar to the default keyboard, without emojis
+- **numbers-and-punctuation**(iOS only): Keyboard that opens by default on the page with numbers and punctuation. User can switch back to first page showing alphabetical characters.
+- **name-phone-pad**(iOS only): Keyboard that opens by default on the page with alphabetical characters, where user can switch to second page showing a phone pad (useful to search for contacts, either by their name, or phone number).
+- **twitter**(iOS only): Keyboard with `@` and `#` keys in place of "Return" key
+- **web-search**(iOS only): Keyboard with "Go" key im place of "Return" key
 
 #### `mask`
 

--- a/examples/ui_elements/forms/text_input/index.xml.njk
+++ b/examples/ui_elements/forms/text_input/index.xml.njk
@@ -73,16 +73,6 @@ tags: forms
         </view>
       </view>
       <view style="FormGroup">
-        <text style="label">Phone pad keyboard</text>
-        <text-field
-          keyboard-type="phone-pad"
-          placeholder="Phone number"
-          placeholderTextColor="#8D9494"
-          name="text"
-          style="input"
-          value="(281) 555-2048"/>
-      </view>
-      <view style="FormGroup">
         <text style="label">Number pad keyboard</text>
         <text-field
           keyboard-type="number-pad"
@@ -93,6 +83,26 @@ tags: forms
           value="600 80 5555"/>
       </view>
       <view style="FormGroup">
+        <text style="label">Decimal pad keyboard</text>
+        <text-field
+          keyboard-type="decimal-pad"
+          placeholder="Dollar amount"
+          placeholderTextColor="#8D9494"
+          name="text"
+          style="input"
+          value="123.45"/>
+      </view>
+      <view style="FormGroup">
+        <text style="label">Phone pad keyboard</text>
+        <text-field
+          keyboard-type="phone-pad"
+          placeholder="Phone number"
+          placeholderTextColor="#8D9494"
+          name="text"
+          style="input"
+          value="(281) 555-2048"/>
+      </view>
+      <view style="FormGroup">
         <text style="label">Email keyboard</text>
         <text-field
           keyboard-type="email-address"
@@ -101,6 +111,66 @@ tags: forms
           name="text"
           style="input"
           value="gigsy@instawork.com"/>
+      </view>
+      <view style="FormGroup">
+        <text style="label">URL keyboard</text>
+        <text-field
+          keyboard-type="url"
+          placeholder="URL"
+          placeholderTextColor="#8D9494"
+          name="text"
+          style="input"
+          value="https://hyperview.org"/>
+      </view>
+      <view style="FormGroup">
+        <text style="label">ASCII only keyboard (iOS only)</text>
+        <text-field
+          keyboard-type="ascii-capable"
+          placeholder="ASCII string"
+          placeholderTextColor="#8D9494"
+          name="text"
+          style="input"
+          value="abc123"/>
+      </view>
+      <view style="FormGroup">
+        <text style="label">Numbers and punctuation keyboard (iOS only)</text>
+        <text-field
+          keyboard-type="numbers-and-punctuation"
+          placeholder="Some text here…"
+          placeholderTextColor="#8D9494"
+          name="text"
+          style="input"
+          value="123,456?789!"/>
+      </view>
+      <view style="FormGroup">
+        <text style="label">Alphabetical and phone pad keyboard (iOS only)</text>
+        <text-field
+          keyboard-type="name-phone-pad"
+          placeholder="Contact"
+          placeholderTextColor="#8D9494"
+          name="text"
+          style="input"
+          value="(281) 555-2048"/>
+      </view>
+      <view style="FormGroup">
+        <text style="label">X (formerly twitter) keyboard (iOS only)</text>
+        <text-field
+          keyboard-type="twitter"
+          placeholder="Post message"
+          placeholderTextColor="#8D9494"
+          name="text"
+          style="input"
+          value="(281) 555-2048"/>
+      </view>
+      <view style="FormGroup">
+        <text style="label">Web search keyboard (iOS only)</text>
+        <text-field
+          keyboard-type="web-search"
+          placeholder="Search the web"
+          placeholderTextColor="#8D9494"
+          name="text"
+          style="input"
+          value="What is Hyperview?"/>
       </view>
       <view style="FormGroup">
         <text style="label">Phone number mask</text>

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -1069,6 +1069,12 @@
             <xs:enumeration value="decimal-pad" />
             <xs:enumeration value="phone-pad" />
             <xs:enumeration value="email-address" />
+            <xs:enumeration value="url" />
+            <xs:enumeration value="ascii-capable" />
+            <xs:enumeration value="numbers-and-punctuation" />
+            <xs:enumeration value="name-phone-pad" />
+            <xs:enumeration value="twitter" />
+            <xs:enumeration value="web-search" />
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>


### PR DESCRIPTION
Add missing keyboard modes available to `<text-field>` via the attribute `keyboard-type`


https://github.com/Instawork/hyperview/assets/309515/2022b574-7957-4470-a2a6-664b796195dd

