### PR TITLE
fix: deep links with behaviors are failing to trigger

### DIFF
--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -6,10 +6,10 @@
  *
  */
 
-import type { HvComponentOnUpdate, ScreenState } from 'hyperview/src/types';
 import type { ComponentType } from 'react';
 import React from 'react';
 import type { RefreshControlProps } from 'react-native';
+import type { ScreenState } from 'hyperview/src/types';
 
 // Provides the date format function to use in date fields
 // in the screen. Default to ISO string format.
@@ -23,11 +23,6 @@ export const DateFormatContext = React.createContext<
 export const RefreshControlComponentContext = React.createContext<
   ComponentType<RefreshControlProps> | undefined
 >(undefined);
-
-export const OnUpdateContext = React.createContext<{
-  onUpdate: HvComponentOnUpdate;
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-}>({ onUpdate: () => {} });
 
 export type SetState = (
   state:

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -319,16 +319,12 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps> {
 
     if (isModal || renderElement?.localName === LOCAL_NAME.NAVIGATOR) {
       return (
-        <Contexts.OnUpdateContext.Consumer>
-          {updater => (
-            <HvNavigator
-              element={renderElement}
-              onUpdate={updater.onUpdate}
-              params={this.props.route?.params}
-              routeComponent={HvRoute}
-            />
-          )}
-        </Contexts.OnUpdateContext.Consumer>
+        <HvNavigator
+          element={renderElement}
+          onUpdate={this.props.onUpdate}
+          params={this.props.route?.params}
+          routeComponent={HvRoute}
+        />
       );
     }
 

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -556,7 +556,7 @@ function RouteFC(props: Types.FCProps) {
   return (
     <HvRouteInner
       // eslint-disable-next-line react/jsx-props-no-spreading
-      {...{ ...props, navigationService, navigator, needsLoad }}
+      {...{ ...props, navigationService, navigator, needsLoad, onUpdate }}
     />
   );
 }


### PR DESCRIPTION
The onUpdate context is no longer needed but was passing a default implementation down to children. Removing the context and using the onUpdate passed by props resolves the bug and cleans up the code.

Asana: https://app.asana.com/0/1204008699308084/1206198337202880/f