### PR TITLE
fix: getElementById errors

### DIFF
--- a/src/behaviors/hv-hide/index.ts
+++ b/src/behaviors/hv-hide/index.ts
@@ -7,6 +7,7 @@
  */
 
 import * as Behaviors from 'hyperview/src/services/behaviors';
+import * as Dom from 'hyperview/src/services/dom';
 import * as Xml from 'hyperview/src/services/xml';
 import type {
   DOMString,
@@ -44,7 +45,8 @@ export default {
 
     const hideElement = () => {
       const doc: Document | null = getRoot();
-      const targetElement: Element | null | undefined = doc?.getElementById(
+      const targetElement: Element | null | undefined = Dom.getElementById(
+        doc,
         targetId,
       );
       if (!targetElement) {

--- a/src/behaviors/hv-select-all/index.ts
+++ b/src/behaviors/hv-select-all/index.ts
@@ -7,6 +7,7 @@
  */
 
 import * as Behaviors from 'hyperview/src/services/behaviors';
+import * as Dom from 'hyperview/src/services/dom';
 import * as Xml from 'hyperview/src/services/xml';
 import type {
   DOMString,
@@ -46,7 +47,8 @@ export default {
 
     const selectAll = () => {
       const doc: Document | null = getRoot();
-      const targetElement: Element | null | undefined = doc?.getElementById(
+      const targetElement: Element | null | undefined = Dom.getElementById(
+        doc,
         targetId,
       );
       if (!targetElement) {

--- a/src/behaviors/hv-set-value/index.ts
+++ b/src/behaviors/hv-set-value/index.ts
@@ -7,6 +7,7 @@
  */
 
 import * as Behaviors from 'hyperview/src/services/behaviors';
+import * as Dom from 'hyperview/src/services/dom';
 import * as Xml from 'hyperview/src/services/xml';
 import type {
   DOMString,
@@ -47,7 +48,8 @@ export default {
 
     const setValue = () => {
       const doc: Document | null = getRoot();
-      const targetElement: Element | null | undefined = doc?.getElementById(
+      const targetElement: Element | null | undefined = Dom.getElementById(
+        doc,
         targetId,
       );
       if (!targetElement) {

--- a/src/behaviors/hv-show/index.ts
+++ b/src/behaviors/hv-show/index.ts
@@ -7,6 +7,7 @@
  */
 
 import * as Behaviors from 'hyperview/src/services/behaviors';
+import * as Dom from 'hyperview/src/services/dom';
 import * as Xml from 'hyperview/src/services/xml';
 import type {
   DOMString,
@@ -44,7 +45,8 @@ export default {
 
     const showElement = () => {
       const doc: Document | null = getRoot();
-      const targetElement: Element | null | undefined = doc?.getElementById(
+      const targetElement: Element | null | undefined = Dom.getElementById(
+        doc,
         targetId,
       );
       if (!targetElement) {

--- a/src/behaviors/hv-toggle/index.ts
+++ b/src/behaviors/hv-toggle/index.ts
@@ -7,6 +7,7 @@
  */
 
 import * as Behaviors from 'hyperview/src/services/behaviors';
+import * as Dom from 'hyperview/src/services/dom';
 import * as Xml from 'hyperview/src/services/xml';
 import type {
   DOMString,
@@ -44,7 +45,8 @@ export default {
 
     const toggleElement = () => {
       const doc: Document | null = getRoot();
-      const targetElement: Element | null | undefined = doc?.getElementById(
+      const targetElement: Element | null | undefined = Dom.getElementById(
+        doc,
         targetId,
       );
       if (!targetElement) {

--- a/src/behaviors/hv-unselect-all/index.ts
+++ b/src/behaviors/hv-unselect-all/index.ts
@@ -7,6 +7,7 @@
  */
 
 import * as Behaviors from 'hyperview/src/services/behaviors';
+import * as Dom from 'hyperview/src/services/dom';
 import * as Xml from 'hyperview/src/services/xml';
 import type {
   DOMString,
@@ -46,7 +47,8 @@ export default {
 
     const unselectAll = () => {
       const doc: Document | null = getRoot();
-      const targetElement: Element | null | undefined = doc?.getElementById(
+      const targetElement: Element | null | undefined = Dom.getElementById(
+        doc,
         targetId,
       );
       if (!targetElement) {

--- a/src/components/hv-list/index.tsx
+++ b/src/components/hv-list/index.tsx
@@ -74,7 +74,8 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
     }
     const doc: Document | null | undefined =
       typeof this.context === 'function' ? this.context() : null;
-    const targetElement: Element | null | undefined = doc?.getElementById(
+    const targetElement: Element | null | undefined = Dom.getElementById(
+      doc,
       targetId,
     );
     if (!targetElement) {

--- a/src/components/hv-section-list/index.tsx
+++ b/src/components/hv-section-list/index.tsx
@@ -113,7 +113,8 @@ export default class HvSectionList extends PureComponent<
     }
     const doc: Document | null =
       typeof this.context === 'function' ? this.context() : null;
-    const targetElement: Element | null | undefined = doc?.getElementById(
+    const targetElement: Element | null | undefined = Dom.getElementById(
+      doc,
       targetId,
     );
     if (!targetElement) {

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -334,9 +334,8 @@ export default class HvNavigator extends PureComponent<Props> {
 
     // Mutate the dom to match
     if (props.doc) {
-      const route: Element | null = props.doc.getElementById(
-        this.props.params.id,
-      );
+      const route: Element | null =
+        Dom.getElementById(props.doc, this.props.params.id) || null;
       if (route && !NavigatorService.getNavigatorById(props.doc, navigatorId)) {
         const navigator = props.doc.createElementNS(
           Namespaces.HYPERVIEW,

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -163,7 +163,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
     }
 
     if (href[0] === '#') {
-      const element = root.getElementById(href.slice(1));
+      const element = Dom.getElementById(root, href.slice(1));
       if (element) {
         return element.cloneNode(true) as Element;
       }
@@ -388,7 +388,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
           // If a target is specified and exists, use it. Otherwise, the action target defaults
           // to the element triggering the action.
           let targetElement = targetId
-            ? onUpdateCallbacks.getDoc()?.getElementById(targetId)
+            ? Dom.getElementById(onUpdateCallbacks.getDoc(), targetId)
             : element;
           if (!targetElement) {
             targetElement = element;

--- a/src/services/behaviors/index.ts
+++ b/src/services/behaviors/index.ts
@@ -31,7 +31,8 @@ export const toggleIndicators = (
   root: Document,
 ): Document =>
   ids.reduce((newRoot, id) => {
-    const indicatorElement: Element | null | undefined = newRoot.getElementById(
+    const indicatorElement: Element | null | undefined = Dom.getElementById(
+      newRoot,
       id,
     );
     if (!indicatorElement) {

--- a/src/services/dom/errors.ts
+++ b/src/services/dom/errors.ts
@@ -92,7 +92,7 @@ const docToString = (doc: Document): string => {
   try {
     const serializer = new XMLSerializer();
     return serializer.serializeToString(doc);
-  } catch {
-    return 'serializing error';
+  } catch (e) {
+    return `serializing error: ${e.message}`;
   }
 };

--- a/src/services/dom/errors.ts
+++ b/src/services/dom/errors.ts
@@ -93,6 +93,7 @@ const docToString = (doc: Document): string => {
     const serializer = new XMLSerializer();
     return serializer.serializeToString(doc);
   } catch (e) {
-    return `serializing error: ${e.message}`;
+    const error = e as Error;
+    return error ? `serializing error: ${error.message}` : 'serializing error';
   }
 };

--- a/src/services/dom/errors.ts
+++ b/src/services/dom/errors.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 /**
  * Copyright (c) Garuda Labs, Inc.
  *
@@ -6,7 +7,9 @@
  *
  */
 
+import * as ErrorService from 'hyperview/src/services/error';
 import type { LocalName } from 'hyperview/src/types';
+import { XMLSerializer } from '@instawork/xmldom';
 
 export class UnsupportedContentTypeError extends Error {
   name = 'UnsupportedContentTypeError';
@@ -68,5 +71,19 @@ export class ServerError extends Error {
     this.responseText = responseText;
     this.responseHeaders = responseHeaders;
     this.status = status;
+  }
+}
+
+export class DocumentGetElementByIdError extends ErrorService.HvBaseError {
+  name = 'DocumentGetElementByIdError';
+
+  constructor(id: string, doc: Document, error: Error) {
+    super(
+      `Document.getElementById failed for id: ${id} on doc: ${new XMLSerializer().serializeToString(
+        doc,
+      )} and error: ${error.message}`,
+    );
+    this.stack = error.stack;
+    this.setExtraContext('error', error);
   }
 }

--- a/src/services/dom/errors.ts
+++ b/src/services/dom/errors.ts
@@ -79,7 +79,7 @@ export class DocumentGetElementByIdError extends ErrorService.HvBaseError {
 
   constructor(id: string, doc: Document, error: Error) {
     super(
-      `Document.getElementById failed for id: ${id} on doc: ${new XMLSerializer().serializeToString(
+      `Document.getElementById failed for id: ${id} on doc: ${docToString(
         doc,
       )} and error: ${error.message}`,
     );
@@ -87,3 +87,12 @@ export class DocumentGetElementByIdError extends ErrorService.HvBaseError {
     this.setExtraContext('error', error);
   }
 }
+
+const docToString = (doc: Document): string => {
+  try {
+    const serializer = new XMLSerializer();
+    return serializer.serializeToString(doc);
+  } catch {
+    return 'serializing error';
+  }
+};

--- a/src/services/dom/helpers.ts
+++ b/src/services/dom/helpers.ts
@@ -8,6 +8,7 @@
 
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import type { LocalName, NamespaceURI, NodeType } from 'hyperview/src/types';
+import { DocumentGetElementByIdError } from './errors';
 import { NODE_TYPE } from 'hyperview/src/types';
 
 export const getBehaviorElements = (element: Element) => {
@@ -102,21 +103,17 @@ export const getElementById = (
   if (!doc) {
     return doc;
   }
+
   try {
-    return doc.getElementById(id);
-  } catch {
-    let found = null;
-    try {
-      if (!isDoc(doc)) {
-        const element = doc as Element;
-        found = element.ownerDocument
-          ? element.ownerDocument.getElementById(id)
-          : null;
-      }
-    } catch (e) {
-      throw new Error(`getElementById failed for id: ${id} and error: ${e}`);
+    if (isDoc(doc)) {
+      return doc.getElementById(id);
     }
-    return found;
+    const element = doc as Element;
+    return element.ownerDocument
+      ? element.ownerDocument.getElementById(id)
+      : null;
+  } catch (e) {
+    throw new DocumentGetElementByIdError(id, doc, e as Error);
   }
 };
 

--- a/src/services/dom/helpers.ts
+++ b/src/services/dom/helpers.ts
@@ -90,3 +90,36 @@ export const preorder = (
   }
   return acc;
 };
+
+/**
+ * Attempt to find an element by id in the given node
+ * Handle cases where an element is passed in instead of a document
+ */
+export const getElementById = (
+  doc: Document | null | undefined,
+  id: string,
+): Element | null | undefined => {
+  if (!doc) {
+    return doc;
+  }
+  try {
+    return doc.getElementById(id);
+  } catch {
+    let found = null;
+    try {
+      if (!isDoc(doc)) {
+        const element = doc as Element;
+        found = element.ownerDocument
+          ? element.ownerDocument.getElementById(id)
+          : null;
+      }
+    } catch (e) {
+      throw new Error(`getElementById failed for id: ${id} and error: ${e}`);
+    }
+    return found;
+  }
+};
+
+function isDoc(object: Element | Document): object is Element | Document {
+  return 'getElementById' in object;
+}


### PR DESCRIPTION
Attempting to reduce getElementById errors by evaluating whether the passed object is an element. Barring success, improve error logs to include the id being retrieved.

The bug is not easily reproducible locally, putting this into the next release should give us more information into what's happening.

Example of the existing error: https://instawork.sentry.io/issues/4653618920/?query=getElementById&referrer=issue-stream&sort=freq&statsPeriod=30d&stream_index=1

Asana: https://app.asana.com/0/1204008699308084/1205467413007358/f