### PR TITLE
chore(ts): more clean up and fixes

### DIFF
--- a/scripts/sync/index.js
+++ b/scripts/sync/index.js
@@ -17,7 +17,7 @@ const HYPERVIEW_SRC_DIR = path.join(HYPERVIEW_DIR, SRC_DIRNAME);
 
 const updatePackageJson = () => {
   console.log('Updating package.json…');
-  const cmd = `sed -i.bak 's/lib\\/index.js/${SRC_DIRNAME}\\/index.js/g' ${HYPERVIEW_DIR}/package.json`;
+  const cmd = `sed -i.bak 's/lib\\/index.js/${SRC_DIRNAME}\\/index.ts/g' ${HYPERVIEW_DIR}/package.json`;
   childProcess.execSync(cmd);
 };
 

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -23,7 +23,8 @@ export type Props = {
     format: string | undefined,
   ) => string | undefined;
   refreshControl?: ComponentType<RefreshControlProps>;
-  navigation?: NavigatorService.NavigationProp;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  navigation?: any;
   route?: NavigatorService.Route<string, { url?: string }>;
   entrypointUrl: string;
   fetch: Types.Fetch;

--- a/src/core/components/keyboard-aware-scroll-view/index.d.ts
+++ b/src/core/components/keyboard-aware-scroll-view/index.d.ts
@@ -1,1 +1,0 @@
-declare module 'react-native-keyboard-aware-scrollview';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
     },
     "types": ["react-native", "jest", "node"]
   },
-  "exclude": ["**/*.js", "**/*.jsx"]
+  "exclude": ["**/*.js", "**/*.jsx", "demo/**/*"]
 }


### PR DESCRIPTION
- Update sync script to point to index.ts instead of index.js
- Make navigation prop type explicitely loose to prevent conflicts with demo app
- Remove duplicated type file
- Ignore demo/ directory when validating types of Hyperview library