### PR TITLE
chore: externalize hv-route props

### DIFF
--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import * as Navigation from 'hyperview/src/services/navigation';
 import * as NavigatorService from 'hyperview/src/services/navigator';
 import { ComponentType, ReactNode } from 'react';
 import {
@@ -53,6 +54,35 @@ export type RouteProps = NavigatorService.Route<string, { url?: string }>;
 /**
  * The props used by inner components of hv-route
  */
+export type FCProps = {
+  url?: string;
+  navigation?: NavigatorService.NavigationProp;
+  route?: NavigatorService.Route<string, RouteParams>;
+  entrypointUrl: string;
+  fetch: Fetch;
+  onError?: (error: Error) => void;
+  onParseAfter?: (url: string) => void;
+  onParseBefore?: (url: string) => void;
+  onUpdate: HvComponentOnUpdate;
+  behaviors?: HvBehavior[];
+  components?: HvComponent[];
+  elementErrorComponent?: ComponentType<ErrorProps>;
+  errorScreen?: ComponentType<ErrorProps>;
+  loadingScreen?: ComponentType<LoadingProps>;
+  handleBack?: ComponentType<{ children: ReactNode }>;
+  setPreload: (key: number, element: Element) => void;
+  getPreload: (key: number) => Element | undefined;
+  element?: Element;
+  reload: Reload;
+  getState: () => ScreenState;
+  setState: SetState;
+  onRouteBlur?: (route: Route) => void;
+  onRouteFocus?: (route: Route) => void;
+};
+
+/**
+ * The props used by inner components of hv-route
+ */
 export type InnerRouteProps = {
   url?: string;
   navigation?: NavigatorService.NavigationProp;
@@ -77,6 +107,9 @@ export type InnerRouteProps = {
   setState: SetState;
   onRouteBlur?: (route: Route) => void;
   onRouteFocus?: (route: Route) => void;
+  needsLoad: React.MutableRefObject<boolean>;
+  navigator: React.MutableRefObject<NavigatorService.Navigator>;
+  navigationService: React.MutableRefObject<Navigation.default>;
 };
 
 /**


### PR DESCRIPTION
Moving the props out of the class into the FC as a first step in externalizing the onUpdate.