### PR TITLE
chore(examples): Update contacts case study

### DIFF
--- a/examples/case_studies/contacts/index.xml.njk
+++ b/examples/case_studies/contacts/index.xml.njk
@@ -33,5 +33,7 @@ tags: case_studies
   <style id="highlight" fontWeight="bold" color="blue" />
 {% endblock %}
 {% block container %}
-  {% include "./list.xml.njk" %}
+  <form>
+    {% include "./list.xml.njk" %}
+  </form>
 {% endblock %}

--- a/examples/case_studies/contacts/list.xml.njk
+++ b/examples/case_studies/contacts/list.xml.njk
@@ -1,38 +1,47 @@
-{# HACK: The wrapping form is necessary to ensure the list scroll position to be reset upon new search results #}
-{# however, it comes with a visual glitch as the entire list is re-rendered instead of just the items #}
-{# ideally, we would have a behavior to scroll back to the top of the list, so that we don't need this hack #}
-<form xmlns="https://hyperview.org/hyperview">
-  <list id="contacts" trigger="refresh" action="replace" href="?page=1&amp;template=list" target="contacts">
-    {% set page = 1 %}
-    <item key="search" sticky="true" style="relative mx-24">
-      <text-field
-        placeholder="Search a contact…"
-        placeholderTextColor="#8D9494"
-        name="search"
-        style="input"
-        debounce="200"
-        value="{{ search }}"
-      >
-        {# upon the search field changing, we want to: #}
-        {# 1- prevent any further load more on scroll with the previous request query to happen #}
-        {# 2- actually refresh the list with new set of results, including the new "load more" behavior #}
-        <behavior
-          trigger="change"
-          action="hide"
-          target="load-more"
-        />
-        <behavior
-          trigger="change"
-          action="replace"
-          target="contacts"
-          href="?template=list"
-          show-during-load="loading-indicator"
-        />
-      </text-field>
-      <view id="loading-indicator" style="absolute r-0 py-8" hide="true">
-        <spinner />
-      </view>
-    </item>
-    {% include "./contacts.xml.njk" %}
-  </list>
-</form>
+<list
+  id="contacts"
+  trigger="refresh"
+  action="replace"
+  href="?page=1&amp;template=list"
+  target="contacts"
+  xmlns="https://hyperview.org/hyperview"
+>
+  {% set page = 1 %}
+  <item key="search" id="top" sticky="true" style="relative mx-24">
+    <text-field
+      placeholder="Search a contact…"
+      placeholderTextColor="#8D9494"
+      name="search"
+      style="input"
+      debounce="200"
+      value="{{ search }}"
+    >
+      {# upon the search field changing, we want to: #}
+      {# 1- prevent any further load more on scroll with the previous request query to happen #}
+      {# 2- scroll back to the top of the list #}
+      {# 3- actually refresh the list with new set of results, including the new "load more" behavior #}
+      <behavior
+        trigger="change"
+        action="hide"
+        target="load-more"
+      />
+      <behavior
+        trigger="change"
+        action="scroll"
+        target="top"
+        xmlns:scroll="https://hyperview.org/hyperview-scroll"
+      />
+      <behavior
+        trigger="change"
+        action="replace"
+        target="contacts"
+        href="?template=list"
+        show-during-load="loading-indicator"
+      />
+    </text-field>
+    <view id="loading-indicator" style="absolute r-0 py-8" hide="true">
+      <spinner />
+    </view>
+  </item>
+  {% include "./contacts.xml.njk" %}
+</list>


### PR DESCRIPTION
Now that scroll behavior is supported, remove hack that reloaded the entire list on search to re-index the scroll position.