### PR TITLE
chore: remove DOM lib type overrides everywhere

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -61,6 +61,7 @@
         "indent": "off",
         "arrow-body-style": "off",
         "operator-linebreak": "off",
+        "no-undef": "off",
         "no-use-before-define": "off",
         "object-curly-newline": "off",
         "instawork/error-object": "off",
@@ -68,19 +69,15 @@
         "import/no-extraneous-dependencies": [
           "warn",
           {
-            "devDependencies": [
-              "**/stories/*.tsx"
-            ]
+            "devDependencies": ["**/stories/*.tsx"]
           }
         ]
       }
     },
     {
-      "files": [
-        "src/core/components/**/*",
-      ],
+      "files": ["src/core/components/**/*"],
       "rules": {
-        "instawork/stories-components": "warn",
+        "instawork/stories-components": "warn"
       }
     }
   ]

--- a/src/behaviors/hv-alert/index.ts
+++ b/src/behaviors/hv-alert/index.ts
@@ -9,7 +9,7 @@
 import * as Dom from 'hyperview/src/services/dom';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import { Alert, Platform } from 'react-native';
-import type { Element, HvComponentOnUpdate } from 'hyperview/src/types';
+import type { HvComponentOnUpdate } from 'hyperview/src/types';
 import { later } from 'hyperview/src/services';
 
 export default {

--- a/src/behaviors/hv-copy-to-clipboard/index.ts
+++ b/src/behaviors/hv-copy-to-clipboard/index.ts
@@ -7,7 +7,6 @@
  */
 
 import { Clipboard } from 'react-native';
-import type { Element } from 'hyperview/src/types';
 
 export default {
   action: 'copy-to-clipboard',

--- a/src/behaviors/hv-select-all/index.ts
+++ b/src/behaviors/hv-select-all/index.ts
@@ -2,8 +2,6 @@ import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Xml from 'hyperview/src/services/xml';
 import type {
   DOMString,
-  Document,
-  Element,
   HvComponentOnUpdate,
   HvGetRoot,
   HvUpdateRoot,

--- a/src/behaviors/hv-set-value/index.ts
+++ b/src/behaviors/hv-set-value/index.ts
@@ -2,8 +2,6 @@ import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Xml from 'hyperview/src/services/xml';
 import type {
   DOMString,
-  Document,
-  Element,
   HvComponentOnUpdate,
   HvGetRoot,
   HvUpdateRoot,

--- a/src/behaviors/hv-share/index.ts
+++ b/src/behaviors/hv-share/index.ts
@@ -8,8 +8,8 @@
 
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import type { Content, Options } from './types';
-import type { DOMString, Element } from 'hyperview/src/types';
 import { Platform, Share } from 'react-native';
+import type { DOMString } from 'hyperview/src/types';
 
 const getContent = (
   message?: DOMString | null,

--- a/src/behaviors/hv-show/index.ts
+++ b/src/behaviors/hv-show/index.ts
@@ -2,8 +2,6 @@ import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Xml from 'hyperview/src/services/xml';
 import type {
   DOMString,
-  Document,
-  Element,
   HvComponentOnUpdate,
   HvGetRoot,
   HvUpdateRoot,

--- a/src/behaviors/hv-toggle/index.ts
+++ b/src/behaviors/hv-toggle/index.ts
@@ -2,8 +2,6 @@ import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Xml from 'hyperview/src/services/xml';
 import type {
   DOMString,
-  Document,
-  Element,
   HvComponentOnUpdate,
   HvGetRoot,
   HvUpdateRoot,

--- a/src/behaviors/hv-unselect-all/index.ts
+++ b/src/behaviors/hv-unselect-all/index.ts
@@ -2,8 +2,6 @@ import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Xml from 'hyperview/src/services/xml';
 import type {
   DOMString,
-  Document,
-  Element,
   HvComponentOnUpdate,
   HvGetRoot,
   HvUpdateRoot,

--- a/src/components/hv-date-field/field/types.ts
+++ b/src/components/hv-date-field/field/types.ts
@@ -6,11 +6,7 @@
  *
  */
 
-import type {
-  Element,
-  HvComponentOptions,
-  StyleSheets,
-} from 'hyperview/src/types';
+import type { HvComponentOptions, StyleSheets } from 'hyperview/src/types';
 
 import { ReactNode } from 'react';
 

--- a/src/components/hv-date-field/index.tsx
+++ b/src/components/hv-date-field/index.tsx
@@ -10,7 +10,6 @@ import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import type {
   DOMString,
-  Element,
   HvComponentOnUpdate,
   HvComponentProps,
 } from 'hyperview/src/types';
@@ -72,7 +71,7 @@ export default class HvDateField extends PureComponent<HvComponentProps> {
    * If the field is not set, use today's date in the picker.
    */
   onFieldPress = () => {
-    const newElement = this.props.element.cloneNode(true);
+    const newElement = this.props.element.cloneNode(true) as Element;
     const value: string =
       this.props.element.getAttribute('value') ||
       HvDateField.createStringFromDate(new Date());
@@ -90,7 +89,7 @@ export default class HvDateField extends PureComponent<HvComponentProps> {
    * Hides the picker without applying the chosen value.
    */
   onCancel = () => {
-    const newElement = this.props.element.cloneNode(true);
+    const newElement = this.props.element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'false');
     newElement.removeAttribute('picker-value');
     if (this.props.onUpdate !== null) {
@@ -107,7 +106,7 @@ export default class HvDateField extends PureComponent<HvComponentProps> {
       newValue !== undefined ? newValue : this.getPickerValue();
     const value = HvDateField.createStringFromDate(pickerValue);
     const hasChanged = this.props.element.getAttribute('value') !== value;
-    const newElement = this.props.element.cloneNode(true);
+    const newElement = this.props.element.cloneNode(true) as Element;
     newElement.setAttribute('value', value);
     newElement.removeAttribute('picker-value');
     newElement.setAttribute('focused', 'false');
@@ -125,7 +124,7 @@ export default class HvDateField extends PureComponent<HvComponentProps> {
    */
   setPickerValue = (value?: Date | null) => {
     const formattedValue: string = HvDateField.createStringFromDate(value);
-    const newElement = this.props.element.cloneNode(true);
+    const newElement = this.props.element.cloneNode(true) as Element;
     newElement.setAttribute('picker-value', formattedValue);
     if (this.props.onUpdate !== null) {
       this.props.onUpdate(null, 'swap', this.props.element, { newElement });

--- a/src/components/hv-list/index.tsx
+++ b/src/components/hv-list/index.tsx
@@ -13,8 +13,6 @@ import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
 import type {
   DOMString,
-  Document,
-  Element,
   HvComponentOnUpdate,
   HvComponentOptions,
   HvComponentProps,
@@ -77,7 +75,7 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
       return;
     }
     const doc: Document | null | undefined =
-      this.context === null ? null : this.context();
+      typeof this.context === 'function' ? this.context() : null;
     const targetElement: Element | null | undefined = doc?.getElementById(
       targetId,
     );
@@ -184,20 +182,20 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
         return false;
       }
       if (
-        item.parentNode.tagName === LOCAL_NAME.ITEMS &&
-        item.parentNode.namespaceURI === Namespaces.HYPERVIEW &&
+        (item.parentNode as Element).tagName === LOCAL_NAME.ITEMS &&
+        (item.parentNode as Element).namespaceURI === Namespaces.HYPERVIEW &&
         item.parentNode.parentNode === this.props.element
       ) {
         return true;
       }
       if (
-        item.parentNode.tagName === LOCAL_NAME.LIST &&
-        item.parentNode.namespaceURI === Namespaces.HYPERVIEW &&
+        (item.parentNode as Element).tagName === LOCAL_NAME.LIST &&
+        (item.parentNode as Element).namespaceURI === Namespaces.HYPERVIEW &&
         item.parentNode.parentNode !== this.props.element
       ) {
         return false;
       }
-      return isOwnedBySelf(item.parentNode);
+      return isOwnedBySelf(item.parentNode as Element);
     };
 
     return Array.from(

--- a/src/components/hv-picker-field/field/types.ts
+++ b/src/components/hv-picker-field/field/types.ts
@@ -8,9 +8,7 @@
 
 import type {
   DOMString,
-  Element,
   HvComponentOptions,
-  Node,
   StyleSheets,
 } from 'hyperview/src/types';
 

--- a/src/components/hv-picker-field/index.ios.tsx
+++ b/src/components/hv-picker-field/index.ios.tsx
@@ -10,7 +10,6 @@ import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import type {
   DOMString,
-  Element,
   HvComponentProps,
   StyleSheet,
 } from 'hyperview/src/types';

--- a/src/components/hv-picker-field/index.tsx
+++ b/src/components/hv-picker-field/index.tsx
@@ -10,7 +10,6 @@ import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import type {
   DOMString,
-  Element,
   HvComponentProps,
   StyleSheet,
 } from 'hyperview/src/types';
@@ -68,14 +67,14 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
   };
 
   onFocus = () => {
-    const newElement = this.props.element.cloneNode(true);
+    const newElement = this.props.element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'true');
     this.onUpdate(newElement);
     Behaviors.trigger('focus', newElement, this.props.onUpdate);
   };
 
   onBlur = () => {
-    const newElement = this.props.element.cloneNode(true);
+    const newElement = this.props.element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'false');
     this.onUpdate(newElement);
     Behaviors.trigger('blur', newElement, this.props.onUpdate);
@@ -85,7 +84,7 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
    * Hides the picker without applying the chosen value.
    */
   onCancel = () => {
-    const newElement = this.props.element.cloneNode(true);
+    const newElement = this.props.element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'false');
     newElement.removeAttribute('picker-value');
     this.onUpdate(newElement);
@@ -98,7 +97,7 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
     const pickerValue =
       newValue !== undefined ? newValue : this.getPickerValue();
     const value = this.getValue();
-    const newElement = this.props.element.cloneNode(true);
+    const newElement = this.props.element.cloneNode(true) as Element;
     newElement.setAttribute('value', pickerValue);
     newElement.removeAttribute('picker-value');
     newElement.setAttribute('focused', 'false');

--- a/src/components/hv-section-list/index.tsx
+++ b/src/components/hv-section-list/index.tsx
@@ -13,13 +13,9 @@ import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
 import type {
   DOMString,
-  Document,
-  Element,
   HvComponentOnUpdate,
   HvComponentOptions,
   HvComponentProps,
-  Node,
-  NodeList,
 } from 'hyperview/src/types';
 import {
   RefreshControl as DefaultRefreshControl,
@@ -34,8 +30,8 @@ import type { ElementRef } from 'react';
 import { getAncestorByTagName } from 'hyperview/src/services';
 
 const getSectionIndex = (
-  sectionTitle: Node,
-  sectionTitles: NodeList<Node>,
+  sectionTitle: Element,
+  sectionTitles: HTMLCollectionOf<Element>,
 ): number => {
   const sectionIndex = Array.from(sectionTitles).indexOf(sectionTitle);
 
@@ -44,7 +40,7 @@ const getSectionIndex = (
     sectionTitles[0],
     NODE_TYPE.ELEMENT_NODE,
   );
-  if (previousElement?.localName === LOCAL_NAME.ITEM) {
+  if ((previousElement as Element)?.localName === LOCAL_NAME.ITEM) {
     return sectionIndex + 1;
   }
 
@@ -52,21 +48,21 @@ const getSectionIndex = (
 };
 
 const getPreviousSectionTitle = (
-  element: Node,
+  element: Element,
   itemIndex: number,
-): [Node | null, number] => {
+): [Element | null, number] => {
   const { previousSibling } = element;
   if (!previousSibling) {
     return [null, itemIndex];
   }
-  if (previousSibling.localName === LOCAL_NAME.SECTION_TITLE) {
-    return [previousSibling, itemIndex];
+  if ((previousSibling as Element).localName === LOCAL_NAME.SECTION_TITLE) {
+    return [previousSibling as Element, itemIndex];
   }
-  if (previousSibling.localName === LOCAL_NAME.ITEM) {
+  if ((previousSibling as Element).localName === LOCAL_NAME.ITEM) {
     // eslint-disable-next-line no-param-reassign
     itemIndex += 1;
   }
-  return getPreviousSectionTitle(previousSibling, itemIndex);
+  return getPreviousSectionTitle(previousSibling as Element, itemIndex);
 };
 
 export default class HvSectionList extends PureComponent<
@@ -117,7 +113,8 @@ export default class HvSectionList extends PureComponent<
       console.warn('[behaviors/scroll]: missing "target" attribute');
       return;
     }
-    const doc: Document | null = this.context !== null ? this.context() : null;
+    const doc: Document | null =
+      typeof this.context === 'function' ? this.context() : null;
     const targetElement: Element | null | undefined = doc?.getElementById(
       targetId,
     );
@@ -308,12 +305,12 @@ export default class HvSectionList extends PureComponent<
             node.nodeName === LOCAL_NAME.ITEMS ||
             node.nodeName === LOCAL_NAME.SECTION
           ) {
-            addNodes(node);
+            addNodes(node as Element);
           } else if (
             node.nodeName === LOCAL_NAME.ITEM ||
             node.nodeName === LOCAL_NAME.SECTION_TITLE
           ) {
-            flattened.push(sectionElement.childNodes[j]);
+            flattened.push(sectionElement.childNodes[j] as Element);
           }
         }
       }

--- a/src/components/hv-select-multiple/index.ts
+++ b/src/components/hv-select-multiple/index.ts
@@ -10,10 +10,8 @@ import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
 import type {
   DOMString,
-  Element,
   HvComponentOnUpdate,
   HvComponentProps,
-  NodeList,
 } from 'hyperview/src/types';
 import React, { PureComponent } from 'react';
 import { LOCAL_NAME } from 'hyperview/src/types';
@@ -34,7 +32,7 @@ export default class HvSelectMultiple extends PureComponent<HvComponentProps> {
       return values;
     }
     // Add each selected option to the form data
-    const optionElements: NodeList<Element> = element.getElementsByTagNameNS(
+    const optionElements = element.getElementsByTagNameNS(
       Namespaces.HYPERVIEW,
       LOCAL_NAME.OPTION,
     );
@@ -70,7 +68,7 @@ export default class HvSelectMultiple extends PureComponent<HvComponentProps> {
    * Will update the XML DOM to toggle the option with the given value.
    */
   onToggle = (selectedValue?: DOMString | null) => {
-    const newElement = this.props.element.cloneNode(true);
+    const newElement = this.props.element.cloneNode(true) as Element;
     const options = newElement.getElementsByTagNameNS(
       Namespaces.HYPERVIEW,
       'option',
@@ -91,7 +89,7 @@ export default class HvSelectMultiple extends PureComponent<HvComponentProps> {
   };
 
   applyToAllOptions = (selected: boolean) => {
-    const newElement = this.props.element.cloneNode(true);
+    const newElement = this.props.element.cloneNode(true) as Element;
     const options = newElement.getElementsByTagNameNS(
       Namespaces.HYPERVIEW,
       'option',

--- a/src/components/hv-select-single/index.ts
+++ b/src/components/hv-select-single/index.ts
@@ -10,10 +10,8 @@ import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
 import type {
   DOMString,
-  Element,
   HvComponentOnUpdate,
   HvComponentProps,
-  NodeList,
 } from 'hyperview/src/types';
 import React, { PureComponent } from 'react';
 import { LOCAL_NAME } from 'hyperview/src/types';
@@ -33,7 +31,7 @@ export default class HvSelectSingle extends PureComponent<HvComponentProps> {
       return [];
     }
     // Add each selected option to the form data
-    const optionElements: NodeList<Element> = element.getElementsByTagNameNS(
+    const optionElements = element.getElementsByTagNameNS(
       Namespaces.HYPERVIEW,
       LOCAL_NAME.OPTION,
     );
@@ -71,7 +69,7 @@ export default class HvSelectSingle extends PureComponent<HvComponentProps> {
    * selected=true attribute.
    */
   onSelect = (selectedValue?: DOMString | null) => {
-    const newElement = this.props.element.cloneNode(true);
+    const newElement = this.props.element.cloneNode(true) as Element;
     const allowDeselect = this.props.element.getAttribute('allow-deselect');
     const options = newElement.getElementsByTagNameNS(
       Namespaces.HYPERVIEW,

--- a/src/components/hv-switch/index.ts
+++ b/src/components/hv-switch/index.ts
@@ -8,7 +8,6 @@
 
 import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Namespaces from 'hyperview/src/services/namespaces';
-import type { Element, HvComponentProps } from 'hyperview/src/types';
 import { Platform, StyleSheet, Switch } from 'react-native';
 import React, { PureComponent } from 'react';
 import {
@@ -16,6 +15,7 @@ import {
   getNameValueFormInputValues,
 } from 'hyperview/src/services';
 import type { ColorValue } from './style-sheet';
+import type { HvComponentProps } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import normalizeColor from './style-sheet';
 
@@ -71,11 +71,11 @@ export default class HvSwitch extends PureComponent<HvComponentProps> {
         ? unselectedStyle.backgroundColor
         : null,
       onChange: () => {
-        const newElement = this.props.element.cloneNode(true);
+        const newElement = this.props.element.cloneNode(true) as Element;
         Behaviors.trigger('change', newElement, this.props.onUpdate);
       },
       onValueChange: (value: any) => {
-        const newElement = this.props.element.cloneNode(true);
+        const newElement = this.props.element.cloneNode(true) as Element;
         newElement.setAttribute('value', value ? 'on' : 'off');
         if (this.props.onUpdate) {
           this.props.onUpdate(null, 'swap', this.props.element, { newElement });

--- a/src/components/hv-text-field/index.tsx
+++ b/src/components/hv-text-field/index.tsx
@@ -8,11 +8,7 @@
 import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Dom from 'hyperview/src/services/dom';
 import * as Namespaces from 'hyperview/src/services/namespaces';
-import type {
-  Element,
-  HvComponentProps,
-  TextContextType,
-} from 'hyperview/src/types';
+import type { HvComponentProps, TextContextType } from 'hyperview/src/types';
 import React, { MutableRefObject, useCallback, useRef } from 'react';
 import {
   createProps,
@@ -54,7 +50,7 @@ const HvTextField = (props: HvComponentProps) => {
 
   // Handlers
   const setFocus = (focused: boolean) => {
-    const newElement = props.element.cloneNode(true);
+    const newElement = props.element.cloneNode(true) as Element;
     if (props.onUpdate !== null) {
       props.onUpdate(null, 'swap', props.element, { newElement });
 
@@ -81,7 +77,7 @@ const HvTextField = (props: HvComponentProps) => {
   // This handler takes care of handling the state, so it shouldn't be debounced
   const onChangeText = (value: string) => {
     const formattedValue = HvTextField.getFormattedValue(props.element, value);
-    const newElement = props.element.cloneNode(true);
+    const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('value', formattedValue);
     if (props.onUpdate !== null) {
       props.onUpdate(null, 'swap', props.element, { newElement });

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -7,7 +7,6 @@
  */
 
 import type { ComponentType } from 'react';
-import type { Document } from 'hyperview/src/types';
 import React from 'react';
 import type { RefreshControlProps } from 'react-native';
 

--- a/src/contexts/navigator-map.tsx
+++ b/src/contexts/navigator-map.tsx
@@ -6,16 +6,15 @@
  *
  */
 
-import * as TypesLegacy from 'hyperview/src/types';
 import React, { createContext, useState } from 'react';
 
 export type NavigatorMapContextProps = {
   setRoute: (key: string, route: string) => void;
   getRoute: (key: string) => string | undefined;
-  setElement: (key: string, element: TypesLegacy.Element) => void;
-  getElement: (key: string) => TypesLegacy.Element | undefined;
-  setPreload: (key: number, element: TypesLegacy.Element) => void;
-  getPreload: (key: number) => TypesLegacy.Element | undefined;
+  setElement: (key: string, element: Element) => void;
+  getElement: (key: string) => Element | undefined;
+  setPreload: (key: number, element: Element) => void;
+  getPreload: (key: number) => Element | undefined;
   initialRouteName?: string;
 };
 
@@ -44,8 +43,8 @@ type Props = { children: React.ReactNode };
  */
 export function NavigatorMapProvider(props: Props) {
   const [routeMap] = useState<Map<string, string>>(new Map());
-  const [elementMap] = useState<Map<string, TypesLegacy.Element>>(new Map());
-  const [preloadMap] = useState<Map<number, TypesLegacy.Element>>(new Map());
+  const [elementMap] = useState<Map<string, Element>>(new Map());
+  const [preloadMap] = useState<Map<number, Element>>(new Map());
 
   const setRoute = (key: string, route: string) => {
     routeMap.set(key, route);
@@ -55,19 +54,19 @@ export function NavigatorMapProvider(props: Props) {
     return routeMap.get(key);
   };
 
-  const setElement = (key: string, element: TypesLegacy.Element) => {
+  const setElement = (key: string, element: Element) => {
     elementMap.set(key, element);
   };
 
-  const getElement = (key: string): TypesLegacy.Element | undefined => {
+  const getElement = (key: string): Element | undefined => {
     return elementMap.get(key);
   };
 
-  const setPreload = (key: number, element: TypesLegacy.Element) => {
+  const setPreload = (key: number, element: Element) => {
     preloadMap.set(key, element);
   };
 
-  const getPreload = (key: number): TypesLegacy.Element | undefined => {
+  const getPreload = (key: number): Element | undefined => {
     return preloadMap.get(key);
   };
 

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -49,7 +49,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
    * Build all screens from received routes
    */
   buildScreens = (
-    element: TypesLegacy.Element,
+    element: Element,
     type: TypesLegacy.DOMString,
   ): React.ReactNode => {
     const screens: React.ReactElement[] = [];
@@ -64,15 +64,13 @@ export default class HvNavigator extends PureComponent<Types.Props> {
     }
 
     const { buildTabScreen } = this;
-    const elements: TypesLegacy.Element[] = NavigatorService.getChildElements(
-      element,
-    );
+    const elements: Element[] = NavigatorService.getChildElements(element);
 
     // For tab navigators, the screens are appended
     // For stack navigators, the dynamic screens are added later
     // This iteration will also process nested navigators
     //    and retrieve additional urls from child routes
-    elements.forEach((navRoute: TypesLegacy.Element) => {
+    elements.forEach((navRoute: Element) => {
       if (navRoute.localName === TypesLegacy.LOCAL_NAME.NAV_ROUTE) {
         const id:
           | TypesLegacy.DOMString
@@ -85,7 +83,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
         }
 
         // Check for nested navigators
-        const nestedNavigator: TypesLegacy.Element | null = getFirstTag(
+        const nestedNavigator: Element | null = getFirstTag(
           navRoute,
           TypesLegacy.LOCAL_NAME.NAVIGATOR,
         );
@@ -175,7 +173,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
       | null
       | undefined = props.element.getAttribute('type');
     const selected:
-      | TypesLegacy.Element
+      | Element
       | undefined = NavigatorService.getSelectedNavRouteElement(props.element);
     if (!selected) {
       throw new NavigatorService.HvNavigatorError(

--- a/src/core/components/hv-navigator/types.ts
+++ b/src/core/components/hv-navigator/types.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import * as TypesLegacy from 'hyperview/src/types';
 import { FC } from 'react';
 
 export type RouteParams = {
@@ -31,6 +30,6 @@ export type NavigatorParams = {
  * All of the props used by hv-navigator
  */
 export type Props = {
-  element: TypesLegacy.Element;
+  element: Element;
   routeComponent: FC;
 };

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -113,7 +113,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     }
   };
 
-  getRenderElement = (): TypesLegacy.Element | null => {
+  getRenderElement = (): Element | null => {
     if (this.props.element) {
       return this.props.element;
     }
@@ -122,7 +122,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     }
 
     // Get the <doc> element
-    const root: TypesLegacy.Element | null = Helpers.getFirstTag(
+    const root: Element | null = Helpers.getFirstTag(
       this.state.doc,
       TypesLegacy.LOCAL_NAME.DOC,
     );
@@ -131,7 +131,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     }
 
     // Get the first child as <screen> or <navigator>
-    const screenElement: TypesLegacy.Element | null = Helpers.getFirstTag(
+    const screenElement: Element | null = Helpers.getFirstTag(
       root,
       TypesLegacy.LOCAL_NAME.SCREEN,
     );
@@ -139,7 +139,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
       return screenElement;
     }
 
-    const navigatorElement: TypesLegacy.Element | null = Helpers.getFirstTag(
+    const navigatorElement: Element | null = Helpers.getFirstTag(
       root,
       TypesLegacy.LOCAL_NAME.NAVIGATOR,
     );
@@ -152,7 +152,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     );
   };
 
-  registerPreload = (id: number, element: TypesLegacy.Element): void => {
+  registerPreload = (id: number, element: Element): void => {
     this.props.setPreload(id, element);
   };
 
@@ -170,7 +170,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
           preloadElement.getElementsByTagNameNS(Namespaces.HYPERVIEW, 'body'),
         );
         const styleSheet = Stylesheets.createStylesheets(
-          (preloadElement as unknown) as TypesLegacy.Document,
+          (preloadElement as unknown) as Document,
         );
         const component:
           | string
@@ -231,7 +231,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
             behaviors={this.props.behaviors}
             closeModal={this.navLogic.closeModal}
             components={this.props.components}
-            doc={this.state.doc?.cloneNode(true)}
+            doc={this.state.doc?.cloneNode(true) as Document}
             elementErrorComponent={this.props.elementErrorComponent}
             entrypointUrl={this.props.entrypointUrl}
             errorScreen={this.props.errorScreen}
@@ -260,7 +260,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
   Route = (props: {
     handleBack?: ComponentType<{ children: ReactNode }>;
   }): React.ReactElement => {
-    const renderElement: TypesLegacy.Element | null = this.getRenderElement();
+    const renderElement: Element | null = this.getRenderElement();
 
     if (!renderElement) {
       throw new NavigatorService.HvRenderError('No element found');
@@ -379,7 +379,7 @@ export default function HvRoute(props: Types.Props) {
     type !== NavigatorService.NAVIGATOR_TYPE.STACK || index === 0;
 
   // Get the navigator element from the context
-  const element: TypesLegacy.Element | undefined =
+  const element: Element | undefined =
     id && includeElement ? navigatorMapContext.getElement(id) : undefined;
 
   return (

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -9,12 +9,7 @@
 import * as NavigatorService from 'hyperview/src/services/navigator';
 
 import { ComponentType, ReactNode } from 'react';
-import {
-  Document,
-  Element,
-  HvBehavior,
-  HvComponent,
-} from 'hyperview/src/types';
+import { HvBehavior, HvComponent } from 'hyperview/src/types';
 import type { Props as ErrorProps } from 'hyperview/src/core/components/load-error';
 import type { Props as LoadingProps } from 'hyperview/src/core/components/loading';
 

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -44,6 +44,6 @@ export type Props = {
   errorScreen?: ComponentType<ErrorProps>;
   loadingScreen?: ComponentType<LoadingProps>;
   handleBack?: ComponentType<{ children: ReactNode }>;
-  doc?: TypesLegacy.Document;
-  registerPreload?: (id: number, element: TypesLegacy.Element) => void;
+  doc?: Document;
+  registerPreload?: (id: number, element: Element) => void;
 };

--- a/src/core/components/keyboard-aware-scroll-view/index.d.ts
+++ b/src/core/components/keyboard-aware-scroll-view/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-native-keyboard-aware-scrollview';

--- a/src/core/components/modal/types.ts
+++ b/src/core/components/modal/types.ts
@@ -7,7 +7,6 @@
  */
 
 import type {
-  Element,
   HvComponentOnUpdate,
   HvComponentOptions,
   StyleSheets,

--- a/src/core/hyper-ref/index.tsx
+++ b/src/core/hyper-ref/index.tsx
@@ -20,7 +20,6 @@ import {
 } from 'hyperview/src/types';
 import { ATTRIBUTES, PRESS_TRIGGERS_PROP_NAMES } from './types';
 import type {
-  Element,
   HvComponentOnUpdate,
   HvComponentOptions,
   NavAction,
@@ -144,7 +143,9 @@ export default class HyperRef extends PureComponent<Props, State> {
       );
       handler(this.props.element);
       if (__DEV__) {
-        const listenerElement: Element = behaviorElement.cloneNode(false);
+        const listenerElement: Element = behaviorElement.cloneNode(
+          false,
+        ) as Element;
         const caughtEvent:
           | string
           | undefined
@@ -332,8 +333,9 @@ export default class HyperRef extends PureComponent<Props, State> {
 
     // If element is a <text> nested under another <text>, simply add press events
     const isNestedUnderText =
-      this.props.element.parentNode?.namespaceURI === Namespaces.HYPERVIEW &&
-      this.props.element.parentNode?.localName === LOCAL_NAME.TEXT;
+      (this.props.element.parentNode as Element)?.namespaceURI ===
+        Namespaces.HYPERVIEW &&
+      (this.props.element.parentNode as Element)?.localName === LOCAL_NAME.TEXT;
 
     if (isNestedUnderText) {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -351,10 +353,6 @@ export default class HyperRef extends PureComponent<Props, State> {
               ? noop
               : undefined)
           }
-          onResponderGrant={onPressIn}
-          // Both release and terminate responder are needed to properly pressOut
-          onResponderRelease={onPressOut}
-          onResponderTerminate={onPressOut}
           style={style}
           suppressHighlighting
           testID={testID}
@@ -477,7 +475,7 @@ export const addHref = (
   const action = element.getAttribute('action');
   const childNodes = element.childNodes ? Array.from(element.childNodes) : [];
   const behaviorElements = childNodes.filter(
-    n => n && n.nodeType === 1 && n.tagName === 'behavior',
+    n => n && n.nodeType === 1 && (n as Element).tagName === 'behavior',
   );
   const hasBehaviors = href || action || behaviorElements.length > 0;
   if (!hasBehaviors) {

--- a/src/core/hyper-ref/types.ts
+++ b/src/core/hyper-ref/types.ts
@@ -7,7 +7,6 @@
  */
 
 import type {
-  Element,
   HvComponentOnUpdate,
   HvComponentOptions,
   PressTrigger,

--- a/src/services/behaviors/index.ts
+++ b/src/services/behaviors/index.ts
@@ -7,13 +7,7 @@
  */
 
 import * as Dom from 'hyperview/src/services/dom';
-import type {
-  Document,
-  Element,
-  HvComponentOnUpdate,
-  Node,
-  UpdateAction,
-} from 'hyperview/src/types';
+import type { HvComponentOnUpdate, UpdateAction } from 'hyperview/src/types';
 import { ACTIONS } from 'hyperview/src/types';
 import { shallowCloneToRoot } from 'hyperview/src/services';
 

--- a/src/services/dom/helpers.ts
+++ b/src/services/dom/helpers.ts
@@ -7,14 +7,7 @@
  */
 
 import * as Namespaces from 'hyperview/src/services/namespaces';
-import type {
-  Document,
-  Element,
-  LocalName,
-  NamespaceURI,
-  Node,
-  NodeType,
-} from 'hyperview/src/types';
+import type { LocalName, NamespaceURI, NodeType } from 'hyperview/src/types';
 
 export const getBehaviorElements = (element: any) => {
   const behaviorElements = Array.from<Element>(element.childNodes).filter(

--- a/src/services/dom/parser.ts
+++ b/src/services/dom/parser.ts
@@ -22,7 +22,6 @@ import {
 } from './types';
 import { DOMParser } from '@instawork/xmldom';
 import { Dimensions } from 'react-native';
-import type { Document } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import { getFirstTag } from './helpers';
 import { version } from 'hyperview/package.json';

--- a/src/services/index.d.ts
+++ b/src/services/index.d.ts
@@ -7,7 +7,6 @@
  */
 
 import type {
-  Element,
   HvComponentOptions,
   StyleSheet,
   StyleSheets,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -10,14 +10,10 @@ import * as Xml from 'hyperview/src/services/xml';
 import type {
   ComponentRegistry,
   DOMString,
-  Document,
-  Element,
   HvComponent,
   HvComponentOptions,
   HvFormValues,
   LocalName,
-  Node,
-  NodeList,
   StyleSheet,
   StyleSheets,
 } from 'hyperview/src/types';
@@ -144,7 +140,7 @@ export const later = (delayMs: number): Promise<void> => {
  * nodes will be existing objects.
  */
 export const shallowClone = (element: Element): Element => {
-  const newElement: Element = element.cloneNode(false);
+  const newElement: Element = element.cloneNode(false) as Element;
   let childNode: Node | null | undefined = element.firstChild;
   while (childNode) {
     const nextChild: Node | null | undefined = childNode.nextSibling;
@@ -249,7 +245,7 @@ export const getAncestorByTagName = (
     return null;
   }
 
-  while (parentNode.tagName !== tagName) {
+  while ((parentNode as Element).tagName !== tagName) {
     ({ parentNode } = parentNode);
     if (!parentNode) {
       return null;
@@ -300,7 +296,7 @@ export const getFormData = (
     // Get all inputs in the form
     .forEach((data: [string, string, HvComponent]) => {
       const [ns, tag, component] = data;
-      const inputElements: NodeList<Element> = formElement.getElementsByTagNameNS(
+      const inputElements = formElement.getElementsByTagNameNS(
         ns,
         tag as LocalName,
       );

--- a/src/services/inline-context/index.ts
+++ b/src/services/inline-context/index.ts
@@ -14,7 +14,6 @@ import {
   ignoreSpacesFollowingSpace,
   trim,
 } from './helpers';
-import type { Element, Node } from 'hyperview/src/types';
 import { NODE_TYPE } from 'hyperview/src/types';
 import { preorder } from 'hyperview/src/services/dom/helpers';
 

--- a/src/services/keyboard/index.ts
+++ b/src/services/keyboard/index.ts
@@ -6,8 +6,6 @@
  *
  */
 
-import type { Element } from 'hyperview/src/types';
-
 type KeyboardDismissMode = 'none' | 'on-drag' | 'interactive';
 
 export const getKeyboardDismissMode = (

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -15,11 +15,9 @@ import { ANCHOR_ID_SEPARATOR } from './types';
 /**
  * Get an array of all child elements of a node
  */
-export const getChildElements = (
-  element: TypesLegacy.Element,
-): TypesLegacy.Element[] => {
-  return (Array.from(element.childNodes) || []).filter(
-    (child: TypesLegacy.Element) => {
+export const getChildElements = (element: Element): Element[] => {
+  return (Array.from(element.childNodes as NodeListOf<Element>) || []).filter(
+    (child: Element) => {
       return child.nodeType === TypesLegacy.NODE_TYPE.ELEMENT_NODE;
     },
   );
@@ -28,7 +26,7 @@ export const getChildElements = (
 /**
  * Determine if an element is a navigation element
  */
-export const isNavigationElement = (element: TypesLegacy.Element): boolean => {
+export const isNavigationElement = (element: Element): boolean => {
   return (
     element.localName === TypesLegacy.LOCAL_NAME.NAVIGATOR ||
     element.localName === TypesLegacy.LOCAL_NAME.NAV_ROUTE
@@ -39,11 +37,11 @@ export const isNavigationElement = (element: TypesLegacy.Element): boolean => {
  * Get the route designated as 'selected' or the first route if none is marked
  */
 export const getSelectedNavRouteElement = (
-  element: TypesLegacy.Element,
-): TypesLegacy.Element | undefined => {
-  const elements: TypesLegacy.Element[] = getChildElements(
-    element,
-  ).filter(child => isNavigationElement(child));
+  element: Element,
+): Element | undefined => {
+  const elements: Element[] = getChildElements(element).filter(child => {
+    return isNavigationElement(child);
+  });
 
   if (!elements.length) {
     return undefined;

--- a/src/services/render/index.d.ts
+++ b/src/services/render/index.d.ts
@@ -7,7 +7,6 @@
  */
 
 import type {
-  Element,
   HvComponentOnUpdate,
   HvComponentOptions,
   StyleSheets,

--- a/src/services/render/index.tsx
+++ b/src/services/render/index.tsx
@@ -9,7 +9,6 @@
 import * as InlineContext from 'hyperview/src/services/inline-context';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import type {
-  Element,
   HvComponentOnUpdate,
   HvComponentOptions,
   StyleSheets,
@@ -91,11 +90,9 @@ export const renderElement = (
       // Explicitly setting the key causes collision when several components render
       // with `undefined` value for `key`
       // Object spreading will define the prop only when its value is truthy
-      const extraProps = {
-        key: element.getAttribute('key'),
-      };
-      if (!extraProps.key) {
-        delete extraProps.key;
+      const extraProps: Partial<{ [key: string]: string | null }> = {};
+      if (element.getAttribute('key')) {
+        extraProps.key = element.getAttribute('key');
       }
       return (
         <Component
@@ -119,9 +116,10 @@ export const renderElement = (
     // Render non-empty text nodes, when wrapped inside a <text> element
     if (element.nodeValue) {
       if (
-        (element.parentNode?.namespaceURI === Namespaces.HYPERVIEW &&
-          element.parentNode?.localName === LOCAL_NAME.TEXT) ||
-        element.parentNode?.namespaceURI !== Namespaces.HYPERVIEW
+        ((element.parentNode as Element)?.namespaceURI ===
+          Namespaces.HYPERVIEW &&
+          (element.parentNode as Element)?.localName === LOCAL_NAME.TEXT) ||
+        (element.parentNode as Element)?.namespaceURI !== Namespaces.HYPERVIEW
       ) {
         if (options.preformatted) {
           return element.nodeValue;
@@ -162,7 +160,7 @@ export const renderChildren = (
     for (let i = 0; i < childNodes.length; i += 1) {
       const e = renderElement(
         // $FlowFixMe
-        element.childNodes.item(i),
+        element.childNodes.item(i) as Element,
         stylesheets,
         onUpdate,
         { ...options, skipHref: false },

--- a/src/services/stylesheets/index.ts
+++ b/src/services/stylesheets/index.ts
@@ -9,7 +9,6 @@
 import * as Dom from 'hyperview/src/services/dom';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import type {
-  Document,
   StyleSheet as StyleSheetType,
   StyleSheets,
 } from 'hyperview/src/types';
@@ -175,12 +174,14 @@ function createStylesheet(document: Document, modifiers = {}): StyleSheetType {
 
     for (let i = 0; i < styleElements.length; i += 1) {
       const styleElement = styleElements.item(i);
-      const hasModifier = styleElement?.parentNode?.tagName === 'modifier';
+      const hasModifier =
+        (styleElement?.parentNode as Element)?.tagName === 'modifier';
 
       let styleId = styleElement?.getAttribute('id');
       if (hasModifier) {
         // TODO(adam): Use less hacky way to get id of parent style element.
-        styleId = styleElement?.parentNode?.parentNode?.getAttribute('id');
+        styleId = (styleElement?.parentNode
+          ?.parentNode as Element)?.getAttribute('id');
       }
 
       // This must be a root style or a modifier style
@@ -196,7 +197,8 @@ function createStylesheet(document: Document, modifiers = {}): StyleSheetType {
         const [modifier, state] = modifierEntries[j];
 
         const elementModifierState =
-          styleElement?.parentNode?.getAttribute(modifier) === 'true';
+          (styleElement?.parentNode as Element)?.getAttribute(modifier) ===
+          'true';
 
         if (elementModifierState !== state) {
           matchesModifiers = false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,31 +74,6 @@ export const NODE_TYPE = {
 
 export type NodeType = typeof NODE_TYPE[keyof typeof NODE_TYPE];
 
-export type Node = {
-  tagName: DOMString;
-  localName: LocalName;
-  readonly attributes: NamedNodeMap | null | undefined;
-  readonly childNodes: NodeList<Node> | null | undefined;
-  readonly firstChild: Node | null | undefined;
-  readonly lastChild: Node | null | undefined;
-  readonly namespaceURI: NamespaceURI | null | undefined;
-  readonly nextSibling: Node | null | undefined;
-  readonly nodeName: DOMString;
-  readonly nodeType: NodeType;
-  nodeValue: string | null | undefined;
-  readonly ownerDocument: Document | null | undefined;
-  readonly parentNode: Node | null | undefined;
-  readonly previousSibling: Node | null | undefined;
-  appendChild: (newChild: Node) => Node;
-  hasAttributes: () => boolean;
-  hasChildNodes: () => boolean;
-  insertBefore: (newChild: Node, refChild: Node) => Node;
-  isSupported: (feature: DOMString, version: DOMString) => boolean;
-  normalize: () => void;
-  removeChild: (oldChild: Node) => Node;
-  replaceChild: (newChild: Node, oldChild: Node) => Node;
-};
-
 export type Attribute = Node & {
   value: DOMString;
   nodeType: typeof NODE_TYPE.ATTRIBUTE_NODE;
@@ -128,76 +103,6 @@ export type DOMImplementation = {
     systemId: DOMString,
   ) => DocumentType;
   hasFeature: (feature: DOMString, version: DOMString) => boolean;
-};
-
-export type Document = Node & {
-  cloneNode: (deep: boolean) => Document;
-  doctype: DocumentType;
-  documentElement: Element;
-  implementation: DOMImplementation;
-  createAttribute: (name: DOMString) => Attribute;
-  createAttributeNS: (
-    namespaceURI: NamespaceURI,
-    qualifiedName: DOMString,
-  ) => Attribute;
-  createCDATASection: (data: DOMString) => CDATASection;
-  createComment: (data: DOMString) => Comment;
-  createDocumentFragment: () => DocumentFragment;
-  createElement: (tagName: DOMString) => Element;
-  createElementNS: (
-    namespaceURI: NamespaceURI,
-    qualifiedName: DOMString,
-  ) => Node;
-  createEntityReference: (name: DOMString) => EntityReference;
-  createProcessingInstruction: (
-    target: DOMString,
-    data: DOMString,
-  ) => ProcessingInstruction;
-  createTextNode: (data: DOMString) => Node;
-  getElementById: (elementId: DOMString) => Element | null | undefined;
-  getElementsByTagName: (tagName: DOMString) => NodeList<Element>;
-  getElementsByTagNameNS: (
-    namespaceURI: NamespaceURI,
-    localName: LocalName,
-  ) => NodeList<Element>;
-  importNode: (importedNode: Node, deep: boolean) => Node;
-};
-
-export type Element = Omit<Node, 'childNodes' | 'parentNode'> & {
-  // not technically correct, but it's how we're using it
-  // TODO: fix?
-  childNodes: NodeList<Element>;
-  parentNode: Element | null | undefined;
-
-  cloneNode: (deep: boolean) => Element;
-  getAttribute: (name: DOMString) => DOMString | null | undefined;
-  getAttributeNode: (name: DOMString) => Attribute | null | undefined;
-  getAttributeNodeNS: (
-    namespaceURI: NamespaceURI,
-    localName: LocalName,
-  ) => Attribute | null | undefined;
-  getAttributeNS: (
-    namespaceURI: NamespaceURI,
-    localName: LocalName,
-  ) => DOMString | null | undefined;
-  getElementsByTagName: (name: DOMString) => NodeList<Element>;
-  getElementsByTagNameNS: (
-    namespaceURI: NamespaceURI,
-    localName: LocalName,
-  ) => NodeList<Element>;
-  hasAttribute: (name: DOMString) => boolean;
-  hasAttributeNS: (namespaceURI: NamespaceURI, localName: LocalName) => boolean;
-  removeAttribute: (name: DOMString) => void;
-  removeAttributeNode: (attribute: Attribute) => Attribute;
-  removeAttributeNS: (namespaceURI: NamespaceURI, localName: LocalName) => void;
-  setAttribute: (name: DOMString, value: DOMString) => void;
-  setAttributeNode: (attribute: Attribute) => Attribute;
-  setAttributeNodeNS: (attribute: Attribute) => Attribute;
-  setAttributeNS: (
-    namespaceURI: NamespaceURI,
-    qualifiedName: LocalName,
-    value: DOMString,
-  ) => void;
 };
 
 export type DocumentFragment = Node;
@@ -232,14 +137,6 @@ export type Comment = CharacterData & {
 export type CDATASection = CharacterData & {
   nodeName: '#cdata-section';
   nodeType: typeof NODE_TYPE.CDATA_SECTION_NODE;
-};
-
-export type NodeList<T> = {
-  filter: (predicate: (item: T) => boolean) => T[];
-  length: number;
-  item: (index: number) => T | null | undefined;
-} & {
-  [index: number]: T;
 };
 
 export type NamedNodeMap = {

--- a/test/helpers.tsx
+++ b/test/helpers.tsx
@@ -10,7 +10,7 @@ import * as Components from 'hyperview/src/services/components';
 import * as Dom from 'hyperview/src/services/dom';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Stylesheets from 'hyperview/src/services/stylesheets';
-import type { Element, HvComponent, LocalName } from 'hyperview/src/types';
+import type { HvComponent, LocalName } from 'hyperview/src/types';
 import { DOMParser } from '@instawork/xmldom';
 import React from 'react';
 import { action } from '@storybook/addon-actions';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,10 @@
     "baseUrl": ".",
     "paths": {
       "hyperview/*": ["./*"],
-      "flow-to-typescript-codemod": ["./src/flow.d.ts"]
+      "flow-to-typescript-codemod": ["./src/flow.d.ts"],
+      "react-native-keyboard-aware-scrollview": [
+        "./src/core/components/keyboard-aware-scroll-view/index.d.ts"
+      ]
     }
   },
   "files": ["src/core/components/hv-root/index.tsx"],


### PR DESCRIPTION
This requires some additional explicit casting to `Element`.