### PR TITLE
fix: loading screens not working

### DIFF
--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -218,7 +218,13 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
       const doc = options.onUpdateCallbacks.getDoc();
       const state = options.onUpdateCallbacks.getState();
       if (navigation && doc && state.url) {
-        const { behaviorElement, delay, newElement, targetId } = options;
+        const {
+          behaviorElement,
+          delay,
+          newElement,
+          showIndicatorId,
+          targetId,
+        } = options;
         const delayVal: number = +(delay || '');
         navigation.setUrl(state.url);
         navigation.setDocument(doc);
@@ -231,6 +237,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
             behaviorElement: behaviorElement || undefined,
             delay: delayVal,
             newElement: newElement || undefined,
+            showIndicatorId: showIndicatorId || undefined,
             targetId: targetId || undefined,
           },
           options.onUpdateCallbacks.registerPreload,


### PR DESCRIPTION
Added a missing option into the navigation call.

| Before | After |
| -- | -- |
| ![before](https://github.com/Instawork/hyperview/assets/127122858/fed81afa-fb29-4e1e-95d1-9eeafab11b3a) | ![after](https://github.com/Instawork/hyperview/assets/127122858/a8729133-ac76-47a1-93d4-17bf61b5b699) |

Asana: https://app.asana.com/0/1204008699308084/1205908539633327/f