### PR TITLE
chore: clean up import spaces

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -40,6 +40,15 @@
     "instawork/stories-components": "error",
     "instawork/stories-navbars": "error",
     "instawork/stories-screens": "error",
+    "padding-line-between-statements": "off",
+    "@typescript-eslint/padding-line-between-statements": [
+      "error",
+      {
+        "blankLine": "never",
+        "prev": "import",
+        "next": "import"
+      }
+    ],
     "react/destructuring-assignment": "error",
     "react/jsx-sort-props": "error",
     "sort-keys": "error"

--- a/demo/src/HandleBack.ts
+++ b/demo/src/HandleBack.ts
@@ -10,7 +10,6 @@ import { useFocusEffect, useNavigation, useNavigationState, useRoute } from '@re
 import { BackHandler } from 'react-native';
 import React from 'react';
 import type { RouteProp } from '@react-navigation/core';
-import type { RouteParams } from './types';
 
 export default ({ children }: { children: JSX.Element }) => {
   const route = useRoute<RouteProp<any>>();

--- a/demo/src/HyperviewScreen.tsx
+++ b/demo/src/HyperviewScreen.tsx
@@ -14,7 +14,6 @@ import type { NavigationRouteParams } from 'hyperview';
 import React from 'react';
 import { fetchWrapper, formatDate } from './helpers';
 
-
 export default (props: Props) => {
   const entrypointUrl = props.route.params?.url;
 

--- a/src/components/hv-date-field/field/types.ts
+++ b/src/components/hv-date-field/field/types.ts
@@ -7,7 +7,6 @@
  */
 
 import type { HvComponentOptions, StyleSheets } from 'hyperview/src/types';
-
 import { ReactNode } from 'react';
 
 export type Props = {

--- a/src/contexts/navigation.ts
+++ b/src/contexts/navigation.ts
@@ -13,9 +13,7 @@ import type {
   Reload,
   Route,
 } from 'hyperview/src/types';
-
 import React, { ComponentType, ReactNode } from 'react';
-
 import type { Props as ErrorProps } from 'hyperview/src/core/components/load-error';
 import type { Props as LoadingProps } from 'hyperview/src/core/components/loading';
 

--- a/src/core/components/modal/types.ts
+++ b/src/core/components/modal/types.ts
@@ -11,7 +11,6 @@ import type {
   HvComponentOptions,
   StyleSheets,
 } from 'hyperview/src/types';
-
 import type { ReactNode } from 'react';
 
 export type Props = {

--- a/src/core/components/navigator-stack/index.tsx
+++ b/src/core/components/navigator-stack/index.tsx
@@ -11,7 +11,6 @@ import * as CustomStackRouter from 'hyperview/src/core/components/navigator-stac
 import * as NavigationContext from 'hyperview/src/contexts/navigation';
 import * as React from 'react';
 import * as Types from './types';
-
 import {
   StackActionHelpers,
   StackNavigationState,

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,6 @@ import * as Stylesheets from './services/stylesheets';
 import Navigation from './services/navigation';
 import type { Route as NavigatorRoute } from './services/navigator';
 import type React from 'react';
-
 import type { XResponseStaleReason } from './services/dom/types';
 
 export type DOMString = string;


### PR DESCRIPTION
Manually removed extra spaces.
Added `padding-line-between-statements` linting rule to error when there's spaces between imports. Comments or linting overrides are allowed.

Rule info:
- https://typescript-eslint.io/rules/padding-line-between-statements/
- https://eslint.org/docs/latest/rules/padding-line-between-statements#rule-details


https://github.com/Instawork/hyperview/assets/127122858/1106233c-424d-4df2-929a-3d72857b020b



Asana: https://app.asana.com/0/1204323441804469/1205761921034729/f