### PR TITLE
fix: deep link modals trigger too many page loads

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -134,10 +134,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
       // When a modal is included, a wrapper stack navigator is created
       // The route which contains the navigator should not load the document
       // The code below prevents the route from loading the document
-      if (
-        this.props.route?.params?.isModal &&
-        this.props.route?.name === this.props.route?.params?.id
-      ) {
+      if (this.props.route?.params?.isModal) {
         return;
       }
 

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -131,6 +131,16 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
     }
 
     try {
+      // When a modal is included, a wrapper stack navigator is created
+      // The route which contains the navigator should not load the document
+      // The code below prevents the route from loading the document
+      if (
+        this.props.route?.params?.isModal &&
+        this.props.route?.name === this.props.route?.params?.id
+      ) {
+        return;
+      }
+
       const url: string = this.getUrl();
 
       const { doc } = await this.parser.loadDocument(url);


### PR DESCRIPTION
When viewing a modal screen from a deep link, the url was loaded three times.

Background: when a modal is defined in Hyperview navigation XML schema, we can include a designation of "modal=true". When true, Hyperview will automatically create a stack navigator to contain the modal so that any additional navigation actions from the modal are contained within its own stack.

Cause: the original route was continuing to call a url load in the middle of the render cycle for the new stack navigator causing a state refresh multiple times.

Fix: ensure that routes which are defined as modal don't trigger their own load action (the child modal screen will have a unique name).

**Code explanation**
Given a (simplified) document input
```xml
<doc>
  <navigator id="root-navigator" type="stack">
    <nav-route id="tabs-route" href="">
      ...
    </nav-route>
    <nav-route id="storybook-route" href="/storybook" modal="true" />
  </navigator>
</doc>
```

The (simplified) component structure would be
```xml
<HvRoute id="" url="entrypointurl">
  <HvNavigator id="root-navigator" type="stack">
    <HvRoute id="tabs-navigator" type="tabs">
      ...
    </HvRoute>
    <HvRoute id="storybook-route" url="/storybook" modal="true">
      <HvNavigator id="stack-storybook-route" type="stack">
        <HvRoute id="modal-screen-storybook-route" url="/storybook"/>
      </HvNavigator>
    </HvRoute>
  </HvNavigator>
</HvRoute>
```

In this structure, the `<HvRoute>` with id "storybook-route" should not be loading a url, that will be handled by the "modal-screen-storybook-route" route.


| Before | After |
| -- | -- |
| ![before](https://github.com/Instawork/hyperview/assets/127122858/2cd3db10-9ff3-4c47-b42f-139a214a69a8) | ![after](https://github.com/Instawork/hyperview/assets/127122858/c25be81c-28d9-4a0e-a3d5-7045cf764a17) |

Asana: https://app.asana.com/0/1204008699308084/1205943003379301/f


