### PR TITLE
fix(schema): move `debounce` attribute to `behaviorAttributes`

### DIFF
--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -403,6 +403,7 @@
     <xs:attribute name="new-value" type="xs:string" />
     <xs:attribute name="copy-to-clipboard-value" type="xs:string" />
     <xs:attribute name="immediate" type="xs:boolean" />
+    <xs:attribute name="debounce" type="xs:nonNegativeInteger" />
     <xs:attributeGroup ref="alert:alertAttributes" />
     <xs:attributeGroup ref="scroll:scrollAttributes" />
   </xs:attributeGroup>
@@ -1126,7 +1127,6 @@
       <xs:attribute name="type" type="xs:string" />
       <xs:attributeGroup ref="hv:behaviorAttributes" />
       <xs:attribute name="text-content-type" type="hv:text-content-type" />
-      <xs:attribute name="debounce" type="xs:nonNegativeInteger" />
     </xs:complexType>
   </xs:element>
 


### PR DESCRIPTION
Eventhough the `debounce` attribute is limited to `<text-field>`, it can be applied to `<behavior>` elements nested under a `<text-field>`. Right now our schema definition does not have this level of granularity to restrict the attribute to elements nested under another kind of element.