### PR TITLE
fix: refresh control should only be added when a refresh trigger exists

### DIFF
--- a/src/components/hv-list/index.tsx
+++ b/src/components/hv-list/index.tsx
@@ -242,6 +242,8 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
       <Contexts.RefreshControlComponentContext.Consumer>
         {ContextRefreshControl => {
           const RefreshControl = ContextRefreshControl || DefaultRefreshControl;
+          const hasRefreshTrigger =
+            this.props.element.getAttribute('trigger') === 'refresh';
           return (
             <FlatList
               ref={this.onRef}
@@ -253,10 +255,12 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               keyExtractor={(item: any) => item && item.getAttribute('key')}
               refreshControl={
-                <RefreshControl
-                  onRefresh={this.refresh}
-                  refreshing={this.state.refreshing}
-                />
+                hasRefreshTrigger ? (
+                  <RefreshControl
+                    onRefresh={this.refresh}
+                    refreshing={this.state.refreshing}
+                  />
+                ) : undefined
               }
               removeClippedSubviews={false}
               // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/hv-section-list/index.tsx
+++ b/src/components/hv-section-list/index.tsx
@@ -355,6 +355,8 @@ export default class HvSectionList extends PureComponent<
       <Contexts.RefreshControlComponentContext.Consumer>
         {ContextRefreshControl => {
           const RefreshControl = ContextRefreshControl || DefaultRefreshControl;
+          const hasRefreshTrigger =
+            this.props.element.getAttribute('trigger') === 'refresh';
           return (
             <SectionList
               ref={this.onRef}
@@ -364,10 +366,12 @@ export default class HvSectionList extends PureComponent<
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               keyExtractor={(item: any) => item.getAttribute('key')}
               refreshControl={
-                <RefreshControl
-                  onRefresh={this.refresh}
-                  refreshing={this.state.refreshing}
-                />
+                hasRefreshTrigger ? (
+                  <RefreshControl
+                    onRefresh={this.refresh}
+                    refreshing={this.state.refreshing}
+                  />
+                ) : undefined
               }
               removeClippedSubviews={false}
               // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Check for the "refresh" trigger before adding the <RefreshControl> to `list` and `section-list`.

Confirmed in Pro app and HV Demo.

Fixes https://instawork.sentry.io/issues/4682025463/
Fixes https://instawork.sentry.io/issues/4585045549/

Sentry: this should resolve any of the `Error: No href passed to fetchElement` errors which contain `hyperview/worker_app/helpdesk-parent` at the end of the breadcrumbs.

| Before | After |
| -- | -- |
| ![before](https://github.com/Instawork/hyperview/assets/127122858/edfab479-4471-462a-8aec-eb4be370cdb3) | ![after](https://github.com/Instawork/hyperview/assets/127122858/676cd54d-2abc-4f95-ba83-6ee6c05786fa) |

Asana: https://app.asana.com/0/1204008699308084/1206114436157353/f
