### PR TITLE
fix: tab reset with deep link

### DIFF
--- a/src/core/components/navigator-stack/helpers.test.ts
+++ b/src/core/components/navigator-stack/helpers.test.ts
@@ -19,6 +19,20 @@ const navDocSourceThreeRoute =
   '<doc xmlns="https://hyperview.org/hyperview"><navigator id="navigator" type="stack"><nav-route id="route1" href="/route1" /><nav-route id="route2" href="/route2" /><nav-route id="route3" href="/route3"  /></navigator></doc>';
 
 /**
+ * Test document response
+ * Includes a navigator with two routes, the second being card, the third as modal
+ */
+const navDocSourceModal =
+  '<doc xmlns="https://hyperview.org/hyperview"><navigator id="navigator" type="stack"><nav-route id="route1" href="/route1" /><nav-route id="route2" href="/route2" modal="false" /><nav-route id="route3" href="/route3" modal="true" /></navigator></doc>';
+
+/**
+ * Test document response
+ * Includes a navigator with two routes, the second being card, the third as card
+ */
+const navDocSourceCard =
+  '<doc xmlns="https://hyperview.org/hyperview"><navigator id="navigator" type="stack"><nav-route id="route1" href="/route1" /><nav-route id="route2" href="/route2" modal="false" /><nav-route id="route3" href="/route3" modal="false" /></navigator></doc>';
+
+/**
  * Parser used to parse the document
  */
 const parser = new DOMParser({
@@ -180,6 +194,90 @@ describe('buildRoutesFromDom', () => {
     expect(routes[0].key).toEqual('key1');
     expect(routes[1].key).toEqual('key2');
     // The third route is the new one
+    expect(routes[2].key).toEqual('route3');
+  });
+
+  it('should change presentation to modal', () => {
+    const doc = parser.parseFromString(navDocSourceModal);
+    const state: StackNavigationState<Types.ParamListBase> = {
+      index: 0,
+      key: 'key1',
+      routeNames: ['route1'],
+      routes: [
+        {
+          key: 'key1',
+          name: 'route-1',
+          params: { id: 'route1', url: '/route1' },
+        },
+        {
+          key: 'key2',
+          name: 'card',
+          params: { id: 'route2', url: '/route2' },
+        },
+        {
+          key: 'key3',
+          name: 'card',
+          params: { id: 'route3', url: '/route3' },
+        },
+      ],
+      stale: false,
+      type: 'stack',
+    };
+    const routes = buildRoutesFromDom(
+      doc,
+      state,
+      'navigator',
+      routeParamList,
+      'http://foo.com',
+    );
+    // There are still three routes
+    expect(routes.length).toEqual(3);
+    // The first two are unchanged
+    expect(routes[0].key).toEqual('key1');
+    expect(routes[1].key).toEqual('key2');
+    // The third has been changed due to presentation difference
+    expect(routes[2].key).toEqual('route3');
+  });
+
+  it('should change presentation to card', () => {
+    const doc = parser.parseFromString(navDocSourceCard);
+    const state: StackNavigationState<Types.ParamListBase> = {
+      index: 0,
+      key: 'key1',
+      routeNames: ['route1'],
+      routes: [
+        {
+          key: 'key1',
+          name: 'route-1',
+          params: { id: 'route1', url: '/route1' },
+        },
+        {
+          key: 'key2',
+          name: 'card',
+          params: { id: 'route2', url: '/route2' },
+        },
+        {
+          key: 'key3',
+          name: 'modal',
+          params: { id: 'route3', url: '/route3' },
+        },
+      ],
+      stale: false,
+      type: 'stack',
+    };
+    const routes = buildRoutesFromDom(
+      doc,
+      state,
+      'navigator',
+      routeParamList,
+      'http://foo.com',
+    );
+    // There are still three routes
+    expect(routes.length).toEqual(3);
+    // The first two are unchanged
+    expect(routes[0].key).toEqual('key1');
+    expect(routes[1].key).toEqual('key2');
+    // The third has been changed due to presentation difference
     expect(routes[2].key).toEqual('route3');
   });
 });

--- a/src/core/components/navigator-stack/helpers.ts
+++ b/src/core/components/navigator-stack/helpers.ts
@@ -57,10 +57,11 @@ export const buildRoutesFromDom = (
       if (
         existingIndex > -1 &&
         !sequenceBroken &&
-        // Ensure the presentation matches
-        (isModal
-          ? state.routes[existingIndex].name === ID_MODAL
-          : state.routes[existingIndex].name === ID_CARD)
+        // Ensure the presentation matches for dynamic screens
+        (!NavigatorHelpers.isDynamicRoute(state.routes[existingIndex].name) ||
+          (isModal
+            ? state.routes[existingIndex].name === ID_MODAL
+            : state.routes[existingIndex].name === ID_CARD))
       ) {
         routes.push(state.routes[existingIndex]);
       } else {


### PR DESCRIPTION
When a deep link is processed which does not set a new tab, the existing tab should remain selected.

The logic which checked for presentation changes wasn't accounting for routes which aren't dynamically added.

| Before | After |
| -- | -- |
| ![before](https://github.com/Instawork/hyperview/assets/127122858/7b5bab08-7548-40b9-ac5c-827515bc37a3) | ![after](https://github.com/Instawork/hyperview/assets/127122858/268f00d2-630c-4724-ad4a-9822ee149e16) |

Asana: https://app.asana.com/0/1204008699308084/1205979074786687/f
