### PR TITLE
fix: format single digit months in date-field

### DIFF
--- a/src/components/hv-date-field/index.test.ts
+++ b/src/components/hv-date-field/index.test.ts
@@ -61,4 +61,22 @@ describe('HvDateField', () => {
       );
     });
   });
+
+  describe('createDateFromString', () => {
+    it('returns null if no date', () => {
+      expect(HvDateField.createDateFromString(null)).toBeNull();
+    });
+
+    it('returns correct date for double digit month', () => {
+      expect(HvDateField.createDateFromString('2023-11-12')).toEqual(
+        new Date(2023, 10, 12),
+      );
+    });
+
+    it('returns correct date for single digit month', () => {
+      expect(HvDateField.createDateFromString('2023-07-12')).toEqual(
+        new Date(2023, 6, 12),
+      );
+    });
+  });
 });

--- a/src/components/hv-date-field/index.test.ts
+++ b/src/components/hv-date-field/index.test.ts
@@ -43,4 +43,22 @@ describe('HvDateField', () => {
       expect(HvDateField.getFormInputValues(elements[2])).toEqual([]);
     });
   });
+
+  describe('createStringFromDate', () => {
+    it('returns empty string if no date', () => {
+      expect(HvDateField.createStringFromDate(null)).toEqual('');
+    });
+
+    it('returns correct string for double digit month', () => {
+      expect(HvDateField.createStringFromDate(new Date(2023, 10, 12))).toEqual(
+        '2023-11-12',
+      );
+    });
+
+    it('returns correct string for single digit month', () => {
+      expect(HvDateField.createStringFromDate(new Date(2023, 6, 12))).toEqual(
+        '2023-07-12',
+      );
+    });
+  });
 });

--- a/src/components/hv-date-field/index.tsx
+++ b/src/components/hv-date-field/index.tsx
@@ -49,7 +49,7 @@ export default class HvDateField extends PureComponent<HvComponentProps> {
       return '';
     }
     const year = date.getFullYear();
-    const month = date.getMonth() + 1;
+    const month = `${date.getMonth() + 1}`.padStart(2, '0');
     const day = date.getDate();
     return `${year}-${month}-${day}`;
   };


### PR DESCRIPTION
Fixes #757 

Previously, dates where the month is a single digit (January – September / 1 - 9) created formatted dates like `2023-1-27`. This would break parsing the date as an ISO string in certain languages.

This PR pads the month part with a leading zero to make it correctly formatted as `YYYY-MM-DD`.