### PR TITLE
Fix: Ignore stories rule for core components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -69,6 +69,14 @@
         "object-curly-newline": "off",
         "instawork/error-object": "off"
       }
+    },
+    {
+      "files": [
+        "src/core/components/**/*",
+      ],
+      "rules": {
+        "instawork/stories-components": "off",
+      }
     }
   ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -75,7 +75,7 @@
         "src/core/components/**/*",
       ],
       "rules": {
-        "instawork/stories-components": "off",
+        "instawork/stories-components": "warn",
       }
     }
   ]


### PR DESCRIPTION
Warn instead of erroring if stories are missing for core components. Related to https://github.com/Instawork/eslint-plugin-instawork/pull/43 where we're expanding the matcher to any `components/`

<img width="1490" alt="Screenshot 2023-09-26 at 8 05 36 PM" src="https://github.com/Instawork/hyperview/assets/2883006/ec667231-3b60-4d7d-9e69-e548d879b728">
