### PR TITLE
fix: deep link merging

### DIFF
--- a/src/services/dom/helpers.ts
+++ b/src/services/dom/helpers.ts
@@ -90,3 +90,18 @@ export const preorder = (
   }
   return acc;
 };
+
+/**
+ * Get an array of the direct decendant elements of a document or element
+ */
+export const getChildElements = (element: Document | Element): Element[] => {
+  const childElements: Element[] = [];
+  if (element.childNodes) {
+    Array.from(element.childNodes).forEach((child: Node | null) => {
+      if (child && child.nodeType === NODE_TYPE.ELEMENT_NODE) {
+        childElements.push(child as Element);
+      }
+    });
+  }
+  return childElements;
+};

--- a/src/services/dom/helpers.ts
+++ b/src/services/dom/helpers.ts
@@ -90,18 +90,3 @@ export const preorder = (
   }
   return acc;
 };
-
-/**
- * Get an array of the direct decendant elements of a document or element
- */
-export const getChildElements = (element: Document | Element): Element[] => {
-  const childElements: Element[] = [];
-  if (element.childNodes) {
-    Array.from(element.childNodes).forEach((child: Node | null) => {
-      if (child && child.nodeType === NODE_TYPE.ELEMENT_NODE) {
-        childElements.push(child as Element);
-      }
-    });
-  }
-  return childElements;
-};

--- a/src/services/navigator/helpers.test.ts
+++ b/src/services/navigator/helpers.test.ts
@@ -770,4 +770,56 @@ describe('mergeDocuments', () => {
       expect(shiftNavRoutes.length).toEqual(2);
     });
   });
+
+  describe('merge screen with navigator', () => {
+    // The incoming <screen> should replace the original <navigator>
+    const mergeDoc = parser.parseFromString(screenDocSource);
+    const outputDoc = mergeDocument(mergeDoc, originalDoc);
+    it('should merge successfully', () => {
+      expect(outputDoc).toBeDefined();
+    });
+
+    const mergedNavigators = outputDoc.getElementsByTagNameNS(
+      Namespaces.HYPERVIEW,
+      'navigator',
+    );
+
+    it('should find 0 navigators', () => {
+      expect(mergedNavigators.length).toEqual(0);
+    });
+
+    const screens = outputDoc.getElementsByTagNameNS(
+      Namespaces.HYPERVIEW,
+      'screen',
+    );
+
+    it('should find 1 screen', () => {
+      expect(screens.length).toEqual(1);
+    });
+  });
+
+  describe('merge navigator with screen', () => {
+    // The incoming <navigator> should replace the original <screen>
+    const screenDoc = parser.parseFromString(screenDocSource);
+    const outputDoc = mergeDocument(originalDoc, screenDoc);
+    it('should merge successfully', () => {
+      expect(outputDoc).toBeDefined();
+    });
+
+    const mergedNavigators = outputDoc.getElementsByTagNameNS(
+      Namespaces.HYPERVIEW,
+      'navigator',
+    );
+    it('should find 2 navigators', () => {
+      expect(mergedNavigators.length).toEqual(2);
+    });
+
+    const screens = outputDoc.getElementsByTagNameNS(
+      Namespaces.HYPERVIEW,
+      'screen',
+    );
+    it('should find 0 screens', () => {
+      expect(screens.length).toEqual(0);
+    });
+  });
 });

--- a/src/services/navigator/helpers.test.ts
+++ b/src/services/navigator/helpers.test.ts
@@ -110,6 +110,24 @@ const mergeSourceEnabledDoc = `
 `;
 
 /**
+ * Test merge document with merging enabled and an alternate navigator type
+ * Expect the merge to contain a merged document
+ */
+const mergeSourceEnabledTabToStackDoc = `
+<doc xmlns="https://hyperview.org/hyperview">
+  <navigator id="root-navigator" type="stack" merge="true">
+    <nav-route id="tabs-route">
+      <navigator id="tabs-navigator" type="stack" merge="true">
+        <nav-route id="live-shifts-route2" href="/biz-app-hub" selected="false"/>
+        <nav-route id="shifts-route2" href="/biz-app-shift-group-list" selected="true"/>
+        <nav-route id="account-route2" href="/biz_app/account"/>
+      </navigator>
+    </nav-route>
+  </navigator>
+</doc>
+`;
+
+/**
  * Parser used to parse the document
  */
 const parser = new DOMParser({
@@ -820,6 +838,28 @@ describe('mergeDocuments', () => {
     );
     it('should find 0 screens', () => {
       expect(screens.length).toEqual(0);
+    });
+  });
+
+  describe('merge documents with merge="true" and different nav types', () => {
+    // With merging enabled, the docs should be merged, the tab navigator should replace the stack
+    const mergeDoc = parser.parseFromString(mergeSourceEnabledTabToStackDoc);
+    const outputDoc = mergeDocument(mergeDoc, originalDoc);
+
+    it('should merge successfully', () => {
+      expect(outputDoc).toBeDefined();
+    });
+
+    const mergedNavigators = outputDoc.getElementsByTagNameNS(
+      Namespaces.HYPERVIEW,
+      'navigator',
+    );
+    const [mergedTabNavigator] = Array.from(mergedNavigators).filter(
+      n => n.getAttribute('id') === 'tabs-navigator',
+    );
+    const mergedTabRoutes = getChildElements(mergedTabNavigator);
+    it('should find 3 route elements on tabs-navigator', () => {
+      expect(mergedTabRoutes.length).toEqual(3);
     });
   });
 });

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -371,8 +371,11 @@ const mergeNodes = (current: Element, newNodes: NodeListOf<Node>): void => {
           const currentElement = currentMap[id] as Element;
           if (currentElement) {
             if (newElement.localName === LOCAL_NAME.NAVIGATOR) {
+              // Merge if the attribute is set and the navigator types are the same
               const isMergeable =
-                newElement.getAttribute(Types.KEY_MERGE) === 'true';
+                newElement.getAttribute(Types.KEY_MERGE) === 'true' &&
+                newElement.getAttribute(Types.KEY_TYPE) ===
+                  currentElement.getAttribute(Types.KEY_TYPE);
               if (isMergeable) {
                 currentElement.setAttribute(Types.KEY_MERGE, 'true');
                 mergeNodes(currentElement, newElement.childNodes);

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -427,8 +427,8 @@ export const mergeDocument = (
 
   // Look for a primary difference in the first element
   // Example: <navigator> to <screen>
-  const [newElement] = Helpers.getChildElements(newRoot);
-  const [currentElement] = Helpers.getChildElements(currentRoot);
+  const [newElement] = getChildElements(newRoot);
+  const [currentElement] = getChildElements(currentRoot);
   if (currentElement?.localName !== newElement?.localName) {
     // Replace the current document if the first elements are different
     return newDoc;

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -412,21 +412,20 @@ export const mergeDocument = (
     return currentDoc;
   }
 
-  // Create a clone of the current document
-  const composite = currentDoc.cloneNode(true) as Document;
-  const currentRoot = Helpers.getFirstTag(composite, LOCAL_NAME.DOC);
-
-  if (!currentRoot) {
-    throw new Errors.HvRouteError('No root element found in current document');
-  }
-
   // Get the <doc>
   const newRoot = Helpers.getFirstTag(newDoc, LOCAL_NAME.DOC);
   if (!newRoot) {
     throw new Errors.HvRouteError('No root element found in new document');
   }
+  // Create a clone of the current document
+  const composite = currentDoc.cloneNode(true) as Document;
+  const compositeRoot = Helpers.getFirstTag(composite, LOCAL_NAME.DOC);
 
-  mergeNodes(currentRoot, newRoot.childNodes);
+  if (!compositeRoot) {
+    throw new Errors.HvRouteError('No root element found in current document');
+  }
+
+  mergeNodes(compositeRoot, newRoot.childNodes);
   return composite;
 };
 

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -417,6 +417,20 @@ export const mergeDocument = (
   if (!newRoot) {
     throw new Errors.HvRouteError('No root element found in new document');
   }
+  const currentRoot = Helpers.getFirstTag(currentDoc, LOCAL_NAME.DOC);
+  if (!currentRoot) {
+    throw new Errors.HvRouteError('No root element found in current document');
+  }
+
+  // Look for a primary difference in the first element
+  // Example: <navigator> to <screen>
+  const [newElement] = Helpers.getChildElements(newRoot);
+  const [currentElement] = Helpers.getChildElements(currentRoot);
+  if (currentElement?.localName !== newElement?.localName) {
+    // Replace the current document if the first elements are different
+    return newDoc;
+  }
+
   // Create a clone of the current document
   const composite = currentDoc.cloneNode(true) as Document;
   const compositeRoot = Helpers.getFirstTag(composite, LOCAL_NAME.DOC);


### PR DESCRIPTION
When an existing structure exists and a deep link comes in, merging must take into account that the document structure has changed:
1. The primary element may change from a <navigator> to a <screen> or vice versa
2. Any navigator could change types (stack, tab)

These changes validate the incoming type matches the existing. In the case of mismatches, the incoming data replaces existing.

Commits were performed sequentially for easier visibility.

Example below uses an error page to illustrate the issue.

| Before | After |
| -- | -- |
| ![before](https://github.com/Instawork/hyperview/assets/127122858/fb7f4bcc-21a9-4adb-86cd-0f1666143a9b) | ![after](https://github.com/Instawork/hyperview/assets/127122858/0d46746a-c4e2-4494-a6b3-422d4b3f73c8) |

Asana: https://app.asana.com/0/1204008699308084/1205888766113001/f