### PR TITLE
fix: update callback injection in hv-screen

### DIFF
--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -346,8 +346,8 @@ export default class HvScreen extends React.Component {
    */
   onUpdate = (href, action, currentElement, opts) => {
     this.props.onUpdate(href, action, currentElement, {
-      onUpdateCallbacks: this.updateCallbacks,
       ...opts,
+      onUpdateCallbacks: this.updateCallbacks,
     });
   };
 }


### PR DESCRIPTION
The order of the callback injection was wrong from [PR](https://github.com/Instawork/hyperview/pull/739). Which could cause the wrong callbacks to be used in onUpdate() calls.

Relates to https://github.com/Instawork/hyperview/pull/739

Asana: https://app.asana.com/0/1204008699308084/1205908537013919/f