### PR TITLE
chore: move onUpdate into hv-route FC

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -184,41 +184,6 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps> {
   };
 
   /**
-   * Implement the callbacks from this class
-   */
-  updateCallbacks = {
-    clearElementError: () => {
-      // Noop
-    },
-    getDoc: () => this.context.getState().doc || null,
-    getNavigation: () => this.props.navigationService.current,
-    getOnUpdate: () => this.onUpdate,
-    getState: () => this.context.getState(),
-    registerPreload: (id: number, element: Element) =>
-      this.props.setPreload(id, element),
-    setNeedsLoad: () => {
-      if (this.props.needsLoad) {
-        this.props.needsLoad.current = true;
-      }
-    },
-    setState: (state: ScreenState) => {
-      this.context.setState(state);
-    },
-  };
-
-  onUpdate = (
-    href: DOMString | null | undefined,
-    action: DOMString | null | undefined,
-    element: Element,
-    options: HvComponentOptions,
-  ) => {
-    this.props.onUpdate(href, action, element, {
-      ...options,
-      onUpdateCallbacks: this.updateCallbacks,
-    });
-  };
-
-  /**
    * View shown while loading
    * Includes preload functionality
    */
@@ -479,6 +444,39 @@ function RouteFC(props: Types.FCProps) {
       push: navigator.current.push,
     }),
   );
+
+  /**
+   * Implement the callbacks from this class
+   */
+  const updateCallbacks = {
+    clearElementError: () => {
+      // Noop
+    },
+    getDoc: () => stateContext.getState().doc || null,
+    getNavigation: () => navigationService.current,
+    getOnUpdate: () => onUpdate,
+    getState: () => stateContext.getState(),
+    registerPreload: (id: number, element: Element) =>
+      props.setPreload(id, element),
+    setNeedsLoad: () => {
+      needsLoad.current = true;
+    },
+    setState: (state: ScreenState) => {
+      stateContext.setState(state);
+    },
+  };
+
+  const onUpdate = (
+    href: DOMString | null | undefined,
+    action: DOMString | null | undefined,
+    element: Element,
+    options: HvComponentOptions,
+  ) => {
+    props.onUpdate(href, action, element, {
+      ...options,
+      onUpdateCallbacks: updateCallbacks,
+    });
+  };
 
   React.useEffect(() => {
     if (navigation) {

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import * as Navigation from 'hyperview/src/services/navigation';
 import * as NavigatorService from 'hyperview/src/services/navigator';
 import { ComponentType, ReactNode } from 'react';
 import {
@@ -53,6 +54,35 @@ export type RouteProps = NavigatorService.Route<string, { url?: string }>;
 /**
  * The props used by inner components of hv-route
  */
+export type FCProps = {
+  url?: string;
+  navigation?: NavigatorService.NavigationProp;
+  route?: NavigatorService.Route<string, RouteParams>;
+  entrypointUrl: string;
+  fetch: Fetch;
+  onError?: (error: Error) => void;
+  onParseAfter?: (url: string) => void;
+  onParseBefore?: (url: string) => void;
+  onUpdate: HvComponentOnUpdate;
+  behaviors?: HvBehavior[];
+  components?: HvComponent[];
+  elementErrorComponent?: ComponentType<ErrorProps>;
+  errorScreen?: ComponentType<ErrorProps>;
+  loadingScreen?: ComponentType<LoadingProps>;
+  handleBack?: ComponentType<{ children: ReactNode }>;
+  setPreload: (key: number, element: Element) => void;
+  getPreload: (key: number) => Element | undefined;
+  element?: Element;
+  reload: Reload;
+  getState: () => ScreenState;
+  setState: SetState;
+  onRouteBlur?: (route: Route) => void;
+  onRouteFocus?: (route: Route) => void;
+};
+
+/**
+ * The props used by inner components of hv-route
+ */
 export type InnerRouteProps = {
   url?: string;
   navigation?: NavigatorService.NavigationProp;
@@ -77,6 +107,9 @@ export type InnerRouteProps = {
   setState: SetState;
   onRouteBlur?: (route: Route) => void;
   onRouteFocus?: (route: Route) => void;
+  needsLoad: React.MutableRefObject<boolean>;
+  navigator: React.MutableRefObject<NavigatorService.Navigator>;
+  navigationService: React.MutableRefObject<Navigation.default>;
 };
 
 /**


### PR DESCRIPTION
Moving the onUpdate out of the class into the FC. This unblocks using the onUpdate method within the FC directly while still allowing it to be triggered externally when necessary.