### PR TITLE
fix: reload button broken in error screens

### DIFF
--- a/src/contexts/navigation.ts
+++ b/src/contexts/navigation.ts
@@ -10,6 +10,7 @@ import type {
   HvBehavior,
   HvComponent,
   HvComponentOnUpdate,
+  Reload,
 } from 'hyperview/src/types';
 
 import React, { ComponentType, ReactNode } from 'react';
@@ -24,6 +25,7 @@ export type NavigationContextProps = {
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
   onUpdate: HvComponentOnUpdate;
+  reload: Reload;
   url?: string;
   behaviors?: HvBehavior[];
   components?: HvComponent[];

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -79,8 +79,8 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
    */
   reload = (
     optHref: DOMString | null | undefined,
+    onUpdateCallbacks: OnUpdateCallbacks,
     opts: HvComponentOptions | undefined,
-    onUpdateCallbacks: OnUpdateCallbacks | undefined,
   ) => {
     const isBlankHref =
       optHref === null ||
@@ -211,7 +211,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
     const updateAction: UpdateAction = action as UpdateAction;
 
     if (action === ACTIONS.RELOAD) {
-      this.reload(href, options, options.onUpdateCallbacks);
+      this.reload(href, options.onUpdateCallbacks, options);
     } else if (action === ACTIONS.DEEP_LINK && href) {
       Linking.openURL(href);
     } else if (navAction && Object.values(NAV_ACTIONS).includes(navAction)) {

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -79,15 +79,15 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
    */
   reload = (
     optHref: DOMString | null | undefined,
-    opts: HvComponentOptions,
-    onUpdateCallbacks: OnUpdateCallbacks,
+    opts: HvComponentOptions | undefined,
+    onUpdateCallbacks: OnUpdateCallbacks | undefined,
   ) => {
     const isBlankHref =
       optHref === null ||
       optHref === undefined ||
       optHref === '#' ||
       optHref === '';
-    const stateUrl = onUpdateCallbacks.getState().url;
+    const stateUrl = onUpdateCallbacks?.getState().url;
     const url = isBlankHref
       ? stateUrl
       : UrlService.getUrlFromHref(optHref, stateUrl || '');
@@ -124,7 +124,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
       Behaviors.setRanOnce(behaviorElement);
     }
 
-    let newRoot = onUpdateCallbacks.getDoc();
+    let newRoot = onUpdateCallbacks?.getDoc();
     if (newRoot && (showIndicatorIdList || hideIndicatorIdList)) {
       newRoot = Behaviors.setIndicatorsBeforeLoad(
         showIndicatorIdList,
@@ -134,8 +134,8 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
     }
 
     // Re-render the modifications
-    onUpdateCallbacks.setNeedsLoad();
-    onUpdateCallbacks.setState({
+    onUpdateCallbacks?.setNeedsLoad();
+    onUpdateCallbacks?.setState({
       doc: newRoot,
       elementError: null,
       error: null,
@@ -555,6 +555,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
             openModal={this.props.openModal}
             push={this.props.push}
             refreshControl={this.props.refreshControl}
+            reload={this.reload}
             route={this.props.route}
           />
         </Contexts.RefreshControlComponentContext.Provider>
@@ -581,6 +582,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
               onParseAfter: this.props.onParseAfter,
               onParseBefore: this.props.onParseBefore,
               onUpdate: this.onUpdate,
+              reload: this.reload,
             }}
           >
             <HvRoute />

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -87,7 +87,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
       optHref === undefined ||
       optHref === '#' ||
       optHref === '';
-    const stateUrl = onUpdateCallbacks?.getState().url;
+    const stateUrl = onUpdateCallbacks.getState().url;
     const url = isBlankHref
       ? stateUrl
       : UrlService.getUrlFromHref(optHref, stateUrl || '');
@@ -124,7 +124,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
       Behaviors.setRanOnce(behaviorElement);
     }
 
-    let newRoot = onUpdateCallbacks?.getDoc();
+    let newRoot = onUpdateCallbacks.getDoc();
     if (newRoot && (showIndicatorIdList || hideIndicatorIdList)) {
       newRoot = Behaviors.setIndicatorsBeforeLoad(
         showIndicatorIdList,
@@ -134,8 +134,8 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
     }
 
     // Re-render the modifications
-    onUpdateCallbacks?.setNeedsLoad();
-    onUpdateCallbacks?.setState({
+    onUpdateCallbacks.setNeedsLoad();
+    onUpdateCallbacks.setState({
       doc: newRoot,
       elementError: null,
       error: null,

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -79,8 +79,8 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
    */
   reload = (
     optHref: DOMString | null | undefined,
+    opts: HvComponentOptions,
     onUpdateCallbacks: OnUpdateCallbacks,
-    opts: HvComponentOptions | undefined,
   ) => {
     const isBlankHref =
       optHref === null ||
@@ -211,7 +211,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
     const updateAction: UpdateAction = action as UpdateAction;
 
     if (action === ACTIONS.RELOAD) {
-      this.reload(href, options.onUpdateCallbacks, options);
+      this.reload(href, options, options.onUpdateCallbacks);
     } else if (action === ACTIONS.DEEP_LINK && href) {
       Linking.openURL(href);
     } else if (navAction && Object.values(NAV_ACTIONS).includes(navAction)) {

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -241,8 +241,8 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
     options: HvComponentOptions,
   ) => {
     this.props.onUpdate(href, action, element, {
-      onUpdateCallbacks: this.updateCallbacks(),
       ...options,
+      onUpdateCallbacks: this.updateCallbacks(),
     });
   };
 

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -342,6 +342,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
             openModal={this.navLogic.openModal}
             push={this.navLogic.push}
             registerPreload={this.registerPreload}
+            reload={this.props.reload}
             route={route}
             url={url || undefined}
           />

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -241,8 +241,8 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
     options: HvComponentOptions,
   ) => {
     this.props.onUpdate(href, action, element, {
-      ...options,
       onUpdateCallbacks: this.updateCallbacks(),
+      ...options,
     });
   };
 

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -13,6 +13,7 @@ import {
   HvBehavior,
   HvComponent,
   HvComponentOnUpdate,
+  Reload,
 } from 'hyperview/src/types';
 import type { Props as ErrorProps } from 'hyperview/src/core/components/load-error';
 import type { Props as LoadingProps } from 'hyperview/src/core/components/loading';
@@ -40,6 +41,7 @@ export type NavigationContextProps = {
   errorScreen?: ComponentType<ErrorProps>;
   loadingScreen?: ComponentType<LoadingProps>;
   handleBack?: ComponentType<{ children: ReactNode }>;
+  reload: Reload;
 };
 
 export type NavigatorMapContextProps = {
@@ -74,6 +76,7 @@ export type InnerRouteProps = {
   setPreload: (key: number, element: Element) => void;
   getPreload: (key: number) => Element | undefined;
   element?: Element;
+  reload: Reload;
 };
 
 /**

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -235,7 +235,7 @@ export default class HvScreen extends React.Component {
    * Reload if an error occured using the screen's current URL
    */
     reload = () => {
-      this.props.reload(this.state.url, this.updateCallbacks());
+      this.props.reload(this.state.url, this.updateCallbacks);
     };
 
   /**

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -231,12 +231,12 @@ export default class HvScreen extends React.Component {
     }
   }
 
-    /**
+  /**
    * Reload if an error occured using the screen's current URL
    */
-    reload = () => {
-      this.props.reload(this.state.url, this.updateCallbacks);
-    };
+  reload = () => {
+    this.props.reload(this.state.url, null, this.updateCallbacks);
+  };
 
   /**
    * Renders the XML doc into React components. Shows blank screen until the XML doc is available.

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -301,25 +301,23 @@ export default class HvScreen extends React.Component {
   /**
    * Implement the callbacks from this class
    */
-  updateCallbacks = () => {
-    return {
-      clearElementError: () => {
-        if (this.state.elementError) {
-          this.setState({ elementError: null });
-        }
-      },
-      getDoc: () => this.doc,
-      getNavigation: () => this.navigation,
-      getOnUpdate: () => this.onUpdate,
-      getState: () => this.state,
-      registerPreload: (id, element)=>this.registerPreload(id, element),
-      setNeedsLoad: () => {
-        this.needsLoad = true
-      },
-      setState: (state) => {
-        this.setState(state)
-      },
-    };
+  updateCallbacks =  {
+    clearElementError: () => {
+      if (this.state.elementError) {
+        this.setState({ elementError: null });
+      }
+    },
+    getDoc: () => this.doc,
+    getNavigation: () => this.navigation,
+    getOnUpdate: () => this.onUpdate,
+    getState: () => this.state,
+    registerPreload: (id, element) => this.registerPreload(id, element),
+    setNeedsLoad: () => {
+      this.needsLoad = true
+    },
+    setState: (state) => {
+      this.setState(state)
+    },
   };
 
   /**
@@ -327,7 +325,7 @@ export default class HvScreen extends React.Component {
    */
   onUpdate = (href, action, currentElement, opts) => {
     this.props.onUpdate(href, action, currentElement, {
-      onUpdateCallbacks: this.updateCallbacks(),
+      onUpdateCallbacks: this.updateCallbacks,
       ...opts,
     });
   }

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -240,7 +240,7 @@ export default class HvScreen extends React.Component {
       return React.createElement(errorScreen, {
         back: () => this.getNavigation().back(),
         error: this.state.error,
-        onPressReload: () => this.reload(),  // Make sure reload() is called without any args
+        onPressReload: () => this.props.reload(),  // Make sure reload() is called without any args
         onPressViewDetails: (uri) => this.props.openModal({ url: uri }),
       });
     }
@@ -267,7 +267,7 @@ export default class HvScreen extends React.Component {
       }}>
         <Contexts.DateFormatContext.Provider value={this.props.formatDate}>
           {screenElement}
-          {elementErrorComponent ? (React.createElement(elementErrorComponent, { error: this.state.elementError, onPressReload: () => this.reload() })) : null}
+          {elementErrorComponent ? (React.createElement(elementErrorComponent, { error: this.state.elementError, onPressReload: () => this.props.reload() })) : null}
         </Contexts.DateFormatContext.Provider>
       </Contexts.DocContext.Provider>
     );

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -53,4 +53,5 @@ export type Props = {
   handleBack?: ComponentType<{ children: ReactNode }>;
   doc?: Document;
   registerPreload?: (id: number, element: Element) => void;
+  reload: Types.Reload;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -425,3 +425,9 @@ export type ScreenState = {
   styles?: Stylesheets.StyleSheets | null;
   url?: string | null;
 };
+
+export type Reload = (
+  optHref: DOMString | null | undefined,
+  opts: HvComponentOptions | undefined,
+  onUpdateCallbacks: OnUpdateCallbacks | undefined,
+) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -428,6 +428,6 @@ export type ScreenState = {
 
 export type Reload = (
   optHref: DOMString | null | undefined,
+  onUpdateCallbacks: OnUpdateCallbacks,
   opts: HvComponentOptions | undefined,
-  onUpdateCallbacks: OnUpdateCallbacks | undefined,
 ) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -428,6 +428,6 @@ export type ScreenState = {
 
 export type Reload = (
   optHref: DOMString | null | undefined,
+  opts: HvComponentOptions,
   onUpdateCallbacks: OnUpdateCallbacks,
-  opts: HvComponentOptions | undefined,
 ) => void;


### PR DESCRIPTION
When the reload functionality was moved into `<hv-root>` the local reload functionality was broken in `<hv-screen>`

Relates to https://github.com/Instawork/hyperview/pull/727

Resolves https://github.com/Instawork/hyperview/issues/737

Asana: https://app.asana.com/0/1204008699308084/1205859670749796/f

| Before | After |
| -- | -- |
| ![before](https://github.com/Instawork/hyperview/assets/127122858/1f2173a3-aea6-4474-8ec8-e392e592cf16) | ![after](https://github.com/Instawork/hyperview/assets/127122858/1e0dbdba-472c-496c-b552-4efbe1ce6a47) |
