### PR TITLE
fix: reload not triggering a load

### DIFF
--- a/src/core/components/hv-doc/index.tsx
+++ b/src/core/components/hv-doc/index.tsx
@@ -51,7 +51,7 @@ export default class HvDoc extends PureComponent<Types.Props, ScreenState> {
           getState: (): ScreenState => {
             return { ...this.state, doc: this.localDoc };
           },
-          setState: (s): void => {
+          setState: (s, c): void => {
             if (typeof s === 'object') {
               if (s.doc !== undefined) {
                 this.localDoc = s.doc;
@@ -64,7 +64,7 @@ export default class HvDoc extends PureComponent<Types.Props, ScreenState> {
                   this.localDoc = newState.doc;
                 }
                 return newState;
-              });
+              }, c);
             }
           },
         }}

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -134,14 +134,18 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
     }
 
     // Re-render the modifications
-    opts.onUpdateCallbacks?.setState({
-      doc: newRoot,
-      elementError: null,
-      error: null,
-      url,
-    });
-    // Force a reload regardless of state
-    opts.onUpdateCallbacks?.reload();
+    opts.onUpdateCallbacks?.setState(
+      () => {
+        return {
+          doc: newRoot,
+          elementError: null,
+          error: null,
+          url,
+        };
+      },
+      // Force a reload once state is set
+      opts.onUpdateCallbacks?.reload,
+    );
   };
 
   /**

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -134,13 +134,14 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
     }
 
     // Re-render the modifications
-    opts.onUpdateCallbacks?.setNeedsLoad();
     opts.onUpdateCallbacks?.setState({
       doc: newRoot,
       elementError: null,
       error: null,
       url,
     });
+    // Force a reload regardless of state
+    opts.onUpdateCallbacks?.reload();
   };
 
   /**

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -476,9 +476,7 @@ function RouteFC(props: Types.FCProps) {
           setNeedsLoad: () => {
             needsLoad.current = true;
           },
-          setState: (state: ScreenState) => {
-            docContext.setState(state);
-          },
+          setState: (state, callback) => docContext.setState(state, callback),
         },
       });
     },

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -472,6 +472,7 @@ function RouteFC(props: Types.FCProps) {
           getState: () => docContext.getState(),
           registerPreload: (id: number, el: Element) =>
             props.setPreload(id, el),
+          reload: () => {},
           setNeedsLoad: () => {
             needsLoad.current = true;
           },

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -74,15 +74,10 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps> {
   }
 
   componentDidUpdate(prevProps: Types.InnerRouteProps) {
-    if (
-      prevProps.url !== this.props.url ||
-      this.props.needsLoad?.current === true
-    ) {
+    if (prevProps.url !== this.props.url || this.props.needsLoad === true) {
       this.load();
     }
-    if (this.props.needsLoad) {
-      this.props.needsLoad.current = false;
-    }
+    this.props.setNeedsLoad(false);
   }
 
   getUrl = (): string => {
@@ -439,7 +434,8 @@ function RouteFC(props: Types.FCProps) {
   const docContext = useContext(Contexts.DocContext);
 
   // These are provided as a ref instead of a state to avoid re-rendering
-  const needsLoad = React.useRef<boolean>(false);
+  const [needsLoad, setNeedsLoad] = React.useState<boolean>(false);
+
   const navigator = React.useRef<NavigatorService.Navigator>(
     new NavigatorService.Navigator(props),
   );
@@ -472,9 +468,9 @@ function RouteFC(props: Types.FCProps) {
           getState: () => docContext.getState(),
           registerPreload: (id: number, el: Element) =>
             props.setPreload(id, el),
-          reload: () => {},
+          reload: () => setNeedsLoad(true),
           setNeedsLoad: () => {
-            needsLoad.current = true;
+            setNeedsLoad(true);
           },
           setState: (state, callback) => docContext.setState(state, callback),
         },
@@ -571,6 +567,7 @@ function RouteFC(props: Types.FCProps) {
         navigator,
         navigatorUpdate: onUpdate,
         needsLoad,
+        setNeedsLoad,
       }}
     />
   );

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -107,7 +107,8 @@ export type InnerRouteProps = {
   setState: SetState;
   onRouteBlur?: (route: Route) => void;
   onRouteFocus?: (route: Route) => void;
-  needsLoad: React.MutableRefObject<boolean>;
+  needsLoad: boolean;
+  setNeedsLoad: React.Dispatch<React.SetStateAction<boolean>>;
   navigator: React.MutableRefObject<NavigatorService.Navigator>;
   navigationService: React.MutableRefObject<Navigation.default>;
   navigatorUpdate: HvComponentOnUpdate;

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -306,8 +306,8 @@ export default class HvScreen extends React.Component {
     setNeedsLoad: () => {
       this.needsLoad = true;
     },
-    setState: state => {
-      this.context.setState(state);
+    setState: (state, callback) => {
+      this.context.setState(state, callback);
     },
   };
 

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -302,6 +302,7 @@ export default class HvScreen extends React.Component {
     getOnUpdate: () => this.onUpdate,
     getState: () => this.context.getState(),
     registerPreload: (id, element) => this.registerPreload(id, element),
+    reload: this.load,
     setNeedsLoad: () => {
       this.needsLoad = true;
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ import * as Stylesheets from './services/stylesheets';
 import Navigation from './services/navigation';
 import type { Route as NavigatorRoute } from './services/navigator';
 import type React from 'react';
+import { SetState } from './contexts';
 import type { XResponseStaleReason } from './services/dom/types';
 
 export type DOMString = string;
@@ -423,7 +424,7 @@ export type OnUpdateCallbacks = {
   registerPreload: (id: number, element: Element) => void;
   setNeedsLoad: () => void;
   getState: () => ScreenState;
-  setState: (state: ScreenState) => void;
+  setState: SetState;
   reload: () => void;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -424,6 +424,7 @@ export type OnUpdateCallbacks = {
   setNeedsLoad: () => void;
   getState: () => ScreenState;
   setState: (state: ScreenState) => void;
+  reload: () => void;
 };
 
 export type ScreenState = {


### PR DESCRIPTION
Fixing an issue where reload behaviors didn't reload content.

The issue found was that the state set in hv-root did not cause the hv-screen to update. This meant the `componentDidUpdate` was never fired so the "needsLoad" value wasn't evaluated to cause a reload.

The fix is to remove the setting of "needsLoad" from within hv-root and replace it with an explicit call to load.

A separate task has been created to evaluate ways to remove the "needsLoad" from hv-screen and hv-route. https://app.asana.com/0/1204323441804469/1206385492929255/f

| Before | After |
| -- | -- |
| ![before](https://github.com/Instawork/hyperview/assets/127122858/8cba50de-0ab9-4016-bd3e-4989aa1dd050) | ![after](https://github.com/Instawork/hyperview/assets/127122858/ba030c47-4a92-43c8-9ebf-8c0a5a7a7eca) |
| ![before-perms](https://github.com/Instawork/hyperview/assets/127122858/e6a531f8-a95e-4da2-ad2e-8933ee54810a) | ![after-perms](https://github.com/Instawork/hyperview/assets/127122858/be362beb-3a7e-4c57-9659-35222b16d4e4) |


Asana bugs fixed:
- https://app.asana.com/0/1204008699308084/1206367117739199/f
- https://app.asana.com/0/1204008699308084/1206367117739209/f