### PR TITLE
fix: avoid multiple DOM mutations for dynamic stack navigator

### DIFF
--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -337,7 +337,7 @@ export default class HvNavigator extends PureComponent<Props> {
       const route: Element | null = props.doc.getElementById(
         this.props.params.id,
       );
-      if (route) {
+      if (route && !NavigatorService.getNavigatorById(props.doc, navigatorId)) {
         const navigator = props.doc.createElementNS(
           Namespaces.HYPERVIEW,
           LOCAL_NAME.NAVIGATOR,
@@ -349,7 +349,6 @@ export default class HvNavigator extends PureComponent<Props> {
           LOCAL_NAME.NAV_ROUTE,
         );
         screen.setAttribute('id', screenId);
-        screen.setAttribute('url', this.props.params?.url || '');
         navigator.appendChild(screen);
         route.appendChild(navigator);
       }


### PR DESCRIPTION
When the component is re-rendered, there was a possibility of adding a duplicate node into the DOM.

This is a follow up to the work from https://github.com/Instawork/hyperview/pull/760

Asana: https://app.asana.com/0/1204008699308084/1206058760311122/f