### PR TITLE
chore: remove HvRoute prop spreading

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -628,9 +628,23 @@ function HvRouteFC(props: Types.Props) {
 
   return (
     <HvRouteInner
-      // eslint-disable-next-line react/jsx-props-no-spreading
-      {...{ ...props, ...navigationContext, ...navigatorMapContext }}
+      behaviors={navigationContext.behaviors}
+      components={navigationContext.components}
       element={element}
+      elementErrorComponent={navigationContext.elementErrorComponent}
+      entrypointUrl={navigationContext.entrypointUrl}
+      errorScreen={navigationContext.errorScreen}
+      fetch={navigationContext.fetch}
+      getPreload={navigatorMapContext.getPreload}
+      handleBack={navigationContext.handleBack}
+      loadingScreen={navigationContext.loadingScreen}
+      navigation={props.navigation}
+      onParseAfter={navigationContext.onParseAfter}
+      onParseBefore={navigationContext.onParseBefore}
+      onUpdate={navigationContext.onUpdate}
+      reload={navigationContext.reload}
+      route={props.route}
+      setPreload={navigatorMapContext.setPreload}
       url={url}
     />
   );


### PR DESCRIPTION
Removing the prop spreading between the functional component and the class component

Asana: https://app.asana.com/0/1204008699308084/1206433111684027/f