### PR TITLE
chore: clean up reload signature

### DIFF
--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -80,14 +80,13 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
   reload = (
     optHref: DOMString | null | undefined,
     opts: HvComponentOptions,
-    onUpdateCallbacks: OnUpdateCallbacks,
   ) => {
     const isBlankHref =
       optHref === null ||
       optHref === undefined ||
       optHref === '#' ||
       optHref === '';
-    const stateUrl = onUpdateCallbacks.getState().url;
+    const stateUrl = opts.onUpdateCallbacks?.getState().url;
     const url = isBlankHref
       ? stateUrl
       : UrlService.getUrlFromHref(optHref, stateUrl || '');
@@ -124,7 +123,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
       Behaviors.setRanOnce(behaviorElement);
     }
 
-    let newRoot = onUpdateCallbacks.getDoc();
+    let newRoot = opts.onUpdateCallbacks?.getDoc();
     if (newRoot && (showIndicatorIdList || hideIndicatorIdList)) {
       newRoot = Behaviors.setIndicatorsBeforeLoad(
         showIndicatorIdList,
@@ -134,8 +133,8 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
     }
 
     // Re-render the modifications
-    onUpdateCallbacks.setNeedsLoad();
-    onUpdateCallbacks.setState({
+    opts.onUpdateCallbacks?.setNeedsLoad();
+    opts.onUpdateCallbacks?.setState({
       doc: newRoot,
       elementError: null,
       error: null,
@@ -211,7 +210,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
     const updateAction: UpdateAction = action as UpdateAction;
 
     if (action === ACTIONS.RELOAD) {
-      this.reload(href, options, options.onUpdateCallbacks);
+      this.reload(href, options);
     } else if (action === ACTIONS.DEEP_LINK && href) {
       Linking.openURL(href);
     } else if (navAction && Object.values(NAV_ACTIONS).includes(navAction)) {

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -346,8 +346,8 @@ export default class HvScreen extends React.Component {
    */
   onUpdate = (href, action, currentElement, opts) => {
     this.props.onUpdate(href, action, currentElement, {
-      onUpdateCallbacks: this.updateCallbacks,
       ...opts,
+      onUpdateCallbacks: this.updateCallbacks,
     });
   };
 }

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -243,7 +243,9 @@ export default class HvScreen extends React.Component {
    * Reload if an error occured using the screen's current URL
    */
   reload = () => {
-    this.props.reload(this.state.url, null, this.updateCallbacks);
+    this.props.reload(this.state.url, {
+      onUpdateCallbacks: this.updateCallbacks,
+    });
   };
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -429,5 +429,4 @@ export type ScreenState = {
 export type Reload = (
   optHref: DOMString | null | undefined,
   opts: HvComponentOptions,
-  onUpdateCallbacks: OnUpdateCallbacks,
 ) => void;


### PR DESCRIPTION
Simplifying the signature and call to `reload` to use the update callbacks from options rather than as a separate param.

Asana: https://app.asana.com/0/1204008699308084/1205888765821732/f


https://github.com/Instawork/hyperview/assets/127122858/1ef6092b-e4ad-42bf-bc3a-2062ef772c2f

