### PR TITLE
feature: Adding support for blocking close/back navigation

### DIFF
--- a/src/contexts/back-behaviors.test.ts
+++ b/src/contexts/back-behaviors.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import * as DomErrors from 'hyperview/src/services/dom/errors';
+import * as Namespaces from 'hyperview/src/services/namespaces';
+import { DOMParser } from '@instawork/xmldom';
+import { removeElements } from './back-behaviors';
+
+const testDoc = `
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <body>
+      <view>
+        <behavior
+          trigger="back"
+          action="hide"
+          target="foo"
+        />
+        <behavior
+          trigger="back"
+          action="show"
+          target="bar"
+        />
+        <behavior
+          trigger="on-event"
+          event-name="foo"
+        />
+      </view>
+    </body>
+  </screen>
+</doc>
+`;
+
+/**
+ * Parser used to parse the document
+ */
+const parser = new DOMParser({
+  errorHandler: {
+    error: (error: string) => {
+      throw new DomErrors.XMLParserError(error);
+    },
+    fatalError: (error: string) => {
+      throw new DomErrors.XMLParserFatalError(error);
+    },
+    warning: (error: string) => {
+      throw new DomErrors.XMLParserWarning(error);
+    },
+  },
+  locator: {},
+});
+
+describe('BackBehaviorRemove', () => {
+  const doc = parser.parseFromString(testDoc);
+
+  it('should find 3 behaviors', () => {
+    const behaviors = doc.getElementsByTagNameNS(
+      Namespaces.HYPERVIEW,
+      'behavior',
+    );
+    expect(behaviors.length).toEqual(3);
+  });
+
+  it('should find 2 back behaviors', () => {
+    const behaviors = doc.getElementsByTagNameNS(
+      Namespaces.HYPERVIEW,
+      'behavior',
+    );
+    const backBehaviors = Array.from(behaviors).filter(
+      behavior => behavior.getAttribute('trigger') === 'back',
+    );
+
+    expect(backBehaviors.length).toEqual(2);
+  });
+
+  it('should remove 2 back behaviors', () => {
+    const behaviors = Array.from(
+      doc.getElementsByTagNameNS(Namespaces.HYPERVIEW, 'behavior'),
+    );
+    const backBehaviors = Array.from(behaviors).filter(
+      behavior => behavior.getAttribute('trigger') === 'back',
+    );
+
+    const updatedBehaviors = removeElements(behaviors, backBehaviors);
+    expect(updatedBehaviors.length).toEqual(1);
+  });
+});

--- a/src/contexts/back-behaviors.tsx
+++ b/src/contexts/back-behaviors.tsx
@@ -9,23 +9,6 @@
 import React, { ReactNode, createContext, useRef, useState } from 'react';
 import { HvComponentOnUpdate } from 'hyperview/src/types';
 
-class BackBehaviorRegistry {
-  backBehaviorElements: Element[] = [];
-
-  add = (elements: Element[]): void => {
-    this.backBehaviorElements.push(...elements);
-  };
-
-  get = (): Element[] => this.backBehaviorElements;
-
-  remove = (elements: Element[]): void => {
-    this.backBehaviorElements = elements.reduce((acc, e) => {
-      const i = acc.indexOf(e);
-      return i > -1 ? [...acc.slice(0, i), ...acc.slice(i + 1)] : acc;
-    }, this.backBehaviorElements);
-  };
-}
-
 export type BackBehaviorContextProps = {
   add: (elements: Element[], onUpdate: HvComponentOnUpdate) => void;
   get: () => Element[];
@@ -41,22 +24,32 @@ export const BackBehaviorContext = createContext<BackBehaviorContextProps | null
   null,
 );
 
+export function removeElements(
+  registry: Element[],
+  remove: Element[],
+): Element[] {
+  return remove.reduce((acc, e) => {
+    const i = acc.indexOf(e);
+    return i > -1 ? [...acc.slice(0, i), ...acc.slice(i + 1)] : acc;
+  }, registry);
+}
+
 export function BackBehaviorProvider(props: { children: ReactNode }) {
-  const registry = useRef<BackBehaviorRegistry>(new BackBehaviorRegistry());
+  const registry = useRef<Element[]>([]);
   const [onUpdate, setOnUpdate] = useState<HvComponentOnUpdate>(() => null);
 
   const add = (elements: Element[], update: HvComponentOnUpdate): void => {
     if (elements.length === 0) {
       return;
     }
-    registry.current.add(elements);
+    registry.current.push(...elements);
     setOnUpdate(() => update);
   };
 
-  const get = (): Element[] => registry.current.get();
+  const get = (): Element[] => registry.current;
 
   const remove = (elements: Element[]): void => {
-    registry.current.remove(elements);
+    registry.current = removeElements(registry.current, elements);
   };
 
   return (

--- a/src/contexts/back-behaviors.tsx
+++ b/src/contexts/back-behaviors.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React, { ReactNode, createContext, useRef, useState } from 'react';
+import { HvComponentOnUpdate } from 'hyperview/src/types';
+
+class BackBehaviorRegistry {
+  backBehaviorElements: Element[] = [];
+
+  add = (elements: Element[]): void => {
+    this.backBehaviorElements.push(...elements);
+  };
+
+  get = (): Element[] => this.backBehaviorElements;
+
+  remove = (elements: Element[]): void => {
+    this.backBehaviorElements = elements.reduce((acc, e) => {
+      const i = acc.indexOf(e);
+      return i > -1 ? [...acc.slice(0, i), ...acc.slice(i + 1)] : acc;
+    }, this.backBehaviorElements);
+  };
+}
+
+export type BackBehaviorContextProps = {
+  add: (elements: Element[], onUpdate: HvComponentOnUpdate) => void;
+  get: () => Element[];
+  onUpdate: HvComponentOnUpdate;
+  remove: (elements: Element[]) => void;
+};
+
+/*
+ * Provides a registry of back behaviors to allow sharing between hv-screen and hv-route
+ * Additionally contains the onUpdate to use for the behaviors
+ */
+export const BackBehaviorContext = createContext<BackBehaviorContextProps | null>(
+  null,
+);
+
+export function BackBehaviorProvider(props: { children: ReactNode }) {
+  const registry = useRef<BackBehaviorRegistry>(new BackBehaviorRegistry());
+  const [onUpdate, setOnUpdate] = useState<HvComponentOnUpdate>(() => null);
+
+  const add = (elements: Element[], update: HvComponentOnUpdate): void => {
+    if (elements.length === 0) {
+      return;
+    }
+    registry.current.add(elements);
+    setOnUpdate(() => update);
+  };
+
+  const get = (): Element[] => registry.current.get();
+
+  const remove = (elements: Element[]): void => {
+    registry.current.remove(elements);
+  };
+
+  return (
+    <BackBehaviorContext.Provider
+      value={{
+        add,
+        get,
+        onUpdate,
+        remove,
+      }}
+    >
+      {props.children}
+    </BackBehaviorContext.Provider>
+  );
+}

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -32,6 +32,7 @@ import {
   UpdateAction,
 } from 'hyperview/src/types';
 import React, { PureComponent } from 'react';
+import { BackBehaviorProvider } from 'hyperview/src/contexts/back-behaviors';
 import HvRoute from 'hyperview/src/core/components/hv-route';
 import HvScreen from 'hyperview/src/core/components/hv-screen';
 import { Linking } from 'react-native';
@@ -541,29 +542,31 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
         <Contexts.RefreshControlComponentContext.Provider
           value={this.props.refreshControl}
         >
-          <HvScreen
-            back={this.props.back}
-            behaviors={this.props.behaviors}
-            closeModal={this.props.closeModal}
-            components={this.props.components}
-            elementErrorComponent={this.props.elementErrorComponent}
-            entrypointUrl={this.props.entrypointUrl}
-            errorScreen={this.props.errorScreen}
-            fetch={this.props.fetch}
-            formatDate={this.props.formatDate}
-            loadingScreen={this.props.loadingScreen}
-            navigate={this.props.navigate}
-            navigation={this.props.navigation}
-            onError={this.props.onError}
-            onParseAfter={this.props.onParseAfter}
-            onParseBefore={this.props.onParseBefore}
-            onUpdate={this.onUpdate}
-            openModal={this.props.openModal}
-            push={this.props.push}
-            refreshControl={this.props.refreshControl}
-            reload={this.reload}
-            route={this.props.route}
-          />
+          <BackBehaviorProvider>
+            <HvScreen
+              back={this.props.back}
+              behaviors={this.props.behaviors}
+              closeModal={this.props.closeModal}
+              components={this.props.components}
+              elementErrorComponent={this.props.elementErrorComponent}
+              entrypointUrl={this.props.entrypointUrl}
+              errorScreen={this.props.errorScreen}
+              fetch={this.props.fetch}
+              formatDate={this.props.formatDate}
+              loadingScreen={this.props.loadingScreen}
+              navigate={this.props.navigate}
+              navigation={this.props.navigation}
+              onError={this.props.onError}
+              onParseAfter={this.props.onParseAfter}
+              onParseBefore={this.props.onParseBefore}
+              onUpdate={this.onUpdate}
+              openModal={this.props.openModal}
+              push={this.props.push}
+              refreshControl={this.props.refreshControl}
+              reload={this.reload}
+              route={this.props.route}
+            />
+          </BackBehaviorProvider>
         </Contexts.RefreshControlComponentContext.Provider>
       );
     }
@@ -593,7 +596,9 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
               reload: this.reload,
             }}
           >
-            <HvRoute />
+            <BackBehaviorProvider>
+              <HvRoute />
+            </BackBehaviorProvider>
           </NavContexts.Context.Provider>
         </Contexts.RefreshControlComponentContext.Provider>
       </Contexts.DateFormatContext.Provider>

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -32,7 +32,6 @@ import {
   UpdateAction,
 } from 'hyperview/src/types';
 import React, { PureComponent } from 'react';
-import { BackBehaviorProvider } from 'hyperview/src/contexts/back-behaviors';
 import HvRoute from 'hyperview/src/core/components/hv-route';
 import HvScreen from 'hyperview/src/core/components/hv-screen';
 import { Linking } from 'react-native';
@@ -542,31 +541,29 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
         <Contexts.RefreshControlComponentContext.Provider
           value={this.props.refreshControl}
         >
-          <BackBehaviorProvider>
-            <HvScreen
-              back={this.props.back}
-              behaviors={this.props.behaviors}
-              closeModal={this.props.closeModal}
-              components={this.props.components}
-              elementErrorComponent={this.props.elementErrorComponent}
-              entrypointUrl={this.props.entrypointUrl}
-              errorScreen={this.props.errorScreen}
-              fetch={this.props.fetch}
-              formatDate={this.props.formatDate}
-              loadingScreen={this.props.loadingScreen}
-              navigate={this.props.navigate}
-              navigation={this.props.navigation}
-              onError={this.props.onError}
-              onParseAfter={this.props.onParseAfter}
-              onParseBefore={this.props.onParseBefore}
-              onUpdate={this.onUpdate}
-              openModal={this.props.openModal}
-              push={this.props.push}
-              refreshControl={this.props.refreshControl}
-              reload={this.reload}
-              route={this.props.route}
-            />
-          </BackBehaviorProvider>
+          <HvScreen
+            back={this.props.back}
+            behaviors={this.props.behaviors}
+            closeModal={this.props.closeModal}
+            components={this.props.components}
+            elementErrorComponent={this.props.elementErrorComponent}
+            entrypointUrl={this.props.entrypointUrl}
+            errorScreen={this.props.errorScreen}
+            fetch={this.props.fetch}
+            formatDate={this.props.formatDate}
+            loadingScreen={this.props.loadingScreen}
+            navigate={this.props.navigate}
+            navigation={this.props.navigation}
+            onError={this.props.onError}
+            onParseAfter={this.props.onParseAfter}
+            onParseBefore={this.props.onParseBefore}
+            onUpdate={this.onUpdate}
+            openModal={this.props.openModal}
+            push={this.props.push}
+            refreshControl={this.props.refreshControl}
+            reload={this.reload}
+            route={this.props.route}
+          />
         </Contexts.RefreshControlComponentContext.Provider>
       );
     }
@@ -596,9 +593,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
               reload: this.reload,
             }}
           >
-            <BackBehaviorProvider>
-              <HvRoute />
-            </BackBehaviorProvider>
+            <HvRoute />
           </NavContexts.Context.Provider>
         </Contexts.RefreshControlComponentContext.Provider>
       </Contexts.DateFormatContext.Provider>

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -404,7 +404,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
                 element={renderElement}
                 onUpdate={this.onUpdate}
                 params={this.props.route?.params}
-                routeComponent={HvRouteBehaviorWrapper}
+                routeComponent={HvRoute}
               />
             </Contexts.OnUpdateContext.Provider>
           </Contexts.DocContext.Provider>
@@ -418,7 +418,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
               element={renderElement}
               onUpdate={updater.onUpdate}
               params={this.props.route?.params}
-              routeComponent={HvRouteBehaviorWrapper}
+              routeComponent={HvRoute}
             />
           )}
         </Contexts.OnUpdateContext.Consumer>
@@ -526,7 +526,7 @@ const getNestedNavigator = (
  * - Retrieves the navigator element from the context
  * - Passes the props, context, and url to HvRouteInner
  */
-export default function HvRoute(props: Types.Props) {
+function HvRouteFC(props: Types.Props) {
   const navigationContext: Types.NavigationContextProps | null = useContext(
     NavigationContext.Context,
   );
@@ -591,12 +591,6 @@ export default function HvRoute(props: Types.Props) {
             elements.forEach(behaviorElement => {
               const href = behaviorElement.getAttribute('href');
               const action = behaviorElement.getAttribute('action');
-              console.log(
-                'onupdate: ',
-                href,
-                action,
-                backContext.onUpdate !== null,
-              );
               if (backContext.onUpdate) {
                 backContext.onUpdate(href, action, behaviorElement, {
                   behaviorElement,
@@ -643,10 +637,10 @@ export default function HvRoute(props: Types.Props) {
   );
 }
 
-function HvRouteBehaviorWrapper(props: Types.Props) {
+export default function HvRoute(props: Types.Props) {
   return (
     <BackBehaviorProvider>
-      <HvRoute
+      <HvRouteFC
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
       />

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -584,22 +584,21 @@ function HvRouteFC(props: Types.Props) {
         (event: { preventDefault: () => void }) => {
           // Use the current document state to access behaviors on the document
           // Check for elements registered to interrupt back action via a trigger of BACK
-          const elements: Element[] | undefined = backContext?.get();
-          if (elements && elements.length > 0 && backContext?.onUpdate) {
+          const { get, onUpdate } = backContext || {};
+          const elements: Element[] = (get && get()) || [];
+          if (elements.length > 0 && onUpdate) {
             // Process the elements
             event.preventDefault();
             elements.forEach(behaviorElement => {
               const href = behaviorElement.getAttribute('href');
               const action = behaviorElement.getAttribute('action');
-              if (backContext.onUpdate) {
-                backContext.onUpdate(href, action, behaviorElement, {
-                  behaviorElement,
-                  showIndicatorId: behaviorElement.getAttribute(
-                    'show-during-load',
-                  ),
-                  targetId: behaviorElement.getAttribute('target'),
-                });
-              }
+              onUpdate(href, action, behaviorElement, {
+                behaviorElement,
+                showIndicatorId: behaviorElement.getAttribute(
+                  'show-during-load',
+                ),
+                targetId: behaviorElement.getAttribute('target'),
+              });
             });
           } else {
             // Perform cleanup of the associated route (retrieved from parent document state)
@@ -640,10 +639,7 @@ function HvRouteFC(props: Types.Props) {
 export default function HvRoute(props: Types.Props) {
   return (
     <BackBehaviorProvider>
-      <HvRouteFC
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...props}
-      />
+      <HvRouteFC navigation={props.navigation} route={props.route} />
     </BackBehaviorProvider>
   );
 }

--- a/src/core/hyper-ref/index.tsx
+++ b/src/core/hyper-ref/index.tsx
@@ -94,7 +94,7 @@ export default class HyperRef extends PureComponent<Props, State> {
       return;
     }
 
-    // Deregister event listener for on-event triggers
+    // Deregister event listener for back triggers
     this.removeBackBehaviors();
 
     this.updateBehaviorElements();
@@ -107,7 +107,7 @@ export default class HyperRef extends PureComponent<Props, State> {
   componentWillUnmount() {
     // Remove event listener for on-event triggers to avoid memory leaks
     Events.unsubscribe(this.onEventDispatch);
-    // Deregister event listener for on-event triggers
+    // Deregister event listener for back triggers
     this.removeBackBehaviors();
   }
 

--- a/src/core/hyper-ref/index.tsx
+++ b/src/core/hyper-ref/index.tsx
@@ -33,6 +33,7 @@ import {
   Text,
   TouchableOpacity,
 } from 'react-native';
+import { BackBehaviorContext } from 'hyperview/src/contexts/back-behaviors';
 import { PRESS_TRIGGERS_PROP_NAMES } from './types';
 import VisibilityDetectingView from 'hyperview/src/VisibilityDetectingView';
 import { XMLSerializer } from '@instawork/xmldom';
@@ -61,6 +62,8 @@ export const createEventHandler = (
  * triggers.
  */
 export default class HyperRef extends PureComponent<Props, State> {
+  static contextType = BackBehaviorContext;
+
   state: State = {
     pressed: false,
     refreshing: false,
@@ -81,6 +84,9 @@ export default class HyperRef extends PureComponent<Props, State> {
 
     // Register event listener for on-event triggers
     Events.subscribe(this.onEventDispatch);
+
+    // Register behavior elements for back triggers
+    this.addBackBehaviors();
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -88,19 +94,37 @@ export default class HyperRef extends PureComponent<Props, State> {
       return;
     }
 
+    // Deregister event listener for on-event triggers
+    this.removeBackBehaviors();
+
     this.updateBehaviorElements();
     this.updateStyle();
     this.triggerLoadBehaviors();
+    // Register behavior elements for back triggers
+    this.addBackBehaviors();
   }
 
   componentWillUnmount() {
     // Remove event listener for on-event triggers to avoid memory leaks
     Events.unsubscribe(this.onEventDispatch);
+    // Deregister event listener for on-event triggers
+    this.removeBackBehaviors();
   }
 
   updateBehaviorElements = () => {
     // Retrieve and cache behavior elements when element is updated
     this.behaviorElements = Dom.getBehaviorElements(this.props.element);
+  };
+
+  addBackBehaviors = () => {
+    this.context?.add(
+      this.getBehaviorElements(TRIGGERS.BACK),
+      this.props.onUpdate,
+    );
+  };
+
+  removeBackBehaviors = () => {
+    this.context?.remove(this.getBehaviorElements(TRIGGERS.BACK));
   };
 
   updateStyle = () => {

--- a/src/services/navigator/types.ts
+++ b/src/services/navigator/types.ts
@@ -43,7 +43,10 @@ export type NavigationProp = {
   goBack: () => void;
   getState: () => NavigationState;
   getParent: (id?: string) => NavigationProp | undefined;
-  addListener: (event: string, callback: () => void) => () => void;
+  addListener: (
+    eventName: string,
+    callback: (event: { preventDefault: () => void }) => void,
+  ) => () => void;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -278,6 +278,7 @@ export const BEHAVIOR_ATTRIBUTES = {
 
 // https://hyperview.org/docs/reference_behavior_attributes#trigger
 export const TRIGGERS = Object.freeze({
+  BACK: 'back',
   DESELECT: 'deselect',
   LOAD: 'load',
   LOAD_STALE_ERROR: 'load-stale-error',


### PR DESCRIPTION
Re-working the support for back navigation control with a simplified approach.

- added new "back" trigger
- added new "BackBehaviorContext" to manage a behavior registry and store the current 'onUpdate' which will handle the behaviors
- modified hyper-ref to register/deregister its 'trigger=back' behaviors along with its 'onUpdate'
- wrapped all instances of 'hv-route' with a BackBehaviorContext and also wrapped the standalone hv-screen

Tested in iOS simulator for Pro and Partner app
- Pro app won't currently support the feature but its addition doesn't break anything
- Partner app was tested with 'back' behaviors in place and omitted and worked as expected

Verified the following test setups:
```XML
<view id="back-container">
  <behavior
    trigger="back"
    action="hide"
    target="back-container"
  />
  <behavior
    trigger="back"
    action="back"
  />
</view>
```


```XML
<view id="back-container">
  <behavior
    trigger="back"
    action="hide"
    target="back-container"
  />
  <behavior
    trigger="back"
    action="alert"
    alert:title="Test"
    alert:message="Click 'go back' to go back"
  >
    <alert:option alert:label="go back">
      <behavior
        action="back"
      />
    </alert:option>
  </behavior>
</view>
```


https://github.com/Instawork/hyperview/assets/127122858/caccf30b-d4f2-4a64-9874-bb8522f9c7dd



