### PR TITLE
chore: cleanup hv-route state

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -64,19 +64,6 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps> {
     this.navigation = new Navigation(props.entrypointUrl, this.getNavigation());
   }
 
-  /**
-   * Override the state to clear the doc when an element is passed
-   */
-  static getDerivedStateFromProps(
-    props: Types.InnerRouteProps,
-    state: ScreenState,
-  ) {
-    if (props.element) {
-      return { ...state, doc: null };
-    }
-    return state;
-  }
-
   componentDidMount() {
     this.parser = new DomService.Parser(
       this.props.fetch,


### PR DESCRIPTION
This function is no longer relevant. It was used to override the returned state when a deep link changed the hierarchy and the state should no longer return a document. This functionality is out of date because:
- The class no longer owns its state
- The class is wrapped with a state context based on the presence of an element