### PR TITLE
fix: deep link urls are not triggering navigation events

### DIFF
--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -8,10 +8,11 @@
 
 import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Dom from 'hyperview/src/services/dom';
+import * as NavigationContext from 'hyperview/src/contexts/navigation';
 import * as NavigatorMapContext from 'hyperview/src/contexts/navigator-map';
 import * as NavigatorService from 'hyperview/src/services/navigator';
 import { BEHAVIOR_ATTRIBUTES, LOCAL_NAME, TRIGGERS } from 'hyperview/src/types';
-import {
+import type {
   ParamTypes,
   Props,
   RouteParams,
@@ -195,7 +196,6 @@ export default class HvNavigator extends PureComponent<Props> {
    */
   buildScreens = (element: Element, type: string): React.ReactNode => {
     const screens: React.ReactElement[] = [];
-
     const elements: Element[] = NavigatorService.getChildElements(element);
 
     // For tab navigators, the screens are appended
@@ -336,13 +336,17 @@ export default class HvNavigator extends PureComponent<Props> {
 
   render() {
     return (
-      <NavigatorMapContext.NavigatorMapProvider>
-        {this.props.params && this.props.params.isModal ? (
-          <this.ModalNavigator />
-        ) : (
-          <this.Navigator />
+      <NavigationContext.Context.Consumer>
+        {() => (
+          <NavigatorMapContext.NavigatorMapProvider>
+            {this.props.params && this.props.params.isModal ? (
+              <this.ModalNavigator />
+            ) : (
+              <this.Navigator />
+            )}
+          </NavigatorMapContext.NavigatorMapProvider>
         )}
-      </NavigatorMapContext.NavigatorMapProvider>
+      </NavigationContext.Context.Consumer>
     );
   }
 }


### PR DESCRIPTION
Deep link requests were not properly triggering navigation events like tab selections. Behaviors continued to work as expected.

Cause:
There was a chunk of code which was calling `useContext` in the hv-navigator for two contexts. The result of these were not being used so [the code was removed](https://github.com/Instawork/hyperview/pull/701/commits/f3e25c0ae8a3f570387c3727bb094a086fa684ae). Without that context, the `useEffect` of the custom navigators doesn't fire.

Adding it back as part of the hierarchy restores the functionality.

In the videos below, the deep link should cause a selection of the "Accounts" tab.

| Before | After |
| -- | -- |
| ![before](https://github.com/Instawork/hyperview/assets/127122858/268e58a2-5beb-4dea-b554-eb5328bd6df9) | ![after](https://github.com/Instawork/hyperview/assets/127122858/25fc969a-77fa-44c5-a766-fa2bf054ade0) |
