### PR TITLE
chore(hvroute): hvroute as an onUpdate provider for navigator

### DIFF
--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -7,7 +7,7 @@
  */
 
 import type { ComponentType } from 'react';
-import type { HvComponentOnUpdate } from '../types';
+import type { HvComponentOnUpdate } from 'hyperview/src/types';
 import React from 'react';
 import type { RefreshControlProps } from 'react-native';
 

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ComponentType } from 'react';
+import type { HvComponentOnUpdate } from '../types';
 import React from 'react';
 import type { RefreshControlProps } from 'react-native';
 
@@ -27,3 +28,8 @@ export const DocContext = React.createContext<{
   getDoc: () => Document | undefined;
   setDoc?: (doc: Document) => void;
 } | null>(null);
+
+export const OnUpdateContext = React.createContext<{
+  onUpdate: HvComponentOnUpdate;
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+}>({ onUpdate: () => {} });

--- a/src/core/components/hv-navigator/types.ts
+++ b/src/core/components/hv-navigator/types.ts
@@ -7,6 +7,7 @@
  */
 
 import { FC } from 'react';
+import type { HvComponentOnUpdate } from 'hyperview/src/types';
 import type { Props as HvRouteProps } from 'hyperview/src/core/components/hv-route';
 
 export type RouteParams = {
@@ -30,6 +31,7 @@ export type NavigatorParams = {
  */
 export type Props = {
   element?: Element;
+  onUpdate: HvComponentOnUpdate;
   params?: RouteParams;
   routeComponent: FC<HvRouteProps>;
 };

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -220,7 +220,10 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
       if (navigation && doc) {
         const { behaviorElement, delay, newElement, targetId } = options;
         const delayVal: number = +(delay || '');
-        navigation.setUrl(options.onUpdateCallbacks.getState().url || '');
+        const state = options.onUpdateCallbacks.getState();
+        if (state.url) {
+          navigation.setUrl(state.url);
+        }
         navigation.setDocument(doc);
         navigation.navigate(
           href || Navigation.ANCHOR_ID_SEPARATOR,

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -217,13 +217,11 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
     } else if (navAction && Object.values(NAV_ACTIONS).includes(navAction)) {
       const navigation = options.onUpdateCallbacks.getNavigation();
       const doc = options.onUpdateCallbacks.getDoc();
-      if (navigation && doc) {
+      const state = options.onUpdateCallbacks.getState();
+      if (navigation && doc && state.url) {
         const { behaviorElement, delay, newElement, targetId } = options;
         const delayVal: number = +(delay || '');
-        const state = options.onUpdateCallbacks.getState();
-        if (state.url) {
-          navigation.setUrl(state.url);
-        }
+        navigation.setUrl(state.url);
         navigation.setDocument(doc);
         navigation.navigate(
           href || Navigation.ANCHOR_ID_SEPARATOR,

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -216,12 +216,6 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
    * Implement the callbacks from this class
    */
   updateCallbacks = (): OnUpdateCallbacks => {
-    if (!this.state.doc || !this.props.navigation) {
-      throw new NavigatorService.HvRouteError(
-        'No document or navigator found for onUpdate',
-      );
-    }
-
     return {
       clearElementError: () => {
         // Noop

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -217,7 +217,9 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
    */
   updateCallbacks = (): OnUpdateCallbacks => {
     if (!this.state.doc || !this.props.navigation) {
-      throw new NavigatorService.HvRouteError('No document found');
+      throw new NavigatorService.HvRouteError(
+        'No document or navigator found for onUpdate',
+      );
     }
 
     return {

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -19,6 +19,9 @@ import * as Stylesheets from 'hyperview/src/services/stylesheets';
 import * as Types from './types';
 import * as TypesLegacy from 'hyperview/src/types';
 import * as UrlService from 'hyperview/src/services/url';
+import {
+  ScreenState,
+} from 'hyperview/src/types';
 import React, { JSXElementConstructor, PureComponent, useContext } from 'react';
 import HvNavigator from 'hyperview/src/core/components/hv-navigator';
 import HvScreen from 'hyperview/src/core/components/hv-screen';
@@ -32,7 +35,7 @@ import Loading from 'hyperview/src/core/components/loading';
  * - Renders the document
  * - Handles errors
  */
-class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
+class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
   parser?: DomService.Parser;
 
   navLogic: NavigatorService.Navigator;
@@ -43,8 +46,8 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
     super(props);
 
     this.state = {
-      doc: undefined,
-      error: undefined,
+      doc: null,
+      error: null,
     };
     this.navLogic = new NavigatorService.Navigator(this.props);
     this.componentRegistry = Components.getRegistry(this.props.components);
@@ -55,10 +58,10 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
    */
   static getDerivedStateFromProps(
     props: Types.InnerRouteProps,
-    state: Types.State,
+    state: ScreenState,
   ) {
     if (props.element) {
-      return { ...state, doc: undefined };
+      return { ...state, doc: null };
     }
     return state;
   }
@@ -95,7 +98,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
   load = async (): Promise<void> => {
     if (!this.parser) {
       this.setState({
-        doc: undefined,
+        doc: null,
         error: new NavigatorService.HvRouteError('No parser or context found'),
       });
       return;
@@ -108,14 +111,17 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
 
       // Set the state with the merged document
       this.setState(state => {
-        const merged = NavigatorService.mergeDocument(doc, state.doc);
+        const merged = NavigatorService.mergeDocument(
+          doc,
+          state.doc || undefined,
+        );
         const root = Helpers.getFirstChildTag(
           merged,
           TypesLegacy.LOCAL_NAME.DOC,
         );
         if (!root) {
           return {
-            doc: undefined,
+            doc: null,
             error: new NavigatorService.HvRouteError('No root element found'),
           };
         }
@@ -129,7 +135,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
         this.props.onError(err as Error);
       }
       this.setState({
-        doc: undefined,
+        doc: null,
         error: err as Error,
       });
     }
@@ -316,7 +322,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, Types.State> {
         return (
           <Contexts.DocContext.Provider
             value={{
-              getDoc: () => this.state.doc,
+              getDoc: () => this.state.doc || undefined,
               setDoc: (doc: Document) => this.setState({ doc }),
             }}
           >

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -47,11 +47,6 @@ export type NavigatorMapContextProps = {
   getPreload: (key: number) => Element | undefined;
 };
 
-export type State = {
-  doc?: Document;
-  error?: Error;
-};
-
 /**
  * The route prop used by react-navigation
  */

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -98,7 +98,7 @@ export class Navigator {
     }
   };
 
-  back = (params: TypesLegacy.NavigationRouteParams | undefined) => {
+  back = (params?: TypesLegacy.NavigationRouteParams | undefined) => {
     this.sendRequest(TypesLegacy.NAV_ACTIONS.BACK, params);
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -389,13 +389,13 @@ export type NavigationRouteParams = {
 };
 
 export type NavigationProps = {
-  back: (routeParams?: NavigationRouteParams | null | undefined) => void;
-  closeModal: (routeParams?: NavigationRouteParams | null | undefined) => void;
+  back: (routeParams?: NavigationRouteParams | undefined) => void;
+  closeModal: (routeParams?: NavigationRouteParams | undefined) => void;
   navigate: (
     routeParams: NavigationRouteParams,
     key?: string | null | undefined,
   ) => void;
-  openModal: (routeParams?: NavigationRouteParams | null | undefined) => void;
+  openModal: (routeParams: NavigationRouteParams) => void;
   push: (routeParams: NavigationRouteParams) => void;
 };
 


### PR DESCRIPTION
Implement `hv-route` as a provider of `onUpdate` to allow navigators to process behaviors

Only routes which own a document are providers, any children which do not own a document will inherit.

Asana: https://app.asana.com/0/1204008699308084/1205741965789637/f