### PR TITLE
fix: Android switch color

### DIFF
--- a/src/components/hv-switch/style-sheet/index.ts
+++ b/src/components/hv-switch/style-sheet/index.ts
@@ -7,7 +7,8 @@
  */
 
 import type { ColorValue } from 'react-native';
-import { processColor } from 'react-native';
+// @ts-ignore
+import normalizeColor from 'react-native/Libraries/StyleSheet/normalizeColor';
 
-export default processColor;
+export default normalizeColor;
 export type { ColorValue };

--- a/src/components/hv-switch/style-sheet/index.ts
+++ b/src/components/hv-switch/style-sheet/index.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ColorValue } from 'react-native';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import normalizeColor from 'react-native/Libraries/StyleSheet/normalizeColor';
 


### PR DESCRIPTION
Revert [a change that occured during the migration](https://github.com/Instawork/hyperview/pull/693/commits/8eb6a6442a6beea35d80470227cc5d8084498046#diff-d610e5fb53e9820675e03e4d336b6a1a210e78863d68e344182b8cc31d9afda6), which changed the underlying helper used to convert the switch color on Android.

Note: as we cannot resolve the type correctly, I'm temporarily adding an ignore statement to satisfy TS. We will rework the switch implementation in an upcoming refactor, and we should revise how the color styles are applied / what functions from RN we use for this.


| Before | After |
|--------|------|
| <img width="559" alt="Screenshot 2023-10-16 at 1 09 25 PM" src="https://github.com/Instawork/hyperview/assets/309515/fe9c5665-2318-43e1-9832-ac7f20a85036"> | <img width="559" alt="Screenshot 2023-10-16 at 1 07 16 PM" src="https://github.com/Instawork/hyperview/assets/309515/16b233a6-7079-49ae-a854-2022c0aaa105"> |
