### PR TITLE
fix: navigator load behaviors

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -556,7 +556,7 @@ function RouteFC(props: Types.FCProps) {
   return (
     <HvRouteInner
       // eslint-disable-next-line react/jsx-props-no-spreading
-      {...{ ...props, navigationService, navigator, needsLoad, onUpdate }}
+      {...{ ...props, navigationService, navigator, needsLoad }}
     />
   );
 }

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -426,7 +426,14 @@ const getNestedNavigator = (
  */
 function RouteFC(props: Types.FCProps) {
   // eslint-disable-next-line react/destructuring-assignment
-  const { entrypointUrl, route, navigation, onRouteBlur, onRouteFocus } = props;
+  const {
+    entrypointUrl,
+    getState: getParentState,
+    route,
+    navigation,
+    onRouteBlur,
+    onRouteFocus,
+  } = props;
 
   // This is the context provided by either this route or a parent component
   const docContext = useContext(Contexts.DocContext);
@@ -489,7 +496,8 @@ function RouteFC(props: Types.FCProps) {
       const unsubscribeFocus: () => void = navigation.addListener(
         'focus',
         () => {
-          const doc = docContext.getState().doc || undefined;
+          // Use the parent document state to set the selected route
+          const doc = getParentState().doc || undefined;
           const id = route?.params?.id || route?.key;
           NavigatorService.setSelected(doc, id);
           NavigatorService.addStackRoute(
@@ -509,7 +517,8 @@ function RouteFC(props: Types.FCProps) {
       const unsubscribeRemove: () => void = navigation.addListener(
         'beforeRemove',
         (event: { preventDefault: () => void }) => {
-          // Check for elements registered to interupt back action via a trigger of BACK
+          // Use the current document state to access behaviors on the document
+          // Check for elements registered to interrupt back action via a trigger of BACK
           const elements: Element[] = docContext.backBehaviorElements.get();
           if (elements.length > 0) {
             // Process the elements
@@ -526,9 +535,9 @@ function RouteFC(props: Types.FCProps) {
               });
             });
           } else {
-            // Perform cleanup
+            // Perform cleanup of the associated route (retrieved from parent document state)
             NavigatorService.removeStackRoute(
-              docContext.getState().doc || undefined,
+              getParentState().doc || undefined,
               route?.params?.url,
               entrypointUrl,
             );
@@ -546,6 +555,7 @@ function RouteFC(props: Types.FCProps) {
   }, [
     docContext,
     entrypointUrl,
+    getParentState,
     route,
     navigation,
     onRouteBlur,

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -321,7 +321,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps> {
       return (
         <HvNavigator
           element={renderElement}
-          onUpdate={this.props.onUpdate}
+          onUpdate={this.props.navigatorUpdate}
           params={this.props.route?.params}
           routeComponent={HvRoute}
         />
@@ -566,7 +566,13 @@ function RouteFC(props: Types.FCProps) {
   return (
     <HvRouteInner
       // eslint-disable-next-line react/jsx-props-no-spreading
-      {...{ ...props, navigationService, navigator, needsLoad }}
+      {...{
+        ...props,
+        navigationService,
+        navigator,
+        navigatorUpdate: onUpdate,
+        needsLoad,
+      }}
     />
   );
 }

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -110,6 +110,7 @@ export type InnerRouteProps = {
   needsLoad: React.MutableRefObject<boolean>;
   navigator: React.MutableRefObject<NavigatorService.Navigator>;
   navigationService: React.MutableRefObject<Navigation.default>;
+  navigatorUpdate: HvComponentOnUpdate;
 };
 
 /**


### PR DESCRIPTION
The fixes required for https://github.com/Instawork/hyperview/pull/783 and https://github.com/Instawork/hyperview/pull/785 necessitated a change to how the navigator accesses an onUpdate. It is now passed as a unique name to avoid collision with other functionality.

Asana: https://app.asana.com/0/1204008699308084/1206320269516407/f