### PR TITLE
fix(safe area) - adding safe area to demo

### DIFF
--- a/demo/src/Navigator.js
+++ b/demo/src/Navigator.js
@@ -7,31 +7,57 @@
  */
 
 import * as Constants from './constants';
+import {
+  SafeAreaProvider,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
 import HyperviewScreen from './HyperviewScreen';
 import { NavigationContainer } from '@react-navigation/native';
 import React from 'react';
+import { View } from 'react-native';
 import { createStackNavigator } from '@react-navigation/stack';
 
 const Stack = createStackNavigator();
 
+const Navigation = () => {
+  const insets = useSafeAreaInsets();
+  return (
+      <View
+        style={{
+          flex: 1,
+
+          // Paddings to handle safe area
+          paddingBottom: insets.bottom,
+          paddingLeft: insets.left,
+          paddingRight: insets.right,
+          paddingTop: insets.top,
+        }}
+      >
+        <NavigationContainer>
+          <Stack.Navigator screenOptions={{ headerShown: false }}>
+            <Stack.Group>
+              <Stack.Screen
+                component={HyperviewScreen}
+                initialParams={{ url: Constants.ENTRY_POINT_URL }}
+                name={Constants.MAIN_STACK_NAME}
+              />
+            </Stack.Group>
+            <Stack.Group screenOptions={{ presentation: 'modal' }}>
+              <Stack.Screen
+                component={HyperviewScreen}
+                name={Constants.MODAL_STACK_NAME}
+              />
+            </Stack.Group>
+          </Stack.Navigator>
+        </NavigationContainer>
+      </View>
+  );
+};
+
 export default () => {
   return (
-    <NavigationContainer>
-      <Stack.Navigator screenOptions={{ headerShown: false }}>
-        <Stack.Group>
-          <Stack.Screen
-            component={HyperviewScreen}
-            initialParams={{ url: Constants.ENTRY_POINT_URL }}
-            name={Constants.MAIN_STACK_NAME}
-          />
-        </Stack.Group>
-        <Stack.Group screenOptions={{ presentation: 'modal' }}>
-          <Stack.Screen
-            component={HyperviewScreen}
-            name={Constants.MODAL_STACK_NAME}
-          />
-        </Stack.Group>
-      </Stack.Navigator>
-    </NavigationContainer>
+    <SafeAreaProvider>
+      <Navigation />
+    </SafeAreaProvider>
   );
 };


### PR DESCRIPTION
Resolves safe area handling for Android. iOS should work the same as before.

Uses the approach [recommended by react-navigation](https://reactnavigation.org/docs/7.x/handling-safe-area/) (including not using `SafeAreaView`)

Tested on iOS simulator and Android device

| | IOS | Android |
| --- | --- | --- |
| before | ![ios-original](https://github.com/Instawork/hyperview/assets/127122858/564f98a0-5916-48ec-9879-2bfce6d24733) | ![android-original](https://github.com/Instawork/hyperview/assets/127122858/8366bb07-b8b5-4005-ab64-b019f3315db4) |
| after | ![ios-safe-area](https://github.com/Instawork/hyperview/assets/127122858/7e7dc943-67a9-4fd5-bc43-3487aa3f43ba) | ![android-safe-area](https://github.com/Instawork/hyperview/assets/127122858/c57aba46-3603-42e8-86c6-bb1904a14fd4) |

Asana: https://app.asana.com/0/1204008699308084/1205467413007360/f

resolves https://github.com/Instawork/hyperview/pull/674
resolves https://github.com/Instawork/hyperview/issues/550
