### PR TITLE
fix: revert package.json `main` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperview",
   "version": "0.70.0",
-  "main": "src/index.ts",
+  "main": "lib/index.js",
   "description": "React Native client for Hyperview XML",
   "homepage": "https://hyperview.org",
   "keywords": [


### PR DESCRIPTION
This was inadvertently changed in #604 - revert it back to point to the transpiled version by default