### PR TITLE
chore(ts): remove explicit DOM types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -61,10 +61,12 @@
         "flowtype/no-types-missing-file-annotation": "off",
         "func-call-spacing": "off",
         "function-paren-newline": "off",
+        "implicit-arrow-linebreak": "off",
         "indent": "off",
         "instawork/error-object": "off",
         "instawork/flow-annotate": "off",
         "no-spaced-func": "off",
+        "no-undef": "off",
         "no-use-before-define": "off",
         "object-curly-newline": "off",
         "operator-linebreak": "off"

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import * as TypesLegacy from 'hyperview/src/types-legacy';
 import type { ComponentType } from 'react';
 import React from 'react';
 import type { RefreshControlProps } from 'react-native';
@@ -25,5 +24,5 @@ export const RefreshControlComponentContext = React.createContext<
 >(undefined);
 
 export const DocContext = React.createContext<{
-  getDoc: () => TypesLegacy.Document;
+  getDoc: () => Document;
 } | null>(null);

--- a/src/contexts/navigator-map.tsx
+++ b/src/contexts/navigator-map.tsx
@@ -6,16 +6,15 @@
  *
  */
 
-import * as TypesLegacy from 'hyperview/src/types-legacy';
 import React, { createContext, useState } from 'react';
 
 export type NavigatorMapContextProps = {
   setRoute: (key: string, route: string) => void;
   getRoute: (key: string) => string | undefined;
-  setElement: (key: string, element: TypesLegacy.Element) => void;
-  getElement: (key: string) => TypesLegacy.Element | undefined;
-  setPreload: (key: number, element: TypesLegacy.Element) => void;
-  getPreload: (key: number) => TypesLegacy.Element | undefined;
+  setElement: (key: string, element: Element) => void;
+  getElement: (key: string) => Element | undefined;
+  setPreload: (key: number, element: Element) => void;
+  getPreload: (key: number) => Element | undefined;
   initialRouteName?: string;
 };
 
@@ -44,8 +43,8 @@ type Props = { children: React.ReactNode };
  */
 export function NavigatorMapProvider(props: Props) {
   const [routeMap] = useState<Map<string, string>>(new Map());
-  const [elementMap] = useState<Map<string, TypesLegacy.Element>>(new Map());
-  const [preloadMap] = useState<Map<number, TypesLegacy.Element>>(new Map());
+  const [elementMap] = useState<Map<string, Element>>(new Map());
+  const [preloadMap] = useState<Map<number, Element>>(new Map());
 
   const setRoute = (key: string, route: string) => {
     routeMap.set(key, route);
@@ -55,19 +54,19 @@ export function NavigatorMapProvider(props: Props) {
     return routeMap.get(key);
   };
 
-  const setElement = (key: string, element: TypesLegacy.Element) => {
+  const setElement = (key: string, element: Element) => {
     elementMap.set(key, element);
   };
 
-  const getElement = (key: string): TypesLegacy.Element | undefined => {
+  const getElement = (key: string): Element | undefined => {
     return elementMap.get(key);
   };
 
-  const setPreload = (key: number, element: TypesLegacy.Element) => {
+  const setPreload = (key: number, element: Element) => {
     preloadMap.set(key, element);
   };
 
-  const getPreload = (key: number): TypesLegacy.Element | undefined => {
+  const getPreload = (key: number): Element | undefined => {
     return preloadMap.get(key);
   };
 

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -26,10 +26,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
   /**
    * Build an individual tab screen
    */
-  buildTabScreen = (
-    id: string,
-    type: TypesLegacy.DOMString,
-  ): React.ReactElement => {
+  buildTabScreen = (id: string, type: string): React.ReactElement => {
     if (type === NavigatorService.NAVIGATOR_TYPE.TAB) {
       return (
         <BottomTab.Screen
@@ -48,10 +45,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
   /**
    * Build all screens from received routes
    */
-  buildScreens = (
-    element: TypesLegacy.Element,
-    type: TypesLegacy.DOMString,
-  ): React.ReactNode => {
+  buildScreens = (element: Element, type: string): React.ReactNode => {
     const screens: React.ReactElement[] = [];
     const navigationContext: NavigationContext.NavigationContextProps | null = useContext(
       NavigationContext.Context,
@@ -64,20 +58,15 @@ export default class HvNavigator extends PureComponent<Types.Props> {
     }
 
     const { buildTabScreen } = this;
-    const elements: TypesLegacy.Element[] = NavigatorService.getChildElements(
-      element,
-    );
+    const elements: Element[] = NavigatorService.getChildElements(element);
 
     // For tab navigators, the screens are appended
     // For stack navigators, the dynamic screens are added later
     // This iteration will also process nested navigators
     //    and retrieve additional urls from child routes
-    elements.forEach((navRoute: TypesLegacy.Element) => {
+    elements.forEach((navRoute: Element) => {
       if (navRoute.localName === TypesLegacy.LOCAL_NAME.NAV_ROUTE) {
-        const id:
-          | TypesLegacy.DOMString
-          | null
-          | undefined = navRoute.getAttribute('id');
+        const id: string | null | undefined = navRoute.getAttribute('id');
         if (!id) {
           throw new NavigatorService.HvNavigatorError(
             `No id provided for ${navRoute.localName}`,
@@ -85,7 +74,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
         }
 
         // Check for nested navigators
-        const nestedNavigator: TypesLegacy.Element | null = getFirstTag(
+        const nestedNavigator: Element | null = getFirstTag(
           navRoute,
           TypesLegacy.LOCAL_NAME.NAVIGATOR,
         );
@@ -93,10 +82,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
           // Cache the navigator for the route
           navigatorMapContext.setElement(id, nestedNavigator);
         } else {
-          const href:
-            | TypesLegacy.DOMString
-            | null
-            | undefined = navRoute.getAttribute('href');
+          const href: string | null | undefined = navRoute.getAttribute('href');
           if (!href) {
             throw new NavigatorService.HvNavigatorError(
               `No href provided for route '${id}'`,
@@ -152,10 +138,7 @@ export default class HvNavigator extends PureComponent<Types.Props> {
    * Build the required navigator from the xml element
    */
   Navigator = (props: Types.Props): React.ReactElement => {
-    const id:
-      | TypesLegacy.DOMString
-      | null
-      | undefined = props.element.getAttribute('id');
+    const id: string | null | undefined = props.element.getAttribute('id');
     if (!id) {
       throw new NavigatorService.HvNavigatorError('No id found for navigator');
     }
@@ -170,12 +153,9 @@ export default class HvNavigator extends PureComponent<Types.Props> {
       throw new NavigatorService.HvRouteError('No context found');
     }
 
-    const type:
-      | TypesLegacy.DOMString
-      | null
-      | undefined = props.element.getAttribute('type');
+    const type: string | null | undefined = props.element.getAttribute('type');
     const selected:
-      | TypesLegacy.Element
+      | Element
       | undefined = NavigatorService.getSelectedNavRouteElement(props.element);
     if (!selected) {
       throw new NavigatorService.HvNavigatorError(

--- a/src/core/components/hv-navigator/types.ts
+++ b/src/core/components/hv-navigator/types.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import * as TypesLegacy from 'hyperview/src/types-legacy';
 import { FC } from 'react';
 import type { Props as HvRouteProps } from 'hyperview/src/core/components/hv-route';
 
@@ -32,6 +31,6 @@ export type NavigatorParams = {
  * All of the props used by hv-navigator
  */
 export type Props = {
-  element: TypesLegacy.Element;
+  element: Element;
   routeComponent: FC<HvRouteProps>;
 };

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -226,7 +226,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
             behaviors={this.props.behaviors}
             closeModal={this.navLogic.closeModal}
             components={this.props.components}
-            doc={this.state.doc?.cloneNode(true)}
+            doc={this.state.doc?.cloneNode(true) as Document}
             elementErrorComponent={this.props.elementErrorComponent}
             entrypointUrl={this.props.entrypointUrl}
             errorScreen={this.props.errorScreen}

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -113,7 +113,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     }
   };
 
-  getRenderElement = (): TypesLegacy.Element | null => {
+  getRenderElement = (): Element | null => {
     if (this.props.element) {
       return this.props.element;
     }
@@ -122,7 +122,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     }
 
     // Get the <doc> element
-    const root: TypesLegacy.Element | null = Helpers.getFirstTag(
+    const root: Element | null = Helpers.getFirstTag(
       this.state.doc,
       TypesLegacy.LOCAL_NAME.DOC,
     );
@@ -131,7 +131,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     }
 
     // Get the first child as <screen> or <navigator>
-    const screenElement: TypesLegacy.Element | null = Helpers.getFirstTag(
+    const screenElement: Element | null = Helpers.getFirstTag(
       root,
       TypesLegacy.LOCAL_NAME.SCREEN,
     );
@@ -139,7 +139,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
       return screenElement;
     }
 
-    const navigatorElement: TypesLegacy.Element | null = Helpers.getFirstTag(
+    const navigatorElement: Element | null = Helpers.getFirstTag(
       root,
       TypesLegacy.LOCAL_NAME.NAVIGATOR,
     );
@@ -152,7 +152,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     );
   };
 
-  registerPreload = (id: number, element: TypesLegacy.Element): void => {
+  registerPreload = (id: number, element: Element): void => {
     this.props.setPreload(id, element);
   };
 
@@ -255,7 +255,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
   Route = (props: {
     handleBack?: ComponentType<{ children: ReactNode }>;
   }): React.ReactElement => {
-    const renderElement: TypesLegacy.Element | null = this.getRenderElement();
+    const renderElement: Element | null = this.getRenderElement();
 
     if (!renderElement) {
       throw new NavigatorService.HvRenderError('No element found');
@@ -374,7 +374,7 @@ export default function HvRoute(props: Types.Props) {
     type !== NavigatorService.NAVIGATOR_TYPE.STACK || index === 0;
 
   // Get the navigator element from the context
-  const element: TypesLegacy.Element | undefined =
+  const element: Element | undefined =
     id && includeElement ? navigatorMapContext.getElement(id) : undefined;
 
   return (

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -40,14 +40,14 @@ export type NavigationContextProps = {
 
 export type NavigatorMapContextProps = {
   getRoute: (key: string) => string | undefined;
-  getElement: (key: string) => TypesLegacy.Element | undefined;
-  setPreload: (key: number, element: TypesLegacy.Element) => void;
-  getPreload: (key: number) => TypesLegacy.Element | undefined;
+  getElement: (key: string) => Element | undefined;
+  setPreload: (key: number, element: Element) => void;
+  getPreload: (key: number) => Element | undefined;
   initialRouteName?: string;
 };
 
 export type State = {
-  doc?: TypesLegacy.Document;
+  doc?: Document;
   error?: Error;
 };
 
@@ -79,11 +79,11 @@ export type InnerRouteProps = {
   loadingScreen?: ComponentType<LoadingProps>;
   handleBack?: ComponentType<{ children: ReactNode }>;
   getRoute: (key: string) => string | undefined;
-  getElement: (key: string) => TypesLegacy.Element | undefined;
-  setPreload: (key: number, element: TypesLegacy.Element) => void;
-  getPreload: (key: number) => TypesLegacy.Element | undefined;
+  getElement: (key: string) => Element | undefined;
+  setPreload: (key: number, element: Element) => void;
+  getPreload: (key: number) => Element | undefined;
   initialRouteName?: string;
-  element?: TypesLegacy.Element;
+  element?: Element;
 };
 
 /**

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -51,6 +51,6 @@ export type Props = {
   errorScreen?: ComponentType<ErrorProps>;
   loadingScreen?: ComponentType<LoadingProps>;
   handleBack?: ComponentType<{ children: ReactNode }>;
-  doc?: TypesLegacy.Document;
-  registerPreload?: (id: number, element: TypesLegacy.Element) => void;
+  doc?: Document;
+  registerPreload?: (id: number, element: Element) => void;
 };

--- a/src/services/dom.d.ts
+++ b/src/services/dom.d.ts
@@ -11,7 +11,6 @@ import type {
   Fetch,
   XResponseStaleReason,
 } from './types';
-import type { Document } from 'hyperview/src/types-legacy';
 
 /**
  * TS definition of the Parser class to provide an alternate Document response

--- a/src/services/dom/helpers-legacy.ts
+++ b/src/services/dom/helpers-legacy.ts
@@ -14,7 +14,7 @@ import * as Namespaces from 'hyperview/src/services/namespaces';
 import { LocalName, NamespaceURI } from 'hyperview/src/types-legacy';
 
 export const getFirstTag = (
-  document: Document,
+  document: Document | Element,
   localName: LocalName,
   namespace: NamespaceURI = Namespaces.HYPERVIEW,
 ): Element | null => {

--- a/src/services/dom/helpers-legacy.ts
+++ b/src/services/dom/helpers-legacy.ts
@@ -11,12 +11,7 @@
 // CHANGES MADE TO ANY IMPLEMENTATIONS ARE NOTEDED BELOW AND MARKED WITH ***** ADDED *****
 
 import * as Namespaces from 'hyperview/src/services/namespaces';
-import {
-  Document,
-  Element,
-  LocalName,
-  NamespaceURI,
-} from 'hyperview/src/types-legacy';
+import { LocalName, NamespaceURI } from 'hyperview/src/types-legacy';
 
 export const getFirstTag = (
   document: Document,

--- a/src/services/keyboard/index.ts
+++ b/src/services/keyboard/index.ts
@@ -6,12 +6,10 @@
  *
  */
 
-import * as TypesLegacy from 'hyperview/src/types-legacy';
-
 type KeyboardDismissMode = 'none' | 'on-drag' | 'interactive';
 
 export const getKeyboardDismissMode = (
-  element: TypesLegacy.Element,
+  element: Element,
 ): KeyboardDismissMode | undefined => {
   const mode = element.getAttribute('keyboard-dismiss-mode');
   switch (mode) {

--- a/src/services/navigator/helpers.test.ts
+++ b/src/services/navigator/helpers.test.ts
@@ -1,4 +1,4 @@
-import * as DomErrors from '../dom/errors';
+import * as DomErrors from 'hyperview/src/services/dom/errors';
 import * as Errors from './errors';
 import * as Namespaces from '../namespaces';
 import * as Types from './types';

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -16,9 +16,11 @@ import { ANCHOR_ID_SEPARATOR } from './types';
  * Get an array of all child elements of a node
  */
 export const getChildElements = (element: Element): Element[] => {
-  return (Array.from(element.childNodes) || []).filter((child: Element) => {
-    return child.nodeType === TypesLegacy.NODE_TYPE.ELEMENT_NODE;
-  });
+  return (Array.from(element.childNodes as NodeListOf<Element>) || []).filter(
+    (child: Element) => {
+      return child.nodeType === TypesLegacy.NODE_TYPE.ELEMENT_NODE;
+    },
+  );
 };
 
 /**

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -15,20 +15,16 @@ import { ANCHOR_ID_SEPARATOR } from './types';
 /**
  * Get an array of all child elements of a node
  */
-export const getChildElements = (
-  element: TypesLegacy.Element,
-): TypesLegacy.Element[] => {
-  return (Array.from(element.childNodes) || []).filter(
-    (child: TypesLegacy.Element) => {
-      return child.nodeType === TypesLegacy.NODE_TYPE.ELEMENT_NODE;
-    },
-  );
+export const getChildElements = (element: Element): Element[] => {
+  return (Array.from(element.childNodes) || []).filter((child: Element) => {
+    return child.nodeType === TypesLegacy.NODE_TYPE.ELEMENT_NODE;
+  });
 };
 
 /**
  * Determine if an element is a navigation element
  */
-export const isNavigationElement = (element: TypesLegacy.Element): boolean => {
+export const isNavigationElement = (element: Element): boolean => {
   return (
     element.localName === TypesLegacy.LOCAL_NAME.NAVIGATOR ||
     element.localName === TypesLegacy.LOCAL_NAME.NAV_ROUTE
@@ -39,11 +35,11 @@ export const isNavigationElement = (element: TypesLegacy.Element): boolean => {
  * Get the route designated as 'selected' or the first route if none is marked
  */
 export const getSelectedNavRouteElement = (
-  element: TypesLegacy.Element,
-): TypesLegacy.Element | undefined => {
-  const elements: TypesLegacy.Element[] = getChildElements(
-    element,
-  ).filter(child => isNavigationElement(child));
+  element: Element,
+): Element | undefined => {
+  const elements: Element[] = getChildElements(element).filter(child =>
+    isNavigationElement(child),
+  );
 
   if (!elements.length) {
     return undefined;

--- a/src/services/stylesheets.d.ts
+++ b/src/services/stylesheets.d.ts
@@ -7,6 +7,4 @@
  */
 import * as TypesLegacy from 'hyperview/src/types-legacy';
 
-export function createStylesheets(
-  document: TypesLegacy.Document,
-): TypesLegacy.StyleSheets;
+export function createStylesheets(document: Document): TypesLegacy.StyleSheets;

--- a/src/services/stylesheets.d.ts
+++ b/src/services/stylesheets.d.ts
@@ -7,4 +7,6 @@
  */
 import * as TypesLegacy from 'hyperview/src/types-legacy';
 
-export function createStylesheets(document: Document): TypesLegacy.StyleSheets;
+export function createStylesheets(
+  document: Document | Element,
+): TypesLegacy.StyleSheets;

--- a/src/types-legacy.ts
+++ b/src/types-legacy.ts
@@ -69,7 +69,6 @@ export const NAV_ACTIONS = {
 
 export type NavAction = typeof NAV_ACTIONS[keyof typeof NAV_ACTIONS];
 
-export type DOMString = string;
 export type NamespaceURI = string;
 
 export type NodeList<T> = {
@@ -80,50 +79,7 @@ export type NodeList<T> = {
 };
 
 /**
- * Minimal Node type copy from 'hyperview/src/types.js'
- */
-export type Node = {
-  tagName: DOMString;
-  localName: LocalName;
-  readonly childNodes: NodeList<Node> | null | undefined;
-  readonly firstChild: Node | null | undefined;
-  readonly namespaceURI: NamespaceURI | null | undefined;
-  readonly nextSibling: Node | null | undefined;
-  readonly nodeType: NodeType;
-  hasChildNodes: () => boolean;
-};
-
-/**
- * Minimal Element type copy from 'hyperview/src/types.js'
- */
-export type Element = Node & {
-  // ***** ADDED *****
-  cloneNode: (deep: boolean) => Element;
-
-  childNodes: NodeList<Element>;
-  getAttribute: (name: DOMString) => DOMString | null | undefined;
-
-  getElementsByTagNameNS: (
-    namespaceURI: NamespaceURI,
-    localName: LocalName,
-  ) => NodeList<Element>;
-};
-
-/**
- * Minimal Document type copy from 'hyperview/src/types.js'
- */
-export type Document = Node & {
-  // ***** ADDED *****
-  cloneNode: (deep: boolean) => Document;
-
-  getElementsByTagNameNS: (
-    namespaceURI: NamespaceURI,
-    localName: LocalName,
-  ) => NodeList<Element>;
-};
-
-/**
- * Minimal Document type copy from 'hyperview/src/types.js'
+ * Minimal NavigationRouteParams type copy from 'hyperview/src/types.js'
  */
 export type NavigationRouteParams = {
   delay?: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,22 @@
   "compilerOptions": {
     "allowJs": false,
     "checkJs": false,
+    "lib": [
+      "es2019",
+      "es2020.bigint",
+      "es2020.date",
+      "es2020.number",
+      "es2020.promise",
+      "es2020.string",
+      "es2020.symbol.wellknown",
+      "es2021.promise",
+      "es2021.string",
+      "es2021.weakref",
+      "es2022.array",
+      "es2022.object",
+      "es2022.string",
+      "dom"
+    ],
     "outDir": "lib",
     "paths": {
       "hyperview/*": ["./*"]


### PR DESCRIPTION
Instead of redefining DOM types, rely on the official library.

Note:
In b5d1e7b3e6111cd10bb116e6f083794295125811, we're explicitly defining the libs to import in TS. The list of sources applied are existing sources from the extended file (`@tsconfig/react-native/tsconfig.json`) with one addition, `dom`, which allows for global definition of DOM types. In our previous work updating to TS, we didn't needed to define this, likely because we already had TS code importing types from xmldom library, which itself imports the `dom` library.
This override is only needed for the time being to keep tests passing. We should be able to remove the override before the final merge.