### PR TITLE
proposal: preserve fetching order

### DIFF
--- a/examples/case_studies/contacts/index.xml.js
+++ b/examples/case_studies/contacts/index.xml.js
@@ -11,7 +11,9 @@ module.exports = function handler(req, res, next) {
   const { query } = urlParse(req.originalUrl, true);
 
   // no search or next page? pass through to 11ty to render the entire document
-  if (query.search === undefined && !query.page) {
+  // note: we also test for "template" to work mitigate this bug
+  // https://github.com/Instawork/hyperview/issues/735
+  if (query.search === undefined && !query.page && !query.template) {
     next();
     return;
   }

--- a/examples/case_studies/contacts/list.xml.njk
+++ b/examples/case_studies/contacts/list.xml.njk
@@ -37,6 +37,8 @@
         action="replace"
         target="contacts"
         href="?template=list"
+        debounce="200"
+        preserve-order="true"
         show-during-load="loading-indicator"
       />
     </text-field>


### PR DESCRIPTION
This PR introduce a new behavior boolean attribute, `preserve-order`. This attribute is used by behaviors that "fetch" content, i.e. anytime there's a `href` attribute set, with an update action such as `replace`, `replace-inner`, etc. When present, we compute a unique id before the request is emitted, and store it on an attribute of the target element. When the response arrives, we read the attribute of the target element and compare it to the one we generated before the request was sent. If the attribute is set with a value that's different from the one set before the request, we assume this means another request/response cycle took place, and the response we're presently dealing with is "outdated", so we discard it.

To be discussed:
- [ ] naming: is "preserve-order" descriptive enough? should we use a boolean or an enum?
- [ ] visibility: should we make this feature public / documented or keep it "dark" for now?
- [ ] scope: should we think of this capability to be applied to other, non-fetching behaviors?