### PR TITLE
chore(document): account for possible null doc in state

### DIFF
--- a/src/behaviors/hv-hide/index.ts
+++ b/src/behaviors/hv-hide/index.ts
@@ -36,9 +36,9 @@ export default {
 
     const hideElement = () => {
       const doc: Document | null = getRoot();
-      const targetElement: Element | null | undefined = doc
-        ? doc.getElementById(targetId)
-        : null;
+      const targetElement: Element | null | undefined = doc?.getElementById(
+        targetId,
+      );
       if (!targetElement) {
         return;
       }

--- a/src/behaviors/hv-hide/index.ts
+++ b/src/behaviors/hv-hide/index.ts
@@ -35,10 +35,10 @@ export default {
     );
 
     const hideElement = () => {
-      const doc: Document = getRoot();
-      const targetElement: Element | null | undefined = doc.getElementById(
-        targetId,
-      );
+      const doc: Document | null = getRoot();
+      const targetElement: Element | null | undefined = doc
+        ? doc.getElementById(targetId)
+        : null;
       if (!targetElement) {
         return;
       }
@@ -65,13 +65,16 @@ export default {
       hideElement();
     } else {
       // If there's a delay, first trigger the indicators before the hide
-      const newRoot = Behaviors.setIndicatorsBeforeLoad(
-        showIndicatorIds,
-        hideIndicatorIds,
-        getRoot(),
-      );
-      // Update the DOM to reflect the new state of the indicators.
-      updateRoot(newRoot);
+      const doc: Document | null = getRoot();
+      if (doc) {
+        const newRoot = Behaviors.setIndicatorsBeforeLoad(
+          showIndicatorIds,
+          hideIndicatorIds,
+          doc,
+        );
+        // Update the DOM to reflect the new state of the indicators.
+        updateRoot(newRoot);
+      }
       // Wait for the delay then hide the target.
       later(delay).then(hideElement).catch(hideElement);
     }

--- a/src/behaviors/hv-select-all/index.ts
+++ b/src/behaviors/hv-select-all/index.ts
@@ -38,9 +38,9 @@ export default {
 
     const selectAll = () => {
       const doc: Document | null = getRoot();
-      const targetElement: Element | null | undefined = doc
-        ? doc.getElementById(targetId)
-        : null;
+      const targetElement: Element | null | undefined = doc?.getElementById(
+        targetId,
+      );
       if (!targetElement) {
         return;
       }

--- a/src/behaviors/hv-select-all/index.ts
+++ b/src/behaviors/hv-select-all/index.ts
@@ -37,10 +37,10 @@ export default {
     );
 
     const selectAll = () => {
-      const doc: Document = getRoot();
-      const targetElement: Element | null | undefined = doc.getElementById(
-        targetId,
-      );
+      const doc: Document | null = getRoot();
+      const targetElement: Element | null | undefined = doc
+        ? doc.getElementById(targetId)
+        : null;
       if (!targetElement) {
         return;
       }
@@ -66,13 +66,16 @@ export default {
       selectAll();
     } else {
       // If there's a delay, first trigger the indicators before the select-all.
-      const newRoot = Behaviors.setIndicatorsBeforeLoad(
-        showIndicatorIds,
-        hideIndicatorIds,
-        getRoot(),
-      );
-      // Update the DOM to reflect the new state of the indicators.
-      updateRoot(newRoot);
+      const doc: Document | null = getRoot();
+      if (doc) {
+        const newRoot = Behaviors.setIndicatorsBeforeLoad(
+          showIndicatorIds,
+          hideIndicatorIds,
+          doc,
+        );
+        // Update the DOM to reflect the new state of the indicators.
+        updateRoot(newRoot);
+      }
       // Wait for the delay then select-all the target.
       later(delay).then(selectAll).catch(selectAll);
     }

--- a/src/behaviors/hv-set-value/index.ts
+++ b/src/behaviors/hv-set-value/index.ts
@@ -38,10 +38,10 @@ export default {
     );
 
     const setValue = () => {
-      const doc: Document = getRoot();
-      const targetElement: Element | null | undefined = doc.getElementById(
-        targetId,
-      );
+      const doc: Document | null = getRoot();
+      const targetElement: Element | null | undefined = doc
+        ? doc.getElementById(targetId)
+        : null;
       if (!targetElement) {
         return;
       }
@@ -68,13 +68,16 @@ export default {
       setValue();
     } else {
       // If there's a delay, first trigger the indicators before the show.
-      const newRoot = Behaviors.setIndicatorsBeforeLoad(
-        showIndicatorIds,
-        hideIndicatorIds,
-        getRoot(),
-      );
-      // Update the DOM to reflect the new state of the indicators.
-      updateRoot(newRoot);
+      const doc: Document | null = getRoot();
+      if (doc) {
+        const newRoot = Behaviors.setIndicatorsBeforeLoad(
+          showIndicatorIds,
+          hideIndicatorIds,
+          doc,
+        );
+        // Update the DOM to reflect the new state of the indicators.
+        updateRoot(newRoot);
+      }
       // Wait for the delay then show the target.
       later(delay).then(setValue).catch(setValue);
     }

--- a/src/behaviors/hv-set-value/index.ts
+++ b/src/behaviors/hv-set-value/index.ts
@@ -39,9 +39,9 @@ export default {
 
     const setValue = () => {
       const doc: Document | null = getRoot();
-      const targetElement: Element | null | undefined = doc
-        ? doc.getElementById(targetId)
-        : null;
+      const targetElement: Element | null | undefined = doc?.getElementById(
+        targetId,
+      );
       if (!targetElement) {
         return;
       }

--- a/src/behaviors/hv-show/index.ts
+++ b/src/behaviors/hv-show/index.ts
@@ -36,9 +36,9 @@ export default {
 
     const showElement = () => {
       const doc: Document | null = getRoot();
-      const targetElement: Element | null | undefined = doc
-        ? doc.getElementById(targetId)
-        : null;
+      const targetElement: Element | null | undefined = doc?.getElementById(
+        targetId,
+      );
       if (!targetElement) {
         return;
       }

--- a/src/behaviors/hv-show/index.ts
+++ b/src/behaviors/hv-show/index.ts
@@ -35,10 +35,10 @@ export default {
     );
 
     const showElement = () => {
-      const doc: Document = getRoot();
-      const targetElement: Element | null | undefined = doc.getElementById(
-        targetId,
-      );
+      const doc: Document | null = getRoot();
+      const targetElement: Element | null | undefined = doc
+        ? doc.getElementById(targetId)
+        : null;
       if (!targetElement) {
         return;
       }
@@ -65,13 +65,16 @@ export default {
       showElement();
     } else {
       // If there's a delay, first trigger the indicators before the show.
-      const newRoot = Behaviors.setIndicatorsBeforeLoad(
-        showIndicatorIds,
-        hideIndicatorIds,
-        getRoot(),
-      );
-      // Update the DOM to reflect the new state of the indicators.
-      updateRoot(newRoot);
+      const doc: Document | null = getRoot();
+      if (doc) {
+        const newRoot = Behaviors.setIndicatorsBeforeLoad(
+          showIndicatorIds,
+          hideIndicatorIds,
+          doc,
+        );
+        // Update the DOM to reflect the new state of the indicators.
+        updateRoot(newRoot);
+      }
       // Wait for the delay then show the target.
       later(delay).then(showElement).catch(showElement);
     }

--- a/src/behaviors/hv-toggle/index.ts
+++ b/src/behaviors/hv-toggle/index.ts
@@ -35,10 +35,10 @@ export default {
     );
 
     const toggleElement = () => {
-      const doc: Document = getRoot();
-      const targetElement: Element | null | undefined = doc.getElementById(
-        targetId,
-      );
+      const doc: Document | null = getRoot();
+      const targetElement: Element | null | undefined = doc
+        ? doc.getElementById(targetId)
+        : null;
       if (!targetElement) {
         return;
       }
@@ -68,13 +68,16 @@ export default {
       toggleElement();
     } else {
       // If there's a delay, first trigger the indicators before the toggle.
-      const newRoot = Behaviors.setIndicatorsBeforeLoad(
-        showIndicatorIds,
-        hideIndicatorIds,
-        getRoot(),
-      );
-      // Update the DOM to reflect the new state of the indicators.
-      updateRoot(newRoot);
+      const doc: Document | null = getRoot();
+      if (doc) {
+        const newRoot = Behaviors.setIndicatorsBeforeLoad(
+          showIndicatorIds,
+          hideIndicatorIds,
+          doc,
+        );
+        // Update the DOM to reflect the new state of the indicators.
+        updateRoot(newRoot);
+      }
       // Wait for the delay then toggle the target.
       later(delay).then(toggleElement).catch(toggleElement);
     }

--- a/src/behaviors/hv-toggle/index.ts
+++ b/src/behaviors/hv-toggle/index.ts
@@ -36,9 +36,9 @@ export default {
 
     const toggleElement = () => {
       const doc: Document | null = getRoot();
-      const targetElement: Element | null | undefined = doc
-        ? doc.getElementById(targetId)
-        : null;
+      const targetElement: Element | null | undefined = doc?.getElementById(
+        targetId,
+      );
       if (!targetElement) {
         return;
       }

--- a/src/behaviors/hv-unselect-all/index.ts
+++ b/src/behaviors/hv-unselect-all/index.ts
@@ -37,10 +37,10 @@ export default {
     );
 
     const unselectAll = () => {
-      const doc: Document = getRoot();
-      const targetElement: Element | null | undefined = doc.getElementById(
-        targetId,
-      );
+      const doc: Document | null = getRoot();
+      const targetElement: Element | null | undefined = doc
+        ? doc.getElementById(targetId)
+        : null;
       if (!targetElement) {
         return;
       }
@@ -66,13 +66,16 @@ export default {
       unselectAll();
     } else {
       // If there's a delay, first trigger the indicators before the unselect-all.
-      const newRoot = Behaviors.setIndicatorsBeforeLoad(
-        showIndicatorIds,
-        hideIndicatorIds,
-        getRoot(),
-      );
-      // Update the DOM to reflect the new state of the indicators.
-      updateRoot(newRoot);
+      const doc: Document | null = getRoot();
+      if (doc) {
+        const newRoot = Behaviors.setIndicatorsBeforeLoad(
+          showIndicatorIds,
+          hideIndicatorIds,
+          doc,
+        );
+        // Update the DOM to reflect the new state of the indicators.
+        updateRoot(newRoot);
+      }
       // Wait for the delay then unselect-all the target.
       later(delay).then(unselectAll).catch(unselectAll);
     }

--- a/src/behaviors/hv-unselect-all/index.ts
+++ b/src/behaviors/hv-unselect-all/index.ts
@@ -38,9 +38,9 @@ export default {
 
     const unselectAll = () => {
       const doc: Document | null = getRoot();
-      const targetElement: Element | null | undefined = doc
-        ? doc.getElementById(targetId)
-        : null;
+      const targetElement: Element | null | undefined = doc?.getElementById(
+        targetId,
+      );
       if (!targetElement) {
         return;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -410,7 +410,7 @@ export type OnUpdateCallbacks = {
   clearElementError: () => void;
   getNavigation: () => Navigation;
   getOnUpdate: () => HvComponentOnUpdate;
-  getDoc: () => Document;
+  getDoc: () => Document | null;
   registerPreload: (id: number, element: Element) => void;
   setNeedsLoad: () => void;
   getState: () => ScreenState;
@@ -418,10 +418,10 @@ export type OnUpdateCallbacks = {
 };
 
 export type ScreenState = {
-  doc?: Document | null | undefined;
-  elementError?: Error | null | undefined;
-  error?: Error | null | undefined;
-  staleHeaderType?: 'stale-if-error' | null | undefined;
-  styles?: Stylesheets.StyleSheets | null | undefined;
-  url?: string | null | undefined;
+  doc?: Document | null;
+  elementError?: Error | null;
+  error?: Error | null;
+  staleHeaderType?: XResponseStaleReason | null;
+  styles?: Stylesheets.StyleSheets | null;
+  url?: string | null;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,7 +216,7 @@ export type HvComponentOnUpdate = (
   options: HvComponentOptions,
 ) => void;
 
-export type HvGetRoot = () => Document;
+export type HvGetRoot = () => Document | null;
 
 export type HvUpdateRoot = (root: Document, updateStylesheet?: boolean) => void;
 


### PR DESCRIPTION
Both `hv-screen` and `hv-route` have the potential to have a null `doc` in state. This can happen from a bad load, or from an override document being provided by a parent component.
The code used in `onUpdate` and its related methods were not accounting for the possibility of a null `doc'.

- Updated `ScreenState` to reflect the values of the state as assigned in `hv-screen`
- Updated callback signature to allow `getDoc` to return null
- Updated `hv-root` implementation of `onUpdate` and related to account for null doc
- Updated `HvGetRoot` to account for null doc
- Updated behavior implementations which used `HvGetRoot` to account for null doc

Asana: https://app.asana.com/0/0/1205741965789643/f