### PR TITLE
fix: deep link state handling

### DIFF
--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -24,10 +24,11 @@ export const RefreshControlComponentContext = React.createContext<
   ComponentType<RefreshControlProps> | undefined
 >(undefined);
 
-export const DocContext = React.createContext<{
+export type DocContextProps = {
   getDoc: () => Document | undefined;
   setDoc?: (doc: Document) => void;
-} | null>(null);
+};
+export const DocContext = React.createContext<DocContextProps | null>(null);
 
 export const OnUpdateContext = React.createContext<{
   onUpdate: HvComponentOnUpdate;

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -558,9 +558,15 @@ export default function HvRoute(props: Types.Props) {
       const unsubscribeFocus: () => void = props.navigation.addListener(
         'focus',
         () => {
-          NavigatorService.setSelected(
-            docContext?.getDoc(),
-            props.route?.params?.id,
+          const doc = docContext?.getDoc();
+          const id = props.route?.params?.id || props.route?.key;
+          NavigatorService.setSelected(doc, id);
+          NavigatorService.addStackRoute(
+            doc,
+            id,
+            props.route,
+            props.navigation?.getState().routes[0]?.name,
+            navigationContext.entrypointUrl,
           );
           if (navigationContext.onRouteFocus && props.route) {
             navigationContext.onRouteFocus(props.route);
@@ -574,7 +580,8 @@ export default function HvRoute(props: Types.Props) {
         () => {
           NavigatorService.removeStackRoute(
             docContext?.getDoc(),
-            props.route?.params?.id,
+            props.route?.params?.url,
+            navigationContext.entrypointUrl,
           );
         },
       );

--- a/src/core/components/navigator-stack/helpers.test.ts
+++ b/src/core/components/navigator-stack/helpers.test.ts
@@ -1,0 +1,185 @@
+import * as DomErrors from 'hyperview/src/services/dom/errors';
+import * as Types from './types';
+import { DOMParser } from '@instawork/xmldom';
+import { StackNavigationState } from '@react-navigation/native';
+import { buildRoutesFromDom } from './helpers';
+
+/**
+ * Test document response
+ * Includes a navigator with two routes
+ */
+const navDocSource =
+  '<doc xmlns="https://hyperview.org/hyperview"><navigator id="navigator" type="stack"><nav-route id="route1" href="/route1" /><nav-route id="route2" href="/route2" /></navigator></doc>';
+
+/**
+ * Test document response
+ * Includes a navigator with three routes
+ */
+const navDocSourceThreeRoute =
+  '<doc xmlns="https://hyperview.org/hyperview"><navigator id="navigator" type="stack"><nav-route id="route1" href="/route1" /><nav-route id="route2" href="/route2" /><nav-route id="route3" href="/route3"  /></navigator></doc>';
+
+/**
+ * Parser used to parse the document
+ */
+const parser = new DOMParser({
+  errorHandler: {
+    error: (error: string) => {
+      throw new DomErrors.XMLParserError(error);
+    },
+    fatalError: (error: string) => {
+      throw new DomErrors.XMLParserFatalError(error);
+    },
+    warning: (error: string) => {
+      throw new DomErrors.XMLParserWarning(error);
+    },
+  },
+  locator: {},
+});
+
+describe('buildRoutesFromDom', () => {
+  const routeParamList: Record<string, object | undefined> = {
+    route1: { href: '/route1', id: 'route1' },
+    route2: { href: '/route2', id: 'route2' },
+  };
+
+  it('should add one route', () => {
+    const doc = parser.parseFromString(navDocSource);
+    const state: StackNavigationState<Types.ParamListBase> = {
+      index: 0,
+      key: 'key1',
+      routeNames: ['route1'],
+      routes: [
+        {
+          key: 'key1',
+          name: 'card',
+          params: { id: 'route1', url: '/route1' },
+        },
+      ],
+      stale: false,
+      type: 'stack',
+    };
+    const routes = buildRoutesFromDom(
+      doc,
+      state,
+      'navigator',
+      routeParamList,
+      'http://foo.com',
+    );
+    // The dom contains one more route than the state
+    expect(routes.length).toEqual(2);
+    // The first route is the same as the state
+    expect(routes[0].key).toEqual('key1');
+    // The second route is the new route and has a key assigned by name
+    expect(routes[1].key).toEqual('route2');
+  });
+
+  it('should ignore same order route', () => {
+    // When the incoming dom contains the same url as one already in state, don't change
+    const doc = parser.parseFromString(navDocSource);
+    const state: StackNavigationState<Types.ParamListBase> = {
+      index: 0,
+      key: 'key1',
+      routeNames: ['route1'],
+      routes: [
+        {
+          key: 'key1',
+          name: 'card',
+          params: { id: 'route1', url: '/route1' },
+        },
+        {
+          key: 'key2',
+          name: 'card',
+          params: { id: 'route2', url: '/route2' },
+        },
+      ],
+      stale: false,
+      type: 'stack',
+    };
+    const routes = buildRoutesFromDom(
+      doc,
+      state,
+      'navigator',
+      routeParamList,
+      'http://foo.com',
+    );
+    // The number of routes is uncahnged
+    expect(routes.length).toEqual(2);
+    // The keys are unchanged indicating the routes were not replaced
+    expect(routes[0].key).toEqual('key1');
+    expect(routes[1].key).toEqual('key2');
+  });
+
+  it('should replace out of order routes', () => {
+    const doc = parser.parseFromString(navDocSource);
+    const state: StackNavigationState<Types.ParamListBase> = {
+      index: 0,
+      key: 'key1',
+      routeNames: ['route1'],
+      routes: [
+        {
+          key: 'key2',
+          name: 'card',
+          params: { id: 'route2', url: '/route2' },
+        },
+        {
+          key: 'key1',
+          name: 'card',
+          params: { id: 'route1', url: '/route1' },
+        },
+      ],
+      stale: false,
+      type: 'stack',
+    };
+    const routes = buildRoutesFromDom(
+      doc,
+      state,
+      'navigator',
+      routeParamList,
+      'http://foo.com',
+    );
+    // There are still two routes, but the order has changed
+    expect(routes.length).toEqual(2);
+    // The names are replaced because the routes were re-added
+    expect(routes[0].key).toEqual('route1');
+    expect(routes[1].key).toEqual('route2');
+  });
+
+  it('should ignore same order with additional route', () => {
+    // When the incoming dom contains the same order as state but adds new ones after,
+    // leave the current one intact and add a new ones
+    const doc = parser.parseFromString(navDocSourceThreeRoute);
+    const state: StackNavigationState<Types.ParamListBase> = {
+      index: 0,
+      key: 'key1',
+      routeNames: ['route1'],
+      routes: [
+        {
+          key: 'key1',
+          name: 'card',
+          params: { id: 'route1', url: '/route1' },
+        },
+        {
+          key: 'key2',
+          name: 'card',
+          params: { id: 'route2', url: '/route2' },
+        },
+      ],
+      stale: false,
+      type: 'stack',
+    };
+    const routes = buildRoutesFromDom(
+      doc,
+      state,
+      'navigator',
+      routeParamList,
+      'http://foo.com',
+    );
+    // The new route was added
+    expect(routes.length).toEqual(3);
+    // The first two routes are unchanged
+    expect(routes[0].key).toEqual('key1');
+    expect(routes[1].key).toEqual('key2');
+    // The third route is the new one
+    expect(routes[2].key).toEqual('route3');
+  });
+});

--- a/src/core/components/navigator-stack/helpers.ts
+++ b/src/core/components/navigator-stack/helpers.ts
@@ -1,0 +1,77 @@
+import * as NavigatorHelpers from 'hyperview/src/services/navigator/helpers';
+import * as Types from './types';
+import { ID_CARD, ID_MODAL } from 'hyperview/src/services/navigator/types';
+import { LOCAL_NAME } from 'hyperview/src/types';
+import { StackNavigationState } from '@react-navigation/native';
+
+// TODO: Replace this with the Route type from `hyperview/src/types`
+type Route = {
+  key: string;
+  name: string;
+  params?: {
+    id?: string;
+    url?: string;
+  };
+};
+
+export const buildRoutesFromDom = (
+  doc: Document | undefined,
+  state: StackNavigationState<Types.ParamListBase>,
+  navigatorId: string,
+  routeParamList: Record<string, object | undefined>,
+  entrypointUrl: string | undefined,
+): Route[] => {
+  const element = doc
+    ? NavigatorHelpers.getNavigatorById(doc, navigatorId)
+    : null;
+  const elementRoutes = element
+    ? NavigatorHelpers.getChildElements(element).filter(
+        e => e.localName === LOCAL_NAME.NAV_ROUTE,
+      )
+    : [];
+
+  const routes: Route[] = [];
+  const routeIds = state.routes.map((r: Route) => r.params?.id);
+  const routeHrefs = state.routes.map((r: Route) => {
+    return r.params?.url
+      ? NavigatorHelpers.getUrlFromHref(r.params.url, entrypointUrl)
+      : undefined;
+  });
+
+  let sequenceBroken = false;
+  for (let i = 0; i < elementRoutes.length; i += 1) {
+    const routeElement = elementRoutes[i];
+    const href = routeElement.getAttribute('href');
+    const id = routeElement.getAttribute('id');
+    const isModal = routeElement.getAttribute('modal') === 'true';
+    if (id) {
+      const existingIndex = href
+        ? routeHrefs.indexOf(
+            NavigatorHelpers.getUrlFromHref(href, entrypointUrl),
+          )
+        : routeIds.indexOf(id);
+      // Ensure each existing route is in the same order and hasn't been disrupted
+      if (!sequenceBroken && existingIndex !== i) {
+        sequenceBroken = true;
+      }
+      if (
+        existingIndex > -1 &&
+        !sequenceBroken &&
+        // Ensure the presentation matches
+        (isModal
+          ? state.routes[existingIndex].name === ID_MODAL
+          : state.routes[existingIndex].name === ID_CARD)
+      ) {
+        routes.push(state.routes[existingIndex]);
+      } else {
+        const params = routeParamList[id] || {};
+        routes.push({
+          key: id,
+          name: id,
+          params,
+        });
+      }
+    }
+  }
+  return routes;
+};

--- a/src/core/components/navigator-stack/index.tsx
+++ b/src/core/components/navigator-stack/index.tsx
@@ -6,7 +6,9 @@
  *
  */
 
+import * as Contexts from 'hyperview/src/contexts';
 import * as CustomStackRouter from 'hyperview/src/core/components/navigator-stack/router';
+import * as NavigationContext from 'hyperview/src/contexts/navigation';
 import * as React from 'react';
 import * as Types from './types';
 
@@ -23,6 +25,9 @@ import {
 } from '@react-navigation/stack';
 
 const CustomStackNavigator = (props: Types.Props) => {
+  const docContextProps = React.useContext(Contexts.DocContext);
+  const navContextProps = React.useContext(NavigationContext.Context);
+
   const {
     state,
     descriptors,
@@ -36,8 +41,10 @@ const CustomStackNavigator = (props: Types.Props) => {
     StackNavigationEventMap
   >(CustomStackRouter.Router, {
     children: props.children,
+    docContextProps,
     id: props.id,
     initialRouteName: props.initialRouteName,
+    navContextProps,
     screenOptions: props.screenOptions,
   });
 

--- a/src/core/components/navigator-stack/router.tsx
+++ b/src/core/components/navigator-stack/router.tsx
@@ -9,6 +9,16 @@
 import * as NavigatorService from 'hyperview/src/services/navigator';
 import * as Types from './types';
 import { StackNavigationState, StackRouter } from '@react-navigation/native';
+import { LOCAL_NAME } from 'hyperview/src/types';
+
+type Route = {
+  key: string;
+  name: string;
+  params?: {
+    id?: string;
+    url?: string;
+  };
+};
 
 /**
  * Provides a custom stack router that allows us to set the initial route
@@ -21,8 +31,10 @@ export const Router = (stackOptions: Types.StackOptions) => {
 
     getInitialState(options: Types.RouterConfigOptions) {
       const initState = router.getInitialState(options);
-
-      return mutateState(initState, { ...options, routeKeyChanges: [] });
+      return mutateState(initState, stackOptions, {
+        ...options,
+        routeKeyChanges: [],
+      });
     },
 
     getStateForRouteNamesChange(
@@ -30,7 +42,7 @@ export const Router = (stackOptions: Types.StackOptions) => {
       options: Types.RouterRenameOptions,
     ) {
       const changeState = router.getStateForRouteNamesChange(state, options);
-      return mutateState(changeState, options);
+      return mutateState(changeState, stackOptions, options);
     },
   };
 };
@@ -40,29 +52,63 @@ export const Router = (stackOptions: Types.StackOptions) => {
  */
 const mutateState = (
   state: StackNavigationState<Types.ParamListBase>,
+  stackOptions: Types.StackOptions,
   options: Types.RouterRenameOptions,
 ) => {
-  const routes = Array.from(state.routes);
+  const entrypointUrl = stackOptions.navContextProps?.entrypointUrl;
+  const doc = stackOptions.docContextProps?.getDoc();
+  const element = doc
+    ? NavigatorService.getNavigatorById(doc, stackOptions.id)
+    : null;
+  const elementRoutes = element
+    ? NavigatorService.getChildElements(element).filter(
+        e => e.localName === LOCAL_NAME.NAV_ROUTE,
+      )
+    : [];
 
-  const filteredNames = options.routeNames.filter((name: string) => {
-    return (
-      !options.routeKeyChanges?.includes(name) &&
-      !NavigatorService.isDynamicRoute(name)
-    );
+  const routes: Route[] = [];
+  const routeIds = state.routes.map((r: Route) => r.params?.id);
+  const routeHrefs = state.routes.map((r: Route) => {
+    return r.params?.url
+      ? NavigatorService.getUrlFromHref(r.params.url, entrypointUrl)
+      : undefined;
   });
 
-  filteredNames.forEach((name: string) => {
-    if (options.routeParamList) {
-      const params = options.routeParamList[name] || {};
-      if (!routes.find(route => route.name === name)) {
+  let sequenceBroken = false;
+  for (let i = 0; i < elementRoutes.length; i += 1) {
+    const routeElement = elementRoutes[i];
+    const href = routeElement.getAttribute('href');
+    const id = routeElement.getAttribute('id');
+    const isModal = routeElement.getAttribute('modal') === 'true';
+    if (id) {
+      const existingIndex = href
+        ? routeHrefs.indexOf(
+            NavigatorService.getUrlFromHref(href, entrypointUrl),
+          )
+        : routeIds.indexOf(id);
+      // Ensure each existing route is in the same order and hasn't been disrupted
+      if (!sequenceBroken && existingIndex !== i) {
+        sequenceBroken = true;
+      }
+      if (
+        existingIndex > -1 &&
+        !sequenceBroken &&
+        // Ensure the presentation matches
+        (isModal
+          ? state.routes[existingIndex].name === NavigatorService.ID_MODAL
+          : state.routes[existingIndex].name === NavigatorService.ID_CARD)
+      ) {
+        routes.push(state.routes[existingIndex]);
+      } else {
+        const params = options.routeParamList[id] || {};
         routes.push({
-          key: name,
-          name,
+          key: id,
+          name: id,
           params,
         });
       }
     }
-  });
+  }
 
   return {
     ...state,

--- a/src/core/components/navigator-stack/types.ts
+++ b/src/core/components/navigator-stack/types.ts
@@ -6,6 +6,8 @@
  *
  */
 
+import * as Contexts from 'hyperview/src/contexts';
+import * as NavigationContext from 'hyperview/src/contexts/navigation';
 import * as React from 'react';
 import { StackNavigationOptions } from '@react-navigation/stack';
 
@@ -33,8 +35,10 @@ export type RouterRenameOptions = RouterConfigOptions & {
 };
 
 export type StackOptions = {
-  id?: string;
+  docContextProps: Contexts.DocContextProps | null;
+  id: string;
   initialRouteName?: string;
+  navContextProps: NavigationContext.NavigationContextProps | null;
 };
 
 /**

--- a/src/services/navigator/helpers.test.ts
+++ b/src/services/navigator/helpers.test.ts
@@ -874,7 +874,7 @@ describe('mergeDocuments', () => {
   });
 });
 
-describe('add route', () => {
+describe('addStackRoute', () => {
   const doc = parser.parseFromString(navDocStackNavigatorSource);
 
   it('should find 2 route elements', () => {
@@ -886,34 +886,32 @@ describe('add route', () => {
     expect(routes.length).toEqual(2);
   });
 
-  describe('add stack route', () => {
-    addStackRoute(
-      doc,
-      'test-route',
-      { key: 'key1', name: 'card', params: { url: '/a/b/c' } },
-      'route1',
-      'http://foo.com',
-    );
+  addStackRoute(
+    doc,
+    'test-route',
+    { key: 'key1', name: 'card', params: { url: '/a/b/c' } },
+    'route1',
+    'http://foo.com',
+  );
 
-    const navigators = doc.getElementsByTagNameNS(
-      Namespaces.HYPERVIEW,
-      'navigator',
-    );
-    const routes = getChildElements(navigators[0]);
+  const navigators = doc.getElementsByTagNameNS(
+    Namespaces.HYPERVIEW,
+    'navigator',
+  );
+  const routes = getChildElements(navigators[0]);
 
-    it('should find 3 route elements', () => {
-      expect(routes.length).toEqual(3);
-    });
-
-    it('should contain added route', () => {
-      expect(routes[2].getAttribute('id')).toEqual('test-route');
-    });
-
-    removeStackRoute(doc, '/a/b/c', 'http://foo.com');
+  it('should find 3 route elements', () => {
+    expect(routes.length).toEqual(3);
   });
+
+  it('should contain added route', () => {
+    expect(routes[2].getAttribute('id')).toEqual('test-route');
+  });
+
+  removeStackRoute(doc, '/a/b/c', 'http://foo.com');
 });
 
-describe('find navigator by id', () => {
+describe('getNavigatorById', () => {
   const doc = parser.parseFromString(mergeSourceDisabledDoc);
 
   it('should find navigator', () => {

--- a/src/services/navigator/helpers.test.ts
+++ b/src/services/navigator/helpers.test.ts
@@ -4,18 +4,21 @@ import * as Namespaces from '../namespaces';
 import * as Types from './types';
 import { ID_CARD, ID_MODAL } from './types';
 import {
+  addStackRoute,
   buildParams,
   buildRequest,
   cleanHrefFragment,
   findPath,
   getChildElements,
   getNavAction,
+  getNavigatorById,
   getRouteId,
   getSelectedNavRouteElement,
   getUrlFromHref,
   isNavigationElement,
   isUrlFragment,
   mergeDocument,
+  removeStackRoute,
   validateUrl,
 } from './helpers';
 import { DOMParser } from '@instawork/xmldom';
@@ -126,6 +129,13 @@ const mergeSourceEnabledTabToStackDoc = `
   </navigator>
 </doc>
 `;
+
+/**
+ * Test stack navigator response
+ * Includes a navigator with two routes, the second of which is marked as selected
+ */
+const navDocStackNavigatorSource =
+  '<doc xmlns="https://hyperview.org/hyperview"><navigator id="navigator" type="stack"><nav-route id="route1" href="/route1" /><nav-route id="route2" href="/route2" selected="true" /></navigator></doc>';
 
 /**
  * Parser used to parse the document
@@ -861,5 +871,57 @@ describe('mergeDocuments', () => {
     it('should find 3 route elements on tabs-navigator', () => {
       expect(mergedTabRoutes.length).toEqual(3);
     });
+  });
+});
+
+describe('add route', () => {
+  const doc = parser.parseFromString(navDocStackNavigatorSource);
+
+  it('should find 2 route elements', () => {
+    const navigators = doc.getElementsByTagNameNS(
+      Namespaces.HYPERVIEW,
+      'navigator',
+    );
+    const routes = getChildElements(navigators[0]);
+    expect(routes.length).toEqual(2);
+  });
+
+  describe('add stack route', () => {
+    addStackRoute(
+      doc,
+      'test-route',
+      { key: 'key1', name: 'card', params: { url: '/a/b/c' } },
+      'route1',
+      'http://foo.com',
+    );
+
+    const navigators = doc.getElementsByTagNameNS(
+      Namespaces.HYPERVIEW,
+      'navigator',
+    );
+    const routes = getChildElements(navigators[0]);
+
+    it('should find 3 route elements', () => {
+      expect(routes.length).toEqual(3);
+    });
+
+    it('should contain added route', () => {
+      expect(routes[2].getAttribute('id')).toEqual('test-route');
+    });
+
+    removeStackRoute(doc, '/a/b/c', 'http://foo.com');
+  });
+});
+
+describe('find navigator by id', () => {
+  const doc = parser.parseFromString(mergeSourceDisabledDoc);
+
+  it('should find navigator', () => {
+    const navigator = getNavigatorById(doc, 'shift-navigator');
+    expect(navigator).toBeDefined();
+    if (navigator) {
+      const routes = getChildElements(navigator);
+      expect(routes.length).toEqual(2);
+    }
   });
 });

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -122,10 +122,12 @@ export {
 } from './imports';
 export { HvRouteError, HvNavigatorError, HvRenderError } from './errors';
 export {
+  addStackRoute,
   isDynamicRoute,
   isUrlFragment,
   cleanHrefFragment,
   getChildElements,
+  getNavigatorById,
   getRouteById,
   getSelectedNavRouteElement,
   getUrlFromHref,

--- a/src/services/navigator/types.ts
+++ b/src/services/navigator/types.ts
@@ -16,6 +16,7 @@ export const KEY_SELECTED = 'selected';
 export const KEY_MODAL = 'modal';
 export const KEY_ID = 'id';
 export const KEY_TYPE = 'type';
+export const KEY_HREF = 'href';
 
 /**
  * Definition of the available navigator types


### PR DESCRIPTION
An issue was identified where the deep link state of a stack navigator could be handled incorrectly when the incoming navigation didn't include changes to the stack navigator. At the same time, we decided to improve the logic of incoming state affects existing state.

We determined that in cases where a user has already opened views, and they match the order of the incoming deep link, they can remain with their existing state. For example:
- user clicks "company", then views deep link "company"
  - in this case, the user's action is identical to the deep link so their view remains including any existing state

This shows the original bug finding and its resolution

| Before | After |
| -- | -- |
| ![before](https://github.com/Instawork/hyperview/assets/127122858/aa824aba-0673-4f46-84b6-8070b9be42e6) | ![after](https://github.com/Instawork/hyperview/assets/127122858/841b0e1a-3d69-43e7-8e19-de883bba2d33) |

In the following examples, I have modified my "developer menu" to launch storybook directly.

| | |
| -- | -- |
| Launching storybook as a view or by deep link independently work as expected |  ![ex1](https://github.com/Instawork/hyperview/assets/127122858/4c96808f-2b5a-4b70-8f68-74e06ccdeb64) |
| Viewing storybook then triggering deep link retains state | ![ex2](https://github.com/Instawork/hyperview/assets/127122858/cf65ebe8-1c5d-44ad-82cb-3b009b89cb59) |
| Triggering deep link with company after storybook retains state (storybook in same sequential position) | ![ex3](https://github.com/Instawork/hyperview/assets/127122858/892f1f46-6b71-4a9a-a5bd-3938d52d2853) |
| Triggering deep link with storybook after company resets state (not same sequence) | ![ex4](https://github.com/Instawork/hyperview/assets/127122858/61cb3072-e70c-49c9-85b6-1e0d00eb78c4) |
| Triggering deep link with new base resets state (while storybook is still in same index, the changed base forces redraw) | ![ex5](https://github.com/Instawork/hyperview/assets/127122858/a7290f89-4d4d-4560-9ca3-49469d606a36) |


Asana: https://app.asana.com/0/1204008699308084/1205888765821740/f