### PR TITLE
feat: report route focus and blur events

### DIFF
--- a/src/contexts/navigation.ts
+++ b/src/contexts/navigation.ts
@@ -11,7 +11,7 @@ import type {
   HvComponent,
   HvComponentOnUpdate,
   Reload,
-  RouteParams,
+  Route,
 } from 'hyperview/src/types';
 
 import React, { ComponentType, ReactNode } from 'react';
@@ -25,8 +25,8 @@ export type NavigationContextProps = {
   onError?: (error: Error) => void;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
-  onRouteBlur?: (routeParams?: RouteParams) => void;
-  onRouteFocus?: (routeParams?: RouteParams) => void;
+  onRouteBlur?: (route: Route) => void;
+  onRouteFocus?: (route: Route) => void;
   onUpdate: HvComponentOnUpdate;
   reload: Reload;
   url?: string;

--- a/src/contexts/navigation.ts
+++ b/src/contexts/navigation.ts
@@ -24,6 +24,8 @@ export type NavigationContextProps = {
   onError?: (error: Error) => void;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
+  onRouteBlur?: (id?: string, url?: string) => void;
+  onRouteFocus?: (id?: string, url?: string) => void;
   onUpdate: HvComponentOnUpdate;
   reload: Reload;
   url?: string;

--- a/src/contexts/navigation.ts
+++ b/src/contexts/navigation.ts
@@ -11,6 +11,7 @@ import type {
   HvComponent,
   HvComponentOnUpdate,
   Reload,
+  RouteParams,
 } from 'hyperview/src/types';
 
 import React, { ComponentType, ReactNode } from 'react';
@@ -24,8 +25,8 @@ export type NavigationContextProps = {
   onError?: (error: Error) => void;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
-  onRouteBlur?: (id?: string, url?: string) => void;
-  onRouteFocus?: (id?: string, url?: string) => void;
+  onRouteBlur?: (routeParams?: RouteParams) => void;
+  onRouteFocus?: (routeParams?: RouteParams) => void;
   onUpdate: HvComponentOnUpdate;
   reload: Reload;
   url?: string;

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -11,11 +11,15 @@ import * as Dom from 'hyperview/src/services/dom';
 import * as NavigationContext from 'hyperview/src/contexts/navigation';
 import * as NavigatorMapContext from 'hyperview/src/contexts/navigator-map';
 import * as NavigatorService from 'hyperview/src/services/navigator';
-import { BEHAVIOR_ATTRIBUTES, LOCAL_NAME, TRIGGERS } from 'hyperview/src/types';
+import {
+  BEHAVIOR_ATTRIBUTES,
+  LOCAL_NAME,
+  RouteParams,
+  TRIGGERS,
+} from 'hyperview/src/types';
 import type {
   ParamTypes,
   Props,
-  RouteParams,
   ScreenParams,
   StackScreenOptions,
   TabScreenOptions,

--- a/src/core/components/hv-navigator/types.ts
+++ b/src/core/components/hv-navigator/types.ts
@@ -6,15 +6,9 @@
  *
  */
 
+import type { HvComponentOnUpdate, RouteParams } from 'hyperview/src/types';
 import { FC } from 'react';
-import type { HvComponentOnUpdate } from 'hyperview/src/types';
 import type { Props as HvRouteProps } from 'hyperview/src/core/components/hv-route';
-
-export type RouteParams = {
-  id?: string;
-  url: string;
-  isModal?: boolean;
-};
 
 export type ParamTypes = Record<string, RouteParams>;
 

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -580,6 +580,8 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
               onError: this.props.onError,
               onParseAfter: this.props.onParseAfter,
               onParseBefore: this.props.onParseBefore,
+              onRouteBlur: this.props.onRouteBlur,
+              onRouteFocus: this.props.onRouteFocus,
               onUpdate: this.onUpdate,
               reload: this.reload,
             }}

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -30,7 +30,6 @@ import {
   OnUpdateCallbacks,
   UPDATE_ACTIONS,
   UpdateAction,
-  RouteParams,
 } from 'hyperview/src/types';
 import React, { PureComponent } from 'react';
 import HvRoute from 'hyperview/src/core/components/hv-route';

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -30,6 +30,7 @@ import {
   OnUpdateCallbacks,
   UPDATE_ACTIONS,
   UpdateAction,
+  RouteParams,
 } from 'hyperview/src/types';
 import React, { PureComponent } from 'react';
 import HvRoute from 'hyperview/src/core/components/hv-route';

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -543,9 +543,21 @@ export default function HvRoute(props: Types.Props) {
     docContext?.getDoc(),
   );
 
-  // Use the focus event to set the selected route
   React.useEffect(() => {
     if (props.navigation) {
+      const unsubscribeBlur: () => void = props.navigation.addListener(
+        'blur',
+        () => {
+          if (navigationContext.onRouteBlur) {
+            navigationContext.onRouteBlur(
+              props.route?.params?.id,
+              props.route?.params?.url,
+            );
+          }
+        },
+      );
+
+      // Use the focus event to set the selected route
       const unsubscribeFocus: () => void = props.navigation.addListener(
         'focus',
         () => {
@@ -553,9 +565,16 @@ export default function HvRoute(props: Types.Props) {
             docContext?.getDoc(),
             props.route?.params?.id,
           );
+          if (navigationContext.onRouteFocus) {
+            navigationContext.onRouteFocus(
+              props.route?.params?.id,
+              props.route?.params?.url,
+            );
+          }
         },
       );
 
+      // Use the beforeRemove event to remove the route from the stack
       const unsubscribeRemove: () => void = props.navigation.addListener(
         'beforeRemove',
         () => {
@@ -567,12 +586,19 @@ export default function HvRoute(props: Types.Props) {
       );
 
       return () => {
+        unsubscribeBlur();
         unsubscribeFocus();
         unsubscribeRemove();
       };
     }
     return undefined;
-  }, [props.navigation, props.route?.params?.id, docContext]);
+  }, [
+    props.navigation,
+    props.route?.params?.id,
+    props.route?.params?.url,
+    docContext,
+    navigationContext,
+  ]);
 
   return (
     <HvRouteInner

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -549,10 +549,7 @@ export default function HvRoute(props: Types.Props) {
         'blur',
         () => {
           if (navigationContext.onRouteBlur) {
-            navigationContext.onRouteBlur(
-              props.route?.params?.id,
-              props.route?.params?.url,
-            );
+            navigationContext.onRouteBlur(props.route?.params);
           }
         },
       );
@@ -566,10 +563,7 @@ export default function HvRoute(props: Types.Props) {
             props.route?.params?.id,
           );
           if (navigationContext.onRouteFocus) {
-            navigationContext.onRouteFocus(
-              props.route?.params?.id,
-              props.route?.params?.url,
-            );
+            navigationContext.onRouteFocus(props.route?.params);
           }
         },
       );
@@ -592,13 +586,7 @@ export default function HvRoute(props: Types.Props) {
       };
     }
     return undefined;
-  }, [
-    props.navigation,
-    props.route?.params?.id,
-    props.route?.params?.url,
-    docContext,
-    navigationContext,
-  ]);
+  }, [props.navigation, props.route?.params, docContext, navigationContext]);
 
   return (
     <HvRouteInner

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -548,8 +548,8 @@ export default function HvRoute(props: Types.Props) {
       const unsubscribeBlur: () => void = props.navigation.addListener(
         'blur',
         () => {
-          if (navigationContext.onRouteBlur) {
-            navigationContext.onRouteBlur(props.route?.params);
+          if (navigationContext.onRouteBlur && props.route) {
+            navigationContext.onRouteBlur(props.route);
           }
         },
       );
@@ -562,8 +562,8 @@ export default function HvRoute(props: Types.Props) {
             docContext?.getDoc(),
             props.route?.params?.id,
           );
-          if (navigationContext.onRouteFocus) {
-            navigationContext.onRouteFocus(props.route?.params);
+          if (navigationContext.onRouteFocus && props.route) {
+            navigationContext.onRouteFocus(props.route);
           }
         },
       );
@@ -586,7 +586,7 @@ export default function HvRoute(props: Types.Props) {
       };
     }
     return undefined;
-  }, [props.navigation, props.route?.params, docContext, navigationContext]);
+  }, [props.navigation, props.route, docContext, navigationContext]);
 
   return (
     <HvRouteInner

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -33,6 +33,8 @@ export type NavigationContextProps = {
   fetch: Fetch;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
+  onRouteBlur?: (id?: string, url?: string) => void;
+  onRouteFocus?: (id?: string, url?: string) => void;
   onUpdate: HvComponentOnUpdate;
   url?: string;
   behaviors?: HvBehavior[];

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -14,6 +14,7 @@ import {
   HvComponent,
   HvComponentOnUpdate,
   Reload,
+  Route,
   RouteParams,
 } from 'hyperview/src/types';
 import type { Props as ErrorProps } from 'hyperview/src/core/components/load-error';
@@ -24,8 +25,8 @@ export type NavigationContextProps = {
   fetch: Fetch;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
-  onRouteBlur?: (routeParams?: RouteParams) => void;
-  onRouteFocus?: (routeParams?: RouteParams) => void;
+  onRouteBlur?: (route: Route) => void;
+  onRouteFocus?: (route: Route) => void;
   onUpdate: HvComponentOnUpdate;
   url?: string;
   behaviors?: HvBehavior[];

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -14,6 +14,7 @@ import {
   HvComponent,
   HvComponentOnUpdate,
   Reload,
+  RouteParams,
 } from 'hyperview/src/types';
 import type { Props as ErrorProps } from 'hyperview/src/core/components/load-error';
 import type { Props as LoadingProps } from 'hyperview/src/core/components/loading';
@@ -23,8 +24,8 @@ export type NavigationContextProps = {
   fetch: Fetch;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
-  onRouteBlur?: (id?: string, url?: string) => void;
-  onRouteFocus?: (id?: string, url?: string) => void;
+  onRouteBlur?: (routeParams?: RouteParams) => void;
+  onRouteFocus?: (routeParams?: RouteParams) => void;
   onUpdate: HvComponentOnUpdate;
   url?: string;
   behaviors?: HvBehavior[];

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -18,16 +18,6 @@ import {
 import type { Props as ErrorProps } from 'hyperview/src/core/components/load-error';
 import type { Props as LoadingProps } from 'hyperview/src/core/components/loading';
 
-/**
- * Params passed to hv-route
- */
-type RouteParams = {
-  id?: string;
-  url: string;
-  preloadScreen?: number;
-  isModal?: boolean;
-};
-
 export type NavigationContextProps = {
   entrypointUrl: string;
   fetch: Fetch;

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -31,8 +31,8 @@ export type Props = {
   onError?: (error: Error) => void;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
-  onRouteBlur?: (id?: string, url?: string) => void;
-  onRouteFocus?: (id?: string, url?: string) => void;
+  onRouteBlur?: (routeParams?: Types.RouteParams) => void;
+  onRouteFocus?: (routeParams?: Types.RouteParams) => void;
   onUpdate: Types.HvComponentOnUpdate;
   url?: string;
   back?: (

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -31,6 +31,8 @@ export type Props = {
   onError?: (error: Error) => void;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
+  onRouteBlur?: (id?: string, url?: string) => void;
+  onRouteFocus?: (id?: string, url?: string) => void;
   onUpdate: Types.HvComponentOnUpdate;
   url?: string;
   back?: (

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -31,8 +31,8 @@ export type Props = {
   onError?: (error: Error) => void;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
-  onRouteBlur?: (routeParams?: Types.RouteParams) => void;
-  onRouteFocus?: (routeParams?: Types.RouteParams) => void;
+  onRouteBlur?: (route: Types.Route) => void;
+  onRouteFocus?: (route: Types.Route) => void;
   onUpdate: Types.HvComponentOnUpdate;
   url?: string;
   back?: (

--- a/src/types.ts
+++ b/src/types.ts
@@ -399,6 +399,13 @@ export type NavigationProps = {
   push: (routeParams: NavigationRouteParams) => void;
 };
 
+export type RouteParams = {
+  id?: string;
+  url: string;
+  preloadScreen?: number;
+  isModal?: boolean;
+};
+
 export const ON_EVENT_DISPATCH = 'hyperview:on-event';
 
 export type Fetch = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@
 
 import * as Stylesheets from './services/stylesheets';
 import Navigation from './services/navigation';
-
+import type { Route as NavigatorRoute } from './services/navigator';
 import type React from 'react';
 
 import type { XResponseStaleReason } from './services/dom/types';
@@ -398,6 +398,8 @@ export type NavigationProps = {
   openModal: (routeParams: NavigationRouteParams) => void;
   push: (routeParams: NavigationRouteParams) => void;
 };
+
+export type Route = NavigatorRoute<string, RouteParams>;
 
 export type RouteParams = {
   id?: string;


### PR DESCRIPTION
Allow navigation actions to report the blur/focus state of each route. The entire `route` object is returned. This is a combination of
- Elements injected by react-navigation (key and maybe other values)
- Elements injected by Hyperview (params)
  - The `id` is pulled from the `<nav-route>` attribute in the navigation structure.
  - The `url` is from either the `<nav-route>` `url` attribute or from the `href` passed in a `<behavior>`

The `id` will be undefined for any navigation events which occur from `<behavior>` triggers.
The 'url' will be undefined for any `<nav-route>` which does not define an `href` value.

I have verified that the listeners are properly cleaned and resubscribed without causing duplicate listeners.

Asana: https://app.asana.com/0/1204008699308084/1205094358200852/f


https://github.com/Instawork/hyperview/assets/127122858/40f3a3ea-c046-4b94-b514-39f9ff4cb708

