### PR TITLE
chore: validate non-empty href in behaviors

### DIFF
--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -384,7 +384,7 @@
   <xs:attributeGroup name="behaviorAttributes">
     <xs:attribute name="action" type="hv:action" />
     <xs:attribute name="target" type="hv:IDREF" />
-    <xs:attribute name="href" type="xs:string" />
+    <xs:attribute name="href" type="hv:nonEmptyString" />
     <xs:attribute name="href-style" type="hv:styleList" />
     <xs:attribute name="once" type="xs:boolean" />
     <xs:attribute name="trigger" type="hv:trigger" />
@@ -1259,6 +1259,12 @@
     <xs:restriction base="xs:string">
       <xs:enumeration value="stack" />
       <xs:enumeration value="tab" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="nonEmptyString">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1" />
     </xs:restriction>
   </xs:simpleType>
 

--- a/test/schema/behavior/empty_href.xml
+++ b/test/schema/behavior/empty_href.xml
@@ -1,0 +1,10 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <body>
+      <view id="test-view">
+        <!-- This is an invalid behavior because it has an empty href -->
+        <!-- <behavior href="" /> -->
+      </view>
+    </body>
+  </screen>
+</doc>

--- a/test/schema/behavior/full_href.xml
+++ b/test/schema/behavior/full_href.xml
@@ -1,0 +1,9 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <body>
+      <view id="test-view">
+        <behavior href="http://localhost:8085/test" />
+      </view>
+    </body>
+  </screen>
+</doc>

--- a/test/schema/behavior/hash_href.xml
+++ b/test/schema/behavior/hash_href.xml
@@ -1,0 +1,9 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <body>
+      <view id="test-view">
+        <behavior href="#" />
+      </view>
+    </body>
+  </screen>
+</doc>

--- a/test/schema/behavior/omit_href.xml
+++ b/test/schema/behavior/omit_href.xml
@@ -1,0 +1,9 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <body>
+      <view id="test-view">
+        <behavior />
+      </view>
+    </body>
+  </screen>
+</doc>


### PR DESCRIPTION
Adding a new type `nonEmptyString` to validate an entry is not empty. The `href` attribute of `behaviorAttributes` is not required so may be omitted. If not omitted, it must have a value.

There is no "notEmpty" type in the XSD 1.0 spec. The following existing types did not serve our needs:
- xs:string - allows empty strings
- xs:Name - doesn't support necessary characters. http://www.datypic.com/sc/xsd/t-xsd_Name.html
- xs:NMTOKEN - doesn't support necessary characters. http://www.datypic.com/sc/xsd/t-xsd_NMTOKEN.html
- xs:normalizedString - allows empty strings. http://www.datypic.com/sc/xsd/t-xsd_normalizedString.html

So we created a new type.

In the test below, the `empty_href.xml` contains a behavior with an empty href. In the checked in code, this line is commented out.

```
yarn test:validate-xml
test/schema/behavior/full_href.xml validates
test/schema/behavior/hash_href.xml validates
test/schema/behavior/omit_href.xml validates
test/schema/behavior/empty_href.xml:5: element behavior: Schemas validity error : Element '{https://hyperview.org/hyperview}behavior', attribute 'href': [facet 'minLength'] The value '' has a length of '0'; this underruns the allowed minimum length of '1'.
test/schema/behavior/empty_href.xml fails to validate
```


Asana: https://app.asana.com/0/1204008699308084/1206114436157349/f