### PR TITLE
chore: update library versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "url-parse": "1.5.10"
   },
   "peerDependencies": {
-    "@react-native-community/datetimepicker": "^3.0.3",
-    "@react-native-picker/picker": "^2.2.1",
+    "@react-native-community/datetimepicker": "^6.1.1",
+    "@react-native-picker/picker": "^2.4.0",
     "@react-navigation/bottom-tabs": "^6.5.7",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/stack": "^6.3.16",
@@ -73,8 +73,8 @@
     "@babel/runtime": "7.13.7",
     "@faker-js/faker": "^8.0.2",
     "@prettier/plugin-xml": "0.13.0",
-    "@react-native-community/datetimepicker": "3.0.3",
-    "@react-native-picker/picker": "2.2.1",
+    "@react-native-community/datetimepicker": "6.1.1",
+    "@react-native-picker/picker": "2.4.0",
     "@react-navigation/bottom-tabs": "6.5.7",
     "@react-navigation/native": "6.1.6",
     "@react-navigation/stack": "6.3.16",

--- a/src/components/hv-date-field/index.tsx
+++ b/src/components/hv-date-field/index.tsx
@@ -15,7 +15,7 @@ import type {
 } from 'hyperview/src/types';
 import React, { PureComponent } from 'react';
 import DateTimePicker from 'hyperview/src/core/components/date-time-picker';
-import type { Event } from '@react-native-community/datetimepicker';
+import type { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import Field from './field';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import Modal from 'hyperview/src/core/components/modal';
@@ -210,12 +210,14 @@ export default class HvDateField extends PureComponent<HvComponentProps> {
           stylesheets={this.props.stylesheets}
         >
           <Picker
-            onChange={(evt: Event, date?: Date) => this.setPickerValue(date)}
+            onChange={(evt: DateTimePickerEvent, date?: Date) =>
+              this.setPickerValue(date)
+            }
           />
         </Modal>
       );
     }
-    const onChange = (evt: Event, date?: Date) => {
+    const onChange = (evt: DateTimePickerEvent, date?: Date) => {
       if (date === undefined) {
         this.onCancel();
       } else {

--- a/src/components/hv-date-field/types.ts
+++ b/src/components/hv-date-field/types.ts
@@ -6,8 +6,8 @@
  *
  */
 
-import type { Event } from '@react-native-community/datetimepicker';
+import type { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 
 export type PickerProps = {
-  onChange: (event: Event, date?: Date) => void;
+  onChange: (event: DateTimePickerEvent, date?: Date) => void;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2254,17 +2254,17 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
-"@react-native-community/datetimepicker@3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-3.0.3.tgz#711b4cb7fd195ab7ae867b8feab176ce46e765c8"
-  integrity sha512-znltGqSyELRpS/JchT/6MraTRqC83INekEyAkH+0gBrDzv0SwFKwVWacv1tF5D1y5VrHcSrcFB3T/tBsksUgwA==
+"@react-native-community/datetimepicker@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-6.1.1.tgz#4259bc770dc81deac9d81370eb1f456d52116f04"
+  integrity sha512-/ZYDcxMEM/LoTvf4tk1bheaK/yZu3UPPSlolz3RgUDFWixiNacDWu1ZiW8LOhaWs8PnfyGH47xQtEmTxW41mZw==
   dependencies:
     invariant "^2.2.4"
 
-"@react-native-picker/picker@2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.2.1.tgz#32b9f540d8e88a73d8856f73cca88251cecb9614"
-  integrity sha512-EC7yv22QLHlTfnbC1ez9IUdXTOh1W31x96Oir0PfskSGFFJMWWdLTg4VrcE2DsGLzbfjjkBk123c173vf2a5MQ==
+"@react-native-picker/picker@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.4.0.tgz#7ca2e01a3bdf854ee01ca752762ffa73c0e83313"
+  integrity sha512-duGZc3a8Qa21YPrA4U3oR9NAUzBA66FTjubGK2CodA6rNjiwN+xC32hOZ5unkf4qD3DqLWeoPjg3fYf54bVMjA==
 
 "@react-native/assets@1.0.0":
   version "1.0.0"


### PR DESCRIPTION
These libraries are used in the demo app and Instawork apps, but the versions we currently had in Hyperview were old and defining incompatible types.