### PR TITLE
chore(on update): lift onUpdate and its methods from hv-screen to hv-root

### DIFF
--- a/src/behaviors/index.ts
+++ b/src/behaviors/index.ts
@@ -44,4 +44,6 @@ export {
   setIndicatorsBeforeLoad,
   performUpdate,
   setIndicatorsAfterLoad,
+  isOncePreviouslyApplied,
+  setRanOnce,
 } from 'hyperview/src/services/behaviors';

--- a/src/contexts/navigation.ts
+++ b/src/contexts/navigation.ts
@@ -5,7 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import type { Fetch, HvBehavior, HvComponent } from 'hyperview/src/types';
+import type {
+  Fetch,
+  HvBehavior,
+  HvComponent,
+  RootOnUpdate,
+} from 'hyperview/src/types';
 
 import React, { ComponentType, ReactNode } from 'react';
 
@@ -18,6 +23,7 @@ export type NavigationContextProps = {
   onError?: (error: Error) => void;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
+  onUpdate: RootOnUpdate;
   url?: string;
   behaviors?: HvBehavior[];
   components?: HvComponent[];

--- a/src/contexts/navigation.ts
+++ b/src/contexts/navigation.ts
@@ -9,7 +9,7 @@ import type {
   Fetch,
   HvBehavior,
   HvComponent,
-  RootOnUpdate,
+  HvComponentOnUpdate,
 } from 'hyperview/src/types';
 
 import React, { ComponentType, ReactNode } from 'react';
@@ -23,7 +23,7 @@ export type NavigationContextProps = {
   onError?: (error: Error) => void;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
-  onUpdate: RootOnUpdate;
+  onUpdate: HvComponentOnUpdate;
   url?: string;
   behaviors?: HvBehavior[];
   components?: HvComponent[];

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -59,9 +59,6 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
   constructor(props: HvScreenProps.Props) {
     super(props);
 
-    this.onUpdate = this.onUpdate.bind(this);
-    this.reload = this.reload.bind(this);
-
     this.parser = new Dom.Parser(
       this.props.fetch,
       this.props.onParseBefore,

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -165,7 +165,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
     if (href[0] === '#') {
       const element = root.getElementById(href.slice(1));
       if (element) {
-        return element.cloneNode(true);
+        return element.cloneNode(true) as Element;
       }
       throw new Error(`Element with id ${href} not found in document`);
     }

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -160,7 +160,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
     root: Document,
     formData: FormData | null | undefined,
     callbacks: OnUpdateCallbacks,
-  ) => {
+  ): Promise<Element | null> => {
     if (!href) {
       throw new Error('No href passed to fetchElement');
     }

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -87,9 +87,10 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
       optHref === undefined ||
       optHref === '#' ||
       optHref === '';
+    const stateUrl = callbacks.getState().url;
     const url = isBlankHref
-      ? callbacks.getStateUrl()
-      : UrlService.getUrlFromHref(optHref, callbacks.getStateUrl());
+      ? stateUrl
+      : UrlService.getUrlFromHref(optHref, stateUrl || '');
 
     if (!url) {
       return;
@@ -171,7 +172,10 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
     }
 
     try {
-      const url = UrlService.getUrlFromHref(href, callbacks.getStateUrl());
+      const url = UrlService.getUrlFromHref(
+        href,
+        callbacks.getState().url || '',
+      );
       const httpMethod: Dom.HttpMethod = method as Dom.HttpMethod;
       const { doc, staleHeaderType } = await this.parser.loadElement(
         url,
@@ -212,7 +216,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
       if (navigation) {
         const { behaviorElement, delay, newElement, targetId } = options;
         const delayVal: number = +(delay || '');
-        navigation.setUrl(callbacks.getStateUrl());
+        navigation.setUrl(callbacks.getState().url || '');
         navigation.setDocument(callbacks.getDoc());
         navigation.navigate(
           href || Navigation.ANCHOR_ID_SEPARATOR,

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -6,15 +6,35 @@
  *
  */
 
+import * as Behaviors from 'hyperview/src/behaviors';
+import * as Components from 'hyperview/src/services/components';
 import * as Contexts from 'hyperview/src/contexts';
+import * as Dom from 'hyperview/src/services/dom';
+import * as Events from 'hyperview/src/services/events';
 import * as HvScreenProps from 'hyperview/src/core/components/hv-screen/types';
 import * as NavContexts from 'hyperview/src/contexts/navigation';
+import * as Navigation from 'hyperview/src/services/navigation';
 import * as Render from 'hyperview/src/services/render';
 import * as Services from 'hyperview/src/services';
-
+import * as Stylesheets from 'hyperview/src/services/stylesheets';
+import * as UrlService from 'hyperview/src/services/url';
+import * as Xml from 'hyperview/src/services/xml';
+import {
+  ACTIONS,
+  BehaviorRegistry,
+  ComponentRegistry,
+  DOMString,
+  HvComponentOptions,
+  NAV_ACTIONS,
+  NavAction,
+  OnUpdateCallbacks,
+  UPDATE_ACTIONS,
+  UpdateAction,
+} from 'hyperview/src/types';
 import React, { PureComponent } from 'react';
 import HvRoute from 'hyperview/src/core/components/hv-route';
 import HvScreen from 'hyperview/src/core/components/hv-screen';
+import { Linking } from 'react-native';
 
 /**
  * Provides routing to the correct path based on the state passed in
@@ -27,6 +47,460 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
   static renderChildren = Render.renderChildren;
 
   static renderElement = Render.renderElement;
+
+  behaviorRegistry: BehaviorRegistry;
+
+  componentRegistry: ComponentRegistry;
+
+  formComponentRegistry: ComponentRegistry;
+
+  parser: Dom.Parser;
+
+  constructor(props: HvScreenProps.Props) {
+    super(props);
+
+    this.onUpdate = this.onUpdate.bind(this);
+    this.reload = this.reload.bind(this);
+
+    this.parser = new Dom.Parser(
+      this.props.fetch,
+      this.props.onParseBefore,
+      this.props.onParseAfter,
+    );
+
+    this.behaviorRegistry = Behaviors.getRegistry(this.props.behaviors);
+    this.componentRegistry = Components.getRegistry(this.props.components);
+    this.formComponentRegistry = Components.getFormRegistry(
+      this.props.components,
+    );
+  }
+
+  /**
+   * Reload if an error occured.
+   * @param opt_href: Optional string href to use when reloading the screen. If not provided,
+   * the screen's current URL will be used.
+   */
+  reload = (
+    optHref: DOMString | null | undefined,
+    opts: HvComponentOptions,
+    callbacks: OnUpdateCallbacks,
+  ) => {
+    const isBlankHref =
+      optHref === null ||
+      optHref === undefined ||
+      optHref === '#' ||
+      optHref === '';
+    const url = isBlankHref
+      ? callbacks.getStateUrl()
+      : UrlService.getUrlFromHref(optHref, callbacks.getStateUrl());
+
+    if (!url) {
+      return;
+    }
+
+    const options = opts || {};
+    const {
+      behaviorElement,
+      showIndicatorIds,
+      hideIndicatorIds,
+      once,
+      onEnd,
+    } = options;
+
+    const showIndicatorIdList = showIndicatorIds
+      ? Xml.splitAttributeList(showIndicatorIds)
+      : [];
+    const hideIndicatorIdList = hideIndicatorIds
+      ? Xml.splitAttributeList(hideIndicatorIds)
+      : [];
+
+    if (once && behaviorElement) {
+      if (behaviorElement.getAttribute('ran-once')) {
+        // This action is only supposed to run once, and it already ran,
+        // so there's nothing more to do.
+        if (typeof onEnd === 'function') {
+          onEnd();
+        }
+        return;
+      }
+      Behaviors.setRanOnce(behaviorElement);
+    }
+
+    let newRoot = callbacks.getDoc();
+    if (showIndicatorIdList || hideIndicatorIdList) {
+      newRoot = Behaviors.setIndicatorsBeforeLoad(
+        showIndicatorIdList,
+        hideIndicatorIdList,
+        newRoot,
+      );
+    }
+
+    // Re-render the modifications
+    callbacks.setNeedsLoad();
+    callbacks.setState({
+      doc: newRoot,
+      elementError: null,
+      error: null,
+      url,
+    });
+  };
+
+  /**
+   * Fetches the provided reference.
+   * - If the references is an id reference (starting with #),
+   *   returns a clone of that element.
+   * - If the reference is a full URL, fetches the URL.
+   * - If the reference is a path, fetches the path from the host of the URL
+   *   used to render the screen.
+   * Returns a promise that resolves to a DOM element.
+   */
+  fetchElement = async (
+    href: DOMString | null | undefined,
+    method: DOMString | null | undefined = Dom.HTTP_METHODS.GET,
+    root: Document,
+    formData: FormData | null | undefined,
+    callbacks: OnUpdateCallbacks,
+  ) => {
+    if (!href) {
+      throw new Error('No href passed to fetchElement');
+    }
+
+    if (href[0] === '#') {
+      const element = root.getElementById(href.slice(1));
+      if (element) {
+        return element.cloneNode(true);
+      }
+      throw new Error(`Element with id ${href} not found in document`);
+    }
+
+    try {
+      const url = UrlService.getUrlFromHref(href, callbacks.getStateUrl());
+      const httpMethod: Dom.HttpMethod = method as Dom.HttpMethod;
+      const { doc, staleHeaderType } = await this.parser.loadElement(
+        url,
+        formData || null,
+        httpMethod,
+      );
+      if (staleHeaderType) {
+        // We are doing this to ensure that we keep the screen stale until a `reload` happens
+        callbacks.setState({ staleHeaderType });
+      }
+      callbacks.clearElementError();
+      return doc.documentElement;
+    } catch (err: Error | unknown) {
+      if (this.props.onError) {
+        this.props.onError(err as Error);
+      }
+      callbacks.setState({ elementError: err });
+    }
+    return null;
+  };
+
+  onUpdate = (
+    href: DOMString | null | undefined,
+    action: DOMString | null | undefined,
+    element: Element,
+    options: HvComponentOptions,
+    callbacks: OnUpdateCallbacks,
+  ) => {
+    const navAction: NavAction = action as NavAction;
+    const updateAction: UpdateAction = action as UpdateAction;
+
+    if (action === ACTIONS.RELOAD) {
+      this.reload(href, options, callbacks);
+    } else if (action === ACTIONS.DEEP_LINK && href) {
+      Linking.openURL(href);
+    } else if (navAction && Object.values(NAV_ACTIONS).includes(navAction)) {
+      const navigation = callbacks.getNavigation();
+      if (navigation) {
+        const { behaviorElement, delay, newElement, targetId } = options;
+        const delayVal: number = +(delay || '');
+        navigation.setUrl(callbacks.getStateUrl());
+        navigation.setDocument(callbacks.getDoc());
+        navigation.navigate(
+          href || Navigation.ANCHOR_ID_SEPARATOR,
+          navAction,
+          element,
+          this.formComponentRegistry,
+          {
+            behaviorElement: behaviorElement || undefined,
+            delay: delayVal,
+            newElement: newElement || undefined,
+            targetId: targetId || undefined,
+          },
+          callbacks.registerPreload,
+        );
+      }
+    } else if (
+      updateAction &&
+      Object.values(UPDATE_ACTIONS).includes(updateAction)
+    ) {
+      this.onUpdateFragment(href, updateAction, element, options, callbacks);
+    } else if (action === ACTIONS.SWAP) {
+      this.onSwap(element, options.newElement, callbacks);
+    } else if (action === ACTIONS.DISPATCH_EVENT) {
+      const { behaviorElement } = options;
+      if (!behaviorElement) {
+        console.warn('dispatch-event requires a behaviorElement');
+        return;
+      }
+      const eventName = behaviorElement.getAttribute('event-name');
+      const trigger = behaviorElement.getAttribute('trigger');
+      const delay = behaviorElement.getAttribute('delay');
+
+      if (Behaviors.isOncePreviouslyApplied(behaviorElement)) {
+        return;
+      }
+
+      Behaviors.setRanOnce(behaviorElement);
+
+      // Check for event loop formation
+      if (trigger === 'on-event') {
+        throw new Error(
+          'trigger="on-event" and action="dispatch-event" cannot be used on the same element',
+        );
+      }
+      if (!eventName) {
+        throw new Error(
+          'dispatch-event requires an event-name attribute to be present',
+        );
+      }
+
+      const dispatch = () => {
+        Events.dispatch(eventName);
+      };
+
+      if (delay) {
+        setTimeout(dispatch, parseInt(delay, 10));
+      } else {
+        dispatch();
+      }
+    } else {
+      const { behaviorElement } = options;
+      this.onCustomUpdate(behaviorElement, callbacks);
+    }
+  };
+
+  /**
+   * Handler for behaviors on the screen.
+   * @param href {string} A reference to the XML to fetch. Can be local (via id reference prepended
+   *        by #) or a
+   * remote resource.
+   * @param action {string} The name of the action to perform with the returned XML.
+   * @param element {Element} The XML DOM element triggering the behavior.
+   * @param options {Object} Optional attributes:
+   *  - verb: The HTTP method to use for the request
+   *  - targetId: An id reference of the element to apply the action to. Defaults to currentElement
+   *    if not provided.
+   *  - showIndicatorIds: Space-separated list of id references to show during the fetch.
+   *  - hideIndicatorIds: Space-separated list of id references to hide during the fetch.
+   *  - delay: Minimum time to wait to fetch the resource. Indicators will be shown/hidden during
+   *    this time.
+   *  - once: If true, the action should only trigger once. If already triggered, onUpdate will be
+   *    a no-op.
+   *  - onEnd: Callback to run when the resource is fetched.
+   *  - behaviorElement: The behavior element triggering the behavior. Can be different from
+   *    the currentElement.
+   */
+  onUpdateFragment = (
+    href: DOMString | null | undefined,
+    action: UpdateAction,
+    element: Element,
+    options: HvComponentOptions,
+    callbacks: OnUpdateCallbacks,
+  ) => {
+    const opts = options || {};
+    const {
+      behaviorElement,
+      verb,
+      targetId,
+      showIndicatorIds,
+      hideIndicatorIds,
+      delay,
+      once,
+      onEnd,
+    } = opts;
+
+    const showIndicatorIdList = showIndicatorIds
+      ? Xml.splitAttributeList(showIndicatorIds)
+      : [];
+    const hideIndicatorIdList = hideIndicatorIds
+      ? Xml.splitAttributeList(hideIndicatorIds)
+      : [];
+
+    const formData = Services.getFormData(element, this.formComponentRegistry);
+
+    if (once && behaviorElement) {
+      if (behaviorElement.getAttribute('ran-once')) {
+        // This action is only supposed to run once, and it already ran,
+        // so there's nothing more to do.
+        if (typeof onEnd === 'function') {
+          onEnd();
+        }
+        return;
+      }
+      Behaviors.setRanOnce(behaviorElement);
+    }
+
+    let newRoot: Document = callbacks.getDoc();
+    newRoot = Behaviors.setIndicatorsBeforeLoad(
+      showIndicatorIdList,
+      hideIndicatorIdList,
+      newRoot,
+    );
+    // Re-render the modifications
+    callbacks.setState({
+      doc: newRoot,
+    });
+
+    // Fetch the resource, then perform the action on the target and undo indicators.
+    const fetchAndUpdate = () =>
+      this.fetchElement(href, verb, newRoot, formData, callbacks).then(
+        newElement => {
+          // If a target is specified and exists, use it. Otherwise, the action target defaults
+          // to the element triggering the action.
+          let targetElement = targetId
+            ? callbacks.getDoc()?.getElementById(targetId)
+            : element;
+          if (!targetElement) {
+            targetElement = element;
+          }
+
+          if (newElement) {
+            newRoot = Behaviors.performUpdate(
+              action,
+              targetElement,
+              newElement as Element,
+            );
+          } else {
+            // When fetch fails, make sure to get the latest version of
+            // the doc to avoid any race conditions
+            newRoot = callbacks.getDoc();
+          }
+          newRoot = Behaviors.setIndicatorsAfterLoad(
+            showIndicatorIdList,
+            hideIndicatorIdList,
+            newRoot,
+          );
+          // Re-render the modifications
+          callbacks.setState({
+            doc: newRoot,
+          });
+
+          if (typeof onEnd === 'function') {
+            onEnd();
+          }
+        },
+      );
+
+    if (delay) {
+      /**
+       * Delayed behaviors will only trigger after a given amount of time.
+       * During that time, the DOM may change and the triggering element may no longer
+       * be in the document. When that happens, we don't want to trigger the behavior after the time
+       * elapses. To track this, we store the timeout id (generated by setTimeout) on the triggering
+       * element, and then look it up in the document after the elapsed time.
+       * If the timeout id is not present, we update the indicators but don't execute the behavior.
+       */
+      const delayMs = parseInt(delay, 10);
+      const timeoutId = setTimeout(() => {
+        // Check the current doc for an element with the same timeout ID
+        const timeoutElement = Services.getElementByTimeoutId(
+          callbacks.getDoc(),
+          timeoutId.toString(),
+        );
+        if (timeoutElement) {
+          // Element with the same ID exists, we can execute the behavior
+          Services.removeTimeoutId(timeoutElement);
+          fetchAndUpdate();
+        } else {
+          // Element with the same ID does not exist,
+          // we don't execute the behavior and undo the indicators.
+          newRoot = Behaviors.setIndicatorsAfterLoad(
+            showIndicatorIdList,
+            hideIndicatorIdList,
+            callbacks.getDoc(),
+          );
+          callbacks.setState({
+            doc: newRoot,
+          });
+          if (typeof onEnd === 'function') {
+            onEnd();
+          }
+        }
+      }, delayMs);
+      // Store the timeout ID
+      Services.setTimeoutId(element, timeoutId.toString());
+    } else {
+      // If there's no delay, fetch immediately and update the doc when done.
+      fetchAndUpdate();
+    }
+  };
+
+  /**
+   * Used internally to update the state of things like select forms.
+   */
+  onSwap = (
+    currentElement: Element,
+    newElement: Element | null | undefined,
+    callbacks: OnUpdateCallbacks,
+  ) => {
+    const parentElement = currentElement.parentNode as Element;
+    if (!parentElement || !newElement) {
+      return;
+    }
+    parentElement.replaceChild(newElement, currentElement);
+    const newRoot = Services.shallowCloneToRoot(parentElement);
+    callbacks.setState({
+      doc: newRoot,
+    });
+  };
+
+  /**
+   * Extensions for custom behaviors.
+   */
+  onCustomUpdate = (
+    behaviorElement: Element | null | undefined,
+    callbacks: OnUpdateCallbacks,
+  ) => {
+    if (!behaviorElement) {
+      console.warn('Custom behavior requires a behaviorElement');
+      return;
+    }
+    const action = behaviorElement.getAttribute('action');
+    if (!action) {
+      console.warn('Custom behavior requires an action attribute');
+      return;
+    }
+    const behavior = this.behaviorRegistry[action];
+
+    if (Behaviors.isOncePreviouslyApplied(behaviorElement)) {
+      return;
+    }
+
+    Behaviors.setRanOnce(behaviorElement);
+
+    if (behavior) {
+      const updateRoot = (newRoot: Document, updateStylesheet = false) => {
+        return updateStylesheet
+          ? callbacks.setState({
+              doc: newRoot,
+              styles: Stylesheets.createStylesheets(newRoot),
+            })
+          : callbacks.setState({ doc: newRoot });
+      };
+      const getRoot = () => callbacks.getDoc();
+      behavior.callback(
+        behaviorElement,
+        callbacks.getOnUpdate(),
+        getRoot,
+        updateRoot,
+      );
+    } else {
+      // No behavior detected.
+      console.warn(`No behavior registered for action "${action}"`);
+    }
+  };
 
   render() {
     if (this.props.navigation) {

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -525,6 +525,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
             onError={this.props.onError}
             onParseAfter={this.props.onParseAfter}
             onParseBefore={this.props.onParseBefore}
+            onUpdate={this.onUpdate}
             openModal={this.props.openModal}
             push={this.props.push}
             refreshControl={this.props.refreshControl}
@@ -553,6 +554,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
               onError: this.props.onError,
               onParseAfter: this.props.onParseAfter,
               onParseBefore: this.props.onParseBefore,
+              onUpdate: this.onUpdate,
             }}
           >
             <HvRoute />

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -188,7 +188,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
       if (this.props.onError) {
         this.props.onError(err as Error);
       }
-      callbacks.setState({ elementError: err });
+      callbacks.setState({ elementError: err as Error });
     }
     return null;
   };

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -270,6 +270,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
             onError={this.props.onError}
             onParseAfter={this.props.onParseAfter}
             onParseBefore={this.props.onParseBefore}
+            onUpdate={this.props.onUpdate}
             openModal={this.navLogic.openModal}
             push={this.navLogic.push}
             registerPreload={this.registerPreload}

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -8,7 +8,12 @@
 
 import * as NavigatorService from 'hyperview/src/services/navigator';
 import { ComponentType, ReactNode } from 'react';
-import { Fetch, HvBehavior, HvComponent } from 'hyperview/src/types';
+import {
+  Fetch,
+  HvBehavior,
+  HvComponent,
+  RootOnUpdate,
+} from 'hyperview/src/types';
 import type { Props as ErrorProps } from 'hyperview/src/core/components/load-error';
 import type { Props as LoadingProps } from 'hyperview/src/core/components/loading';
 
@@ -27,6 +32,7 @@ export type NavigationContextProps = {
   fetch: Fetch;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
+  onUpdate: RootOnUpdate;
   url?: string;
   behaviors?: HvBehavior[];
   components?: HvComponent[];
@@ -63,6 +69,7 @@ export type InnerRouteProps = {
   onError?: (error: Error) => void;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
+  onUpdate: RootOnUpdate;
   behaviors?: HvBehavior[];
   components?: HvComponent[];
   elementErrorComponent?: ComponentType<ErrorProps>;

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -12,7 +12,7 @@ import {
   Fetch,
   HvBehavior,
   HvComponent,
-  RootOnUpdate,
+  HvComponentOnUpdate,
 } from 'hyperview/src/types';
 import type { Props as ErrorProps } from 'hyperview/src/core/components/load-error';
 import type { Props as LoadingProps } from 'hyperview/src/core/components/loading';
@@ -32,7 +32,7 @@ export type NavigationContextProps = {
   fetch: Fetch;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
-  onUpdate: RootOnUpdate;
+  onUpdate: HvComponentOnUpdate;
   url?: string;
   behaviors?: HvBehavior[];
   components?: HvComponent[];
@@ -69,7 +69,7 @@ export type InnerRouteProps = {
   onError?: (error: Error) => void;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
-  onUpdate: RootOnUpdate;
+  onUpdate: HvComponentOnUpdate;
   behaviors?: HvBehavior[];
   components?: HvComponent[];
   elementErrorComponent?: ComponentType<ErrorProps>;

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -295,23 +295,25 @@ export default class HvScreen extends React.Component {
    *
    */
   onUpdate = (href, action, currentElement, opts) => {
-    this.props.onUpdate(href, action, currentElement, opts, {
-      clearElementError: () => {
-        if (this.state.elementError) {
-          this.setState({ elementError: null });
-        }
-      },
-      getDoc: () => this.doc,
-      getNavigation: () => this.navigation,
-      getOnUpdate: () => this.onUpdate,
-      getState: () => this.state,
-      registerPreload: (id, element)=>this.registerPreload(id, element),
-      setNeedsLoad: () => {
-        this.needsLoad = true
-      },
-      setState: (state) => {
-        this.setState(state)
-      },
+    this.props.onUpdate(href, action, currentElement, {...opts,
+      onUpdateCallbacks: {
+        clearElementError: () => {
+          if (this.state.elementError) {
+            this.setState({ elementError: null });
+          }
+        },
+        getDoc: () => this.doc,
+        getNavigation: () => this.navigation,
+        getOnUpdate: () => this.onUpdate,
+        getState: () => this.state,
+        registerPreload: (id, element)=>this.registerPreload(id, element),
+        setNeedsLoad: () => {
+          this.needsLoad = true
+        },
+        setState: (state) => {
+          this.setState(state)
+        },
+      }
     });
   }
 }

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -272,7 +272,7 @@ export default class HvScreen extends React.Component {
         }
         return;
       }
-      behaviorElement.setAttribute('ran-once', 'true');
+      Behaviors.setRanOnce(behaviorElement);
     }
 
     let newRoot = this.doc;
@@ -330,22 +330,6 @@ export default class HvScreen extends React.Component {
         </Contexts.DateFormatContext.Provider>
       </Contexts.DocContext.Provider>
     );
-  }
-
-  /**
-   * Checks if `once` is previously applied.
-   */
-  isOncePreviouslyApplied = (behaviorElement) => {
-    const once = behaviorElement.getAttribute('once');
-    const ranOnce = behaviorElement.getAttribute('ran-once');
-    if (once === 'true' && ranOnce === 'true') {
-        return true;
-    }
-    return false;
-  }
-
-  setRanOnce = (behaviorElement) => {
-    behaviorElement.setAttribute('ran-once', 'true');
   }
 
   /**
@@ -426,11 +410,11 @@ export default class HvScreen extends React.Component {
       const trigger = behaviorElement.getAttribute('trigger');
       const delay = behaviorElement.getAttribute('delay');
 
-      if (this.isOncePreviouslyApplied(behaviorElement)) {
+      if (Behaviors.isOncePreviouslyApplied(behaviorElement)) {
         return;
       }
 
-      this.setRanOnce(behaviorElement);
+      Behaviors.setRanOnce(behaviorElement);
 
       // Check for event loop formation
       if (trigger === 'on-event') {
@@ -496,7 +480,7 @@ export default class HvScreen extends React.Component {
         }
         return;
       }
-      behaviorElement.setAttribute('ran-once', 'true');
+      Behaviors.setRanOnce(behaviorElement);
 
     }
 
@@ -590,11 +574,11 @@ export default class HvScreen extends React.Component {
     const action = behaviorElement.getAttribute('action');
     const behavior = this.behaviorRegistry[action];
 
-    if (this.isOncePreviouslyApplied(behaviorElement)) {
+    if (Behaviors.isOncePreviouslyApplied(behaviorElement)) {
       return;
     }
 
-    this.setRanOnce(behaviorElement);
+    Behaviors.setRanOnce(behaviorElement);
 
     if (behavior) {
       const updateRoot = (newRoot, updateStylesheet = false) => updateStylesheet

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -304,8 +304,7 @@ export default class HvScreen extends React.Component {
       getDoc: () => this.doc,
       getNavigation: () => this.navigation,
       getOnUpdate: () => this.onUpdate,
-      getStateDoc: () => this.state.doc,
-      getStateUrl: () => this.state.url,
+      getState: () => this.state,
       registerPreload: (id, element)=>this.registerPreload(id, element),
       setNeedsLoad: () => {
         this.needsLoad = true

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -15,16 +15,12 @@ import * as Events from 'hyperview/src/services/events';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
 import * as Stylesheets from 'hyperview/src/services/stylesheets';
-import * as UrlService from 'hyperview/src/services/url';
-import * as Xml from 'hyperview/src/services/xml';
-import { ACTIONS, NAV_ACTIONS, UPDATE_ACTIONS } from 'hyperview/src/types';
-// eslint-disable-next-line instawork/import-services
-import Navigation, { ANCHOR_ID_SEPARATOR } from 'hyperview/src/services/navigation';
-import { createProps, createStyleProp, getElementByTimeoutId, getFormData, later, removeTimeoutId, setTimeoutId, shallowCloneToRoot } from 'hyperview/src/services';
-import { Linking } from 'react-native';
+import { createProps, createStyleProp, later } from 'hyperview/src/services';
 import LoadElementError from '../load-element-error';
 import LoadError from 'hyperview/src/core/components/load-error';
 import Loading from 'hyperview/src/core/components/loading';
+// eslint-disable-next-line instawork/import-services
+import Navigation from 'hyperview/src/services/navigation';
 import React from 'react';
 
 // eslint-disable-next-line instawork/pure-components
@@ -41,7 +37,6 @@ export default class HvScreen extends React.Component {
     super(props);
 
     this.onUpdate = this.onUpdate.bind(this);
-    this.reload = this.reload.bind(this);
 
     this.updateActions = ['replace', 'replace-inner', 'append', 'prepend'];
     this.parser = new Dom.Parser(
@@ -237,60 +232,6 @@ export default class HvScreen extends React.Component {
   }
 
   /**
-   * Reload if an error occured.
-   * @param opt_href: Optional string href to use when reloading the screen. If not provided,
-   * the screen's current URL will be used.
-   */
-  reload = (optHref, opts) => {
-    const isBlankHref =
-      optHref === null ||
-      optHref === undefined ||
-      optHref === '#' ||
-      optHref === '';
-    const url = isBlankHref
-      ? this.state.url // eslint-disable-line react/no-access-state-in-setstate
-      : UrlService.getUrlFromHref(optHref, this.state.url); // eslint-disable-line react/no-access-state-in-setstate
-
-    if (!url) {
-      return;
-    }
-
-    const options = opts || {};
-    const {
-      behaviorElement, showIndicatorIds, hideIndicatorIds, once, onEnd,
-    } = options;
-
-    const showIndicatorIdList = showIndicatorIds ? Xml.splitAttributeList(showIndicatorIds) : [];
-    const hideIndicatorIdList = hideIndicatorIds ? Xml.splitAttributeList(hideIndicatorIds) : [];
-
-    if (once) {
-      if (behaviorElement.getAttribute('ran-once')) {
-        // This action is only supposed to run once, and it already ran,
-        // so there's nothing more to do.
-        if (typeof onEnd === 'function') {
-          onEnd();
-        }
-        return;
-      }
-      Behaviors.setRanOnce(behaviorElement);
-    }
-
-    let newRoot = this.doc;
-    if (showIndicatorIdList || hideIndicatorIdList){
-      newRoot = Behaviors.setIndicatorsBeforeLoad(showIndicatorIdList, hideIndicatorIdList, newRoot);
-    }
-
-    // Re-render the modifications
-    this.needsLoad = true;
-    this.setState({
-      doc: newRoot,
-      elementError: null,
-      error: null,
-      url,
-    });
-  }
-
-  /**
    * Renders the XML doc into React components. Shows blank screen until the XML doc is available.
    */
   render() {
@@ -344,44 +285,6 @@ export default class HvScreen extends React.Component {
     push: this.props.push,
   })
 
-  /**
-   * Fetches the provided reference.
-   * - If the references is an id reference (starting with #),
-   *   returns a clone of that element.
-   * - If the reference is a full URL, fetches the URL.
-   * - If the reference is a path, fetches the path from the host of the URL
-   *   used to render the screen.
-   * Returns a promise that resolves to a DOM element.
-   */
-  fetchElement = async (href, method, root, formData) => {
-    if (href[0] === '#') {
-      const element = root.getElementById(href.slice(1));
-      if (element) {
-        return element.cloneNode(true);
-      }
-      throw new Error(`Element with id ${href} not found in document`);
-    }
-
-    try {
-      const url = UrlService.getUrlFromHref(href, this.state.url, method);
-      const { doc, staleHeaderType } = await this.parser.loadElement(url, formData, method);
-      if (staleHeaderType) {
-        // We are doing this to ensure that we keep the screen stale until a `reload` happens
-        this.setState({ staleHeaderType });
-      }
-      if (this.state.elementError) {
-        this.setState({ elementError: null });
-      }
-      return doc.documentElement;
-    } catch (err) {
-      if (this.props.onError) {
-        this.props.onError(err);
-      }
-      this.setState({ elementError: err });
-    }
-    return null;
-  }
-
   registerPreload = (id, element) => {
     if (this.props.registerPreload){
       this.props.registerPreload(id, element);
@@ -392,204 +295,26 @@ export default class HvScreen extends React.Component {
    *
    */
   onUpdate = (href, action, currentElement, opts) => {
-    if (action === ACTIONS.RELOAD) {
-      this.reload(href, opts);
-    } else if (action === ACTIONS.DEEP_LINK) {
-      Linking.openURL(href);
-    } else if (Object.values(NAV_ACTIONS).includes(action)) {
-      this.navigation.setUrl(this.state.url);
-      this.navigation.setDocument(this.doc);
-      this.navigation.navigate(href || ANCHOR_ID_SEPARATOR, action, currentElement, this.formComponentRegistry, opts, this.registerPreload);
-    } else if (Object.values(UPDATE_ACTIONS).includes(action)) {
-      this.onUpdateFragment(href, action, currentElement, opts);
-    } else if (action === ACTIONS.SWAP) {
-      this.onSwap(currentElement, opts.newElement);
-    } else if (action === ACTIONS.DISPATCH_EVENT) {
-      const { behaviorElement } = opts;
-      const eventName = behaviorElement.getAttribute('event-name');
-      const trigger = behaviorElement.getAttribute('trigger');
-      const delay = behaviorElement.getAttribute('delay');
-
-      if (Behaviors.isOncePreviouslyApplied(behaviorElement)) {
-        return;
-      }
-
-      Behaviors.setRanOnce(behaviorElement);
-
-      // Check for event loop formation
-      if (trigger === 'on-event') {
-        throw new Error('trigger="on-event" and action="dispatch-event" cannot be used on the same element');
-      }
-      if (!eventName) {
-        throw new Error('dispatch-event requires an event-name attribute to be present');
-      }
-
-      const dispatch = () => {
-        Events.dispatch(eventName);
-      }
-
-      if (delay) {
-        setTimeout(dispatch, parseInt(delay, 10));
-      } else {
-        dispatch();
-      }
-    } else {
-      const { behaviorElement } = opts;
-      this.onCustomUpdate(behaviorElement);
-    }
-  }
-
-  /**
-   * Handler for behaviors on the screen.
-   * @param href {string} A reference to the XML to fetch. Can be local (via id reference prepended
-   *        by #) or a
-   * remote resource.
-   * @param action {string} The name of the action to perform with the returned XML.
-   * @param currentElement {Element} The XML DOM element triggering the behavior.
-   * @param options {Object} Optional attributes:
-   *  - verb: The HTTP method to use for the request
-   *  - targetId: An id reference of the element to apply the action to. Defaults to currentElement
-   *    if not provided.
-   *  - showIndicatorIds: Space-separated list of id references to show during the fetch.
-   *  - hideIndicatorIds: Space-separated list of id references to hide during the fetch.
-   *  - delay: Minimum time to wait to fetch the resource. Indicators will be shown/hidden during
-   *    this time.
-   *  - once: If true, the action should only trigger once. If already triggered, onUpdate will be
-   *    a no-op.
-   *  - onEnd: Callback to run when the resource is fetched.
-   *  - behaviorElement: The behavior element triggering the behavior. Can be different from
-   *    the currentElement.
-   */
-  onUpdateFragment = (href, action, currentElement, opts) => {
-    const options = opts || {};
-    const {
-      behaviorElement, verb, targetId, showIndicatorIds, hideIndicatorIds, delay, once, onEnd,
-    } = options;
-
-    const showIndicatorIdList = showIndicatorIds ? Xml.splitAttributeList(showIndicatorIds) : [];
-    const hideIndicatorIdList = hideIndicatorIds ? Xml.splitAttributeList(hideIndicatorIds) : [];
-
-    const formData = getFormData(currentElement, this.formComponentRegistry);
-
-    if (once) {
-      if (behaviorElement.getAttribute('ran-once')) {
-        // This action is only supposed to run once, and it already ran,
-        // so there's nothing more to do.
-        if (typeof onEnd === 'function') {
-          onEnd();
+    this.props.onUpdate(href, action, currentElement, opts, {
+      clearElementError: () => {
+        if (this.state.elementError) {
+          this.setState({ elementError: null });
         }
-        return;
-      }
-      Behaviors.setRanOnce(behaviorElement);
-
-    }
-
-    let newRoot = this.doc;
-    newRoot = Behaviors.setIndicatorsBeforeLoad(showIndicatorIdList, hideIndicatorIdList, newRoot);
-    // Re-render the modifications
-    this.setState({
-      doc: newRoot,
+      },
+      getDoc: () => this.doc,
+      getNavigation: () => this.navigation,
+      getOnUpdate: () => this.onUpdate,
+      getStateDoc: () => this.state.doc,
+      getStateUrl: () => this.state.url,
+      registerPreload: (id, element)=>this.registerPreload(id, element),
+      setNeedsLoad: () => {
+        this.needsLoad = true
+      },
+      // eslint-disable-next-line flowtype/no-types-missing-file-annotation
+      setState: (state: object) => {
+        this.setState(state)
+      },
     });
-
-    // Fetch the resource, then perform the action on the target and undo indicators.
-    const fetchAndUpdate = () => this.fetchElement(href, verb, newRoot, formData)
-      .then((newElement) => {
-        // If a target is specified and exists, use it. Otherwise, the action target defaults
-        // to the element triggering the action.
-        let targetElement = targetId ? this.doc?.getElementById(targetId) : currentElement;
-        if (!targetElement) {
-          targetElement = currentElement;
-        }
-
-        if (newElement) {
-          newRoot = Behaviors.performUpdate(action, targetElement, newElement);
-        } else {
-          // When fetch fails, make sure to get the latest version of the doc to avoid any race conditions
-          newRoot = this.doc;
-        }
-        newRoot = Behaviors.setIndicatorsAfterLoad(showIndicatorIdList, hideIndicatorIdList, newRoot);
-        // Re-render the modifications
-        this.setState({
-          doc: newRoot,
-        });
-
-        if (typeof onEnd === 'function') {
-          onEnd();
-        }
-      });
-
-    if (delay) {
-      /**
-       * Delayed behaviors will only trigger after a given amount of time.
-       * During that time, the DOM may change and the triggering element may no longer
-       * be in the document. When that happens, we don't want to trigger the behavior after the time
-       * elapses. To track this, we store the timeout id (generated by setTimeout) on the triggering
-       * element, and then look it up in the document after the elapsed time. If the timeout id is not
-       * present, we update the indicators but don't execute the behavior.
-       */
-      const delayMs = parseInt(delay, 10);
-      let timeoutId = null;
-      timeoutId = setTimeout(() => {
-        // Check the current doc for an element with the same timeout ID
-        const timeoutElement = getElementByTimeoutId(this.doc, timeoutId.toString());
-        if (timeoutElement) {
-          // Element with the same ID exists, we can execute the behavior
-          removeTimeoutId(timeoutElement);
-          fetchAndUpdate();
-        } else {
-          // Element with the same ID does not exist, we don't execute the behavior and undo the indicators.
-          newRoot = Behaviors.setIndicatorsAfterLoad(showIndicatorIdList, hideIndicatorIdList, this.doc);
-          this.setState({
-            doc: newRoot,
-          });
-          if (typeof onEnd === 'function') {
-            onEnd();
-          }
-        }
-      }, delayMs);
-      // Store the timeout ID
-      setTimeoutId(currentElement, timeoutId.toString());
-    } else {
-      // If there's no delay, fetch immediately and update the doc when done.
-      fetchAndUpdate();
-    }
-  }
-
-  /**
-   * Used internally to update the state of things like select forms.
-   */
-  onSwap = (currentElement, newElement) => {
-    const parentElement = currentElement.parentNode;
-    parentElement.replaceChild(newElement, currentElement);
-    const newRoot = shallowCloneToRoot(parentElement);
-    this.setState({
-      doc: newRoot,
-    });
-  }
-
-  /**
-   * Extensions for custom behaviors.
-   */
-  onCustomUpdate = (behaviorElement) => {
-    const action = behaviorElement.getAttribute('action');
-    const behavior = this.behaviorRegistry[action];
-
-    if (Behaviors.isOncePreviouslyApplied(behaviorElement)) {
-      return;
-    }
-
-    Behaviors.setRanOnce(behaviorElement);
-
-    if (behavior) {
-      const updateRoot = (newRoot, updateStylesheet = false) => updateStylesheet
-        ? this.setState({ doc: newRoot, styles: Stylesheets.createStylesheets(newRoot) })
-        : this.setState({ doc: newRoot });
-      const getRoot = () => this.doc;
-      behavior.callback(behaviorElement, this.onUpdate, getRoot, updateRoot);
-    } else {
-      // No behavior detected.
-      console.warn(`No behavior registered for action "${action}"`);
-    }
   }
 }
 

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -310,8 +310,7 @@ export default class HvScreen extends React.Component {
       setNeedsLoad: () => {
         this.needsLoad = true
       },
-      // eslint-disable-next-line flowtype/no-types-missing-file-annotation
-      setState: (state: object) => {
+      setState: (state) => {
         this.setState(state)
       },
     });

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -31,7 +31,7 @@ export type Props = {
   onError?: (error: Error) => void;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
-  onUpdate: Types.RootOnUpdate;
+  onUpdate: Types.HvComponentOnUpdate;
   url?: string;
   back?: (
     params: TypesLegacy.NavigationRouteParams | object | undefined,

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -31,6 +31,7 @@ export type Props = {
   onError?: (error: Error) => void;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
+  onUpdate: Types.RootOnUpdate;
   url?: string;
   back?: (
     params: TypesLegacy.NavigationRouteParams | object | undefined,

--- a/src/services/behaviors/index.ts
+++ b/src/services/behaviors/index.ts
@@ -231,7 +231,7 @@ export const setRanOnce = (behaviorElement: Element) => {
 /**
  * Checks if `once` is previously applied.
  */
-export const isOncePreviouslyApplied = (behaviorElement: Element) => {
+export const isOncePreviouslyApplied = (behaviorElement: Element): boolean => {
   const once = behaviorElement.getAttribute('once');
   const ranOnce = behaviorElement.getAttribute('ran-once');
   return once === 'true' && ranOnce === 'true';

--- a/src/services/behaviors/index.ts
+++ b/src/services/behaviors/index.ts
@@ -220,3 +220,22 @@ export const createActionHandler = (
   return (element: Element) =>
     onUpdate(null, action, element, { behaviorElement, custom: true });
 };
+
+/**
+ * Set the `ran-once` attribute to true.
+ */
+export const setRanOnce = (behaviorElement: Element) => {
+  behaviorElement.setAttribute('ran-once', 'true');
+};
+
+/**
+ * Checks if `once` is previously applied.
+ */
+export const isOncePreviouslyApplied = (behaviorElement: Element) => {
+  const once = behaviorElement.getAttribute('once');
+  const ranOnce = behaviorElement.getAttribute('ran-once');
+  if (once === 'true' && ranOnce === 'true') {
+    return true;
+  }
+  return false;
+};

--- a/src/services/behaviors/index.ts
+++ b/src/services/behaviors/index.ts
@@ -234,8 +234,5 @@ export const setRanOnce = (behaviorElement: Element) => {
 export const isOncePreviouslyApplied = (behaviorElement: Element) => {
   const once = behaviorElement.getAttribute('once');
   const ranOnce = behaviorElement.getAttribute('ran-once');
-  if (once === 'true' && ranOnce === 'true') {
-    return true;
-  }
-  return false;
+  return once === 'true' && ranOnce === 'true';
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import * as Stylesheets from './services/stylesheets';
 import Navigation from './services/navigation';
 
 import type React from 'react';
@@ -421,5 +422,14 @@ export type OnUpdateCallbacks = {
   getStateUrl: () => string;
   registerPreload: (id: number, element: Element) => void;
   setNeedsLoad: () => void;
-  setState: (state: object) => void;
+  setState: (state: ScreenState) => void;
+};
+
+export type ScreenState = {
+  doc?: Document | null | undefined;
+  elementError?: Error | null | undefined;
+  error?: Error | null | undefined;
+  staleHeaderType?: 'stale-if-error' | null | undefined;
+  styles?: Stylesheets.StyleSheets | null | undefined;
+  url?: string | null | undefined;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+
+import Navigation from './services/navigation';
+
 import type React from 'react';
 
 import type { XResponseStaleReason } from './services/dom/types';
@@ -400,3 +403,23 @@ export type Fetch = (
   input: RequestInfo | URL,
   init?: RequestInit | undefined,
 ) => Promise<Response>;
+
+export type RootOnUpdate = (
+  href: DOMString | null | undefined,
+  action: DOMString | null | undefined,
+  element: Element,
+  options: HvComponentOptions,
+  callbacks: OnUpdateCallbacks,
+) => void;
+
+export type OnUpdateCallbacks = {
+  clearElementError: () => void;
+  getNavigation: () => Navigation;
+  getOnUpdate: () => HvComponentOnUpdate;
+  getStateDoc: () => Document;
+  getDoc: () => Document;
+  getStateUrl: () => string;
+  registerPreload: (id: number, element: Element) => void;
+  setNeedsLoad: () => void;
+  setState: (state: object) => void;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -369,8 +369,8 @@ export const UPDATE_ACTIONS = {
 export type UpdateAction = typeof UPDATE_ACTIONS[keyof typeof UPDATE_ACTIONS];
 
 export type BehaviorOptions = {
-  newElement: Element;
-  behaviorElement: Element;
+  newElement?: Element;
+  behaviorElement?: Element;
   showIndicatorId?: string;
   delay?: number;
   targetId?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,6 +206,7 @@ export type HvComponentOptions = {
   custom?: boolean;
   newElement?: Element | null | undefined;
   showIndicatorId?: string | null | undefined;
+  onUpdateCallbacks?: OnUpdateCallbacks;
 };
 
 export type HvComponentOnUpdate = (
@@ -404,14 +405,6 @@ export type Fetch = (
   input: RequestInfo | URL,
   init?: RequestInit | undefined,
 ) => Promise<Response>;
-
-export type RootOnUpdate = (
-  href: DOMString | null | undefined,
-  action: DOMString | null | undefined,
-  element: Element,
-  options: HvComponentOptions,
-  callbacks: OnUpdateCallbacks,
-) => void;
 
 export type OnUpdateCallbacks = {
   clearElementError: () => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -417,11 +417,10 @@ export type OnUpdateCallbacks = {
   clearElementError: () => void;
   getNavigation: () => Navigation;
   getOnUpdate: () => HvComponentOnUpdate;
-  getStateDoc: () => Document;
   getDoc: () => Document;
-  getStateUrl: () => string;
   registerPreload: (id: number, element: Element) => void;
   setNeedsLoad: () => void;
+  getState: () => ScreenState;
   setState: (state: ScreenState) => void;
 };
 


### PR DESCRIPTION
Follow the commits for the individual steps taken
- moved the 'once' handling methods into /services/behaviors
- updated `BehaviorOptions` to properly reflect the state of the data
- created new `RootOnUpdate` and `OnUpdateCallbacks` types
- added `onUpdate` to all props which occur from `hv-root` to `hv-screen`
- ported the `onUpdate` method and all of its related methods from `hv-screen` to `hv-root`
  - use the callbacks prop to inject any of the instance-specific callbacks needed for the `onUpdate`
- inject the new `onUpdate` into the props

Asana: https://app.asana.com/0/1204008699308084/1205741965789634/f