### PR TITLE
feature(deep link) - provide deep link support for navigation

### DIFF
--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -12,6 +12,8 @@ import * as NavigatorService from 'hyperview/src/services/navigator';
 import * as Types from './types';
 import * as TypesLegacy from 'hyperview/src/types-legacy';
 import React, { PureComponent, useContext } from 'react';
+import { createCustomStackNavigator } from 'hyperview/src/core/components/navigator-stack';
+import { createCustomTabNavigator } from 'hyperview/src/core/components/navigator-tab';
 import { getFirstChildTag } from 'hyperview/src/services/dom/helpers-legacy';
 
 /**
@@ -19,8 +21,8 @@ import { getFirstChildTag } from 'hyperview/src/services/dom/helpers-legacy';
  */
 const SHOW_NAVIGATION_UI = false;
 
-const Stack = NavigatorService.createStackNavigator<Types.ParamTypes>();
-const BottomTab = NavigatorService.createBottomTabNavigator<Types.ParamTypes>();
+const Stack = createCustomStackNavigator<Types.ParamTypes>();
+const BottomTab = createCustomTabNavigator<Types.ParamTypes>();
 
 export default class HvNavigator extends PureComponent<Types.Props> {
   /**

--- a/src/core/components/navigator-stack/index.tsx
+++ b/src/core/components/navigator-stack/index.tsx
@@ -22,7 +22,7 @@ import {
   StackView,
 } from '@react-navigation/stack';
 
-const CustomStackNavigator = (props: Types.Props, ...rest: undefined[]) => {
+const CustomStackNavigator = (props: Types.Props) => {
   const {
     state,
     descriptors,
@@ -35,19 +35,15 @@ const CustomStackNavigator = (props: Types.Props, ...rest: undefined[]) => {
     StackNavigationOptions,
     StackNavigationEventMap
   >(CustomStackRouter.Router, {
-    // backBehavior: props.backBehavior,
     children: props.children,
     id: props.id,
     initialRouteName: props.initialRouteName,
-    // screenListeners: props.screenListeners,
     screenOptions: props.screenOptions,
   });
 
   return (
     <NavigationContent>
       <StackView
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...rest}
         descriptors={descriptors}
         navigation={navigation}
         state={state}
@@ -58,7 +54,7 @@ const CustomStackNavigator = (props: Types.Props, ...rest: undefined[]) => {
 
 export const createCustomStackNavigator = createNavigatorFactory<
   Readonly<Types.NavigationState>,
-  object,
+  StackNavigationOptions,
   Types.EventMapBase,
   typeof CustomStackNavigator
 >(CustomStackNavigator);

--- a/src/core/components/navigator-stack/index.tsx
+++ b/src/core/components/navigator-stack/index.tsx
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import * as CustomStackRouter from 'hyperview/src/core/components/navigator-stack/router';
+import * as React from 'react';
+import * as Types from './types';
+
+import {
+  StackActionHelpers,
+  StackNavigationState,
+  createNavigatorFactory,
+  useNavigationBuilder,
+} from '@react-navigation/native';
+import {
+  StackNavigationEventMap,
+  StackNavigationOptions,
+  StackView,
+} from '@react-navigation/stack';
+
+const CustomStackNavigator = (props: Types.Props, ...rest: undefined[]) => {
+  const {
+    state,
+    descriptors,
+    navigation,
+    NavigationContent,
+  } = useNavigationBuilder<
+    StackNavigationState<Types.ParamListBase>,
+    Types.StackOptions,
+    StackActionHelpers<Types.ParamListBase>,
+    StackNavigationOptions,
+    StackNavigationEventMap
+  >(CustomStackRouter.Router, {
+    // backBehavior: props.backBehavior,
+    children: props.children,
+    id: props.id,
+    initialRouteName: props.initialRouteName,
+    // screenListeners: props.screenListeners,
+    screenOptions: props.screenOptions,
+  });
+
+  return (
+    <NavigationContent>
+      <StackView
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...rest}
+        descriptors={descriptors}
+        navigation={navigation}
+        state={state}
+      />
+    </NavigationContent>
+  );
+};
+
+export const createCustomStackNavigator = createNavigatorFactory<
+  Readonly<Types.NavigationState>,
+  object,
+  Types.EventMapBase,
+  typeof CustomStackNavigator
+>(CustomStackNavigator);

--- a/src/core/components/navigator-stack/router.tsx
+++ b/src/core/components/navigator-stack/router.tsx
@@ -16,57 +16,12 @@ import { StackNavigationState, StackRouter } from '@react-navigation/native';
 export const Router = (stackOptions: Types.StackOptions) => {
   const router = StackRouter(stackOptions);
 
-  /**
-   * Inject all routes into the state and set the index to the last route
-   */
-  const mutateState = (
-    state: StackNavigationState<Types.ParamListBase>,
-    options: Types.RouterRenameOptions,
-  ) => {
-    const routes = Array.from(state.routes);
-
-    const filteredNames = options.routeNames.filter((name: string) => {
-      return (
-        !options.routeKeyChanges?.includes(name) &&
-        !NavigatorService.isDynamicRoute(name)
-      );
-    });
-
-    filteredNames.forEach((name: string) => {
-      const routeParams = options.routeParamList
-        ? options.routeParamList[name]
-        : undefined;
-      const params = routeParams || {};
-      if (!routes.find(route => route.name === name)) {
-        routes.push({
-          key: `${name}`,
-          name,
-          params,
-        });
-      }
-    });
-
-    return {
-      ...state,
-      index: routes.length - 1,
-      routes,
-    };
-  };
-
   return {
     ...router,
 
     getInitialState(options: Types.RouterConfigOptions) {
       const initState = router.getInitialState(options);
 
-      // console.log(
-      //   '@@@@ getInitialState:',
-      //   stackOptions.id,
-      //   'options:',
-      //   options,
-      //   'initState:',
-      //   initState,
-      // );
       return mutateState(initState, { ...options, routeKeyChanges: [] });
     },
 
@@ -75,17 +30,43 @@ export const Router = (stackOptions: Types.StackOptions) => {
       options: Types.RouterRenameOptions,
     ) {
       const changeState = router.getStateForRouteNamesChange(state, options);
-
-      // console.log(
-      //   '@@@@ getStateForRouteNamesChange state:',
-      //   state,
-      //   'options:',
-      //   options,
-      //   'changeState:',
-      //   changeState,
-      // );
-
       return mutateState(changeState, options);
     },
+  };
+};
+
+/**
+ * Inject all routes into the state and set the index to the last route
+ */
+const mutateState = (
+  state: StackNavigationState<Types.ParamListBase>,
+  options: Types.RouterRenameOptions,
+) => {
+  const routes = Array.from(state.routes);
+
+  const filteredNames = options.routeNames.filter((name: string) => {
+    return (
+      !options.routeKeyChanges?.includes(name) &&
+      !NavigatorService.isDynamicRoute(name)
+    );
+  });
+
+  filteredNames.forEach((name: string) => {
+    if (options.routeParamList) {
+      const params = options.routeParamList[name] || {};
+      if (!routes.find(route => route.name === name)) {
+        routes.push({
+          key: name,
+          name,
+          params,
+        });
+      }
+    }
+  });
+
+  return {
+    ...state,
+    index: routes.length - 1,
+    routes,
   };
 };

--- a/src/core/components/navigator-stack/router.tsx
+++ b/src/core/components/navigator-stack/router.tsx
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import * as NavigatorService from 'hyperview/src/services/navigator';
+import * as Types from './types';
+import { StackNavigationState, StackRouter } from '@react-navigation/native';
+
+/**
+ * Provides a custom stack router that allows us to set the initial route
+ */
+export const Router = (stackOptions: Types.StackOptions) => {
+  const router = StackRouter(stackOptions);
+
+  /**
+   * Inject all routes into the state and set the index to the last route
+   */
+  const mutateState = (
+    state: StackNavigationState<Types.ParamListBase>,
+    options: Types.RouterRenameOptions,
+  ) => {
+    const routes = Array.from(state.routes);
+
+    const filteredNames = options.routeNames.filter((name: string) => {
+      return (
+        !options.routeKeyChanges?.includes(name) &&
+        !NavigatorService.isDynamicRoute(name)
+      );
+    });
+
+    filteredNames.forEach((name: string) => {
+      const routeParams = options.routeParamList
+        ? options.routeParamList[name]
+        : undefined;
+      const params = routeParams || {};
+      if (!routes.find(route => route.name === name)) {
+        routes.push({
+          key: `${name}`,
+          name,
+          params,
+        });
+      }
+    });
+
+    return {
+      ...state,
+      index: routes.length - 1,
+      routes,
+    };
+  };
+
+  return {
+    ...router,
+
+    getInitialState(options: Types.RouterConfigOptions) {
+      const initState = router.getInitialState(options);
+
+      // console.log(
+      //   '@@@@ getInitialState:',
+      //   stackOptions.id,
+      //   'options:',
+      //   options,
+      //   'initState:',
+      //   initState,
+      // );
+      return mutateState(initState, { ...options, routeKeyChanges: [] });
+    },
+
+    getStateForRouteNamesChange(
+      state: StackNavigationState<Types.ParamListBase>,
+      options: Types.RouterRenameOptions,
+    ) {
+      const changeState = router.getStateForRouteNamesChange(state, options);
+
+      // console.log(
+      //   '@@@@ getStateForRouteNamesChange state:',
+      //   state,
+      //   'options:',
+      //   options,
+      //   'changeState:',
+      //   changeState,
+      // );
+
+      return mutateState(changeState, options);
+    },
+  };
+};

--- a/src/core/components/navigator-stack/types.ts
+++ b/src/core/components/navigator-stack/types.ts
@@ -7,18 +7,13 @@
  */
 
 import * as React from 'react';
-import {
-  // StackNavigationEventMap,
-  StackNavigationOptions,
-} from '@react-navigation/stack';
+import { StackNavigationOptions } from '@react-navigation/stack';
 
 export type Props = {
   id: string;
-  // backBehavior?: 'none' | 'initialRoute' | 'history' | 'order';
   children?: React.ReactNode;
   initialRouteName?: string;
   screenOptions?: StackNavigationOptions;
-  // screenListeners?: StackNavigationEventMap;
 };
 
 export type ParamListBase = Record<string, object | undefined>;

--- a/src/core/components/navigator-stack/types.ts
+++ b/src/core/components/navigator-stack/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import * as React from 'react';
+import {
+  // StackNavigationEventMap,
+  StackNavigationOptions,
+} from '@react-navigation/stack';
+
+export type Props = {
+  id: string;
+  // backBehavior?: 'none' | 'initialRoute' | 'history' | 'order';
+  children?: React.ReactNode;
+  initialRouteName?: string;
+  screenOptions?: StackNavigationOptions;
+  // screenListeners?: StackNavigationEventMap;
+};
+
+export type ParamListBase = Record<string, object | undefined>;
+
+export type RouterConfigOptions = {
+  routeNames: string[];
+  routeParamList: Record<string, object | undefined>;
+  routeGetIdList: Record<
+    string,
+    | ((options: { params?: Record<string, unknown> }) => string | undefined)
+    | undefined
+  >;
+};
+
+export type RouterRenameOptions = RouterConfigOptions & {
+  routeKeyChanges: string[];
+};
+
+export type StackOptions = {
+  id?: string;
+  initialRouteName?: string;
+};
+
+/**
+ * Minimal representation of the 'NavigationState' used by react-navigation
+ */
+export type NavigationState = {
+  index: number;
+  key: string;
+  routeNames: string[];
+  routes: Route<string, object>[];
+  stale: false;
+  type: string;
+  history?: unknown[];
+};
+
+/**
+ * Minimal representation of the 'Route' used by react-navigation
+ */
+export type Route<
+  RouteName extends string,
+  Params extends object | undefined = object | undefined
+> = {
+  key: string;
+  name: RouteName;
+  params: Params;
+  state?: NavigationState;
+};
+
+export type EventMapBase = {
+  data?: any;
+};

--- a/src/core/components/navigator-tab/index.tsx
+++ b/src/core/components/navigator-tab/index.tsx
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import * as React from 'react';
+import * as Types from './types';
+import {
+  BottomTabNavigationEventMap,
+  BottomTabNavigationOptions,
+  BottomTabView,
+} from '@react-navigation/bottom-tabs';
+import {
+  TabActionHelpers,
+  TabNavigationState,
+  TabRouter,
+  TabRouterOptions,
+  createNavigatorFactory,
+  useNavigationBuilder,
+} from '@react-navigation/native';
+
+const CustomTabNavigator = (
+  props: Types.Props,
+  ...restWithDeprecated: undefined[]
+) => {
+  const {
+    state,
+    descriptors,
+    navigation,
+    NavigationContent,
+  } = useNavigationBuilder<
+    TabNavigationState<Types.ParamListBase>,
+    TabRouterOptions,
+    TabActionHelpers<Types.ParamListBase>,
+    BottomTabNavigationOptions,
+    BottomTabNavigationEventMap
+  >(TabRouter, {
+    backBehavior: props.backBehavior,
+    children: props.children,
+    id: props.id,
+    initialRouteName: props.initialRouteName,
+    screenOptions: props.screenOptions,
+  });
+
+  React.useEffect(() => {
+    navigation.navigate(props.initialRouteName);
+  }, [props.initialRouteName, navigation]);
+
+  return (
+    <NavigationContent>
+      <BottomTabView
+        descriptors={descriptors}
+        navigation={navigation}
+        state={state}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...restWithDeprecated}
+      />
+    </NavigationContent>
+  );
+};
+
+// export default createNavigatorFactory(CustomTabNavigator);
+
+export const createCustomTabNavigator = createNavigatorFactory<
+  Readonly<Types.NavigationState>,
+  object,
+  Types.EventMapBase,
+  typeof CustomTabNavigator
+>(CustomTabNavigator);

--- a/src/core/components/navigator-tab/index.tsx
+++ b/src/core/components/navigator-tab/index.tsx
@@ -22,10 +22,7 @@ import {
   useNavigationBuilder,
 } from '@react-navigation/native';
 
-const CustomTabNavigator = (
-  props: Types.Props,
-  ...restWithDeprecated: undefined[]
-) => {
+const CustomTabNavigator = (props: Types.Props) => {
   const {
     state,
     descriptors,
@@ -55,14 +52,10 @@ const CustomTabNavigator = (
         descriptors={descriptors}
         navigation={navigation}
         state={state}
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...restWithDeprecated}
       />
     </NavigationContent>
   );
 };
-
-// export default createNavigatorFactory(CustomTabNavigator);
 
 export const createCustomTabNavigator = createNavigatorFactory<
   Readonly<Types.NavigationState>,

--- a/src/core/components/navigator-tab/types.tsx
+++ b/src/core/components/navigator-tab/types.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import * as React from 'react';
+import { BottomTabNavigationOptions } from '@react-navigation/bottom-tabs';
+
+export type Props = {
+  id: string;
+  backBehavior: 'none' | 'initialRoute' | 'history' | 'order';
+  initialRouteName: string;
+  children: React.ReactNode;
+  screenOptions: BottomTabNavigationOptions;
+};
+
+export type ParamListBase = Record<string, object | undefined>;
+
+export type RouterConfigOptions = {
+  routeNames: string[];
+  routeParamList: Record<string, object | undefined>;
+  routeGetIdList: Record<
+    string,
+    | ((options: { params?: Record<string, unknown> }) => string | undefined)
+    | undefined
+  >;
+};
+
+export type RouterRenameOptions = RouterConfigOptions & {
+  routeKeyChanges: string[];
+};
+
+export type TabOptions = {
+  id?: string;
+  initialRouteName?: string;
+};
+
+/**
+ * Minimal representation of the 'NavigationState' used by react-navigation
+ */
+export type NavigationState = {
+  index: number;
+  key: string;
+  routeNames: string[];
+  routes: Route<string, object>[];
+  stale: false;
+  type: string;
+  history?: unknown[];
+};
+
+/**
+ * Minimal representation of the 'Route' used by react-navigation
+ */
+export type Route<
+  RouteName extends string,
+  Params extends object | undefined = object | undefined
+> = {
+  key: string;
+  name: RouteName;
+  params: Params;
+  state?: NavigationState;
+};
+
+export type EventMapBase = {
+  data?: any;
+};


### PR DESCRIPTION
This is a working prototype of deep links with custom navigators.

- For stack navigators, the custom navigator provides an injection of a custom router which overrides the behavior of initial state and updates for new routes
  - In the override, all routes are pushed onto the stack
- For tab navigators, the custom navigator calls a 'navigate' whenever the initial route name prop changes

This functionality requires mobile branch https://github.com/Instawork/mobile/tree/hardin/deep-link-url-wip

**Tabs**
With the default behavior, the initial state is correct: shifts-route (middle tab), and second-shifts (right sub tab). However, the deep link has no effect. The current tab selection remains.

Deep link
```xml
<doc {% namespaces %}>
  <navigator id="root-navigator" type="stack" merge="true">
    <nav-route id="tabs-route">
      <navigator id="tabs-navigator" type="tab" merge="true">
        <nav-route id="shifts-route" href="{% url 'biz-app-sub-navigator' %}" selected="true">
          <navigator id="shifts" type="tab" merge="true">
            <nav-route id="second-shifts" href="{% url 'biz-app-shift-group-list' %}" selected="true"/>
          </navigator>
        </nav-route>
      </navigator>
    </nav-route>
  </navigator>
</doc>
```

| initial state | deep link |
| -- | -- |
| ![initstate](https://github.com/Instawork/hyperview/assets/127122858/9fcb9021-eb6c-40cb-a3f9-ba7759a678d5) | ![deeplink](https://github.com/Instawork/hyperview/assets/127122858/3bf36ccd-50aa-4bb7-8c9b-2167d8ac2512) |

With an override navigator, the deep link is able to change the selection in both the main tab and the sub-tab navigators.
| initial state | deep link |
| -- | -- |
| ![initstate](https://github.com/Instawork/hyperview/assets/127122858/9fcb9021-eb6c-40cb-a3f9-ba7759a678d5) | ![deeplink](https://github.com/Instawork/hyperview/assets/127122858/9fd88766-cb00-4880-9ff0-849c3cc9ded1) |

**Stacks**
With the default behavior, the stack navigator pushes only one screen onto the stack: the one with a naming matching the "initialRouteName" property value. Deep links provide no additional functionality.

Initial state (index.xml)
```xml
<doc {% namespaces %}>
  <navigator id="root-navigator" type="stack">
    <nav-route id="tabs-route">
      <navigator id="tabs-navigator" type="tab">
        <nav-route id="live-shifts-route" href="{% url 'biz-app-hub' %}"/>
        <nav-route id="shifts-route" href="{% url 'biz-app-sub-navigator' %}" selected="true"/>
        <nav-route id="account-route" href="{% url 'biz-app-account' %}" selected="true"/>
      </navigator>
    </nav-route>
    <nav-route id="company" href="{% url 'biz-app-account-company' %}" modal="true"/>
  </navigator>
</doc>
```

Deep link
```xml
<doc {% namespaces %}>
  <navigator id="root-navigator" type="stack" merge="true">
    <nav-route id="account" href="{% url 'biz-app-account' %}" modal="true"/>
  </navigator>
</doc>
```

Given this initial state, the desired outcome is to have the "company" modal on top of the tabs.

| initial state | deep link |
| -- | -- |
| ![initstate](https://github.com/Instawork/hyperview/assets/127122858/22b801b8-b3c6-45d4-a91a-ce93dea950c0) | ![deeplink](https://github.com/Instawork/hyperview/assets/127122858/b30fe8d7-c437-4970-a4bc-9d146107d84b) |

After overriding the navigator and router, the stack is able to push all screens onto the stack in the initial state and is able to push screens onto the stack when a deep link is received.

NOTE: There is currently a bug causing the stack initial state to open and immediately close the modal screen. It is caused by the overrides of tabs and stack working against each other. A separate task will be created to look into fixes.

| initial state | deep link |
| -- | -- |
| ![initstate](https://github.com/Instawork/hyperview/assets/127122858/b95b81f4-68ec-4bad-a728-0c7a15604fb9) | ![deeplink](https://github.com/Instawork/hyperview/assets/127122858/370e9d77-a8b2-4216-b5a6-63c05bd08e0e) |


Asana: https://app.asana.com/0/1204008699308084/1205129681586820/f