### PR TITLE
chore: separate props from HvRoot and HvScreen

### DIFF
--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -11,12 +11,12 @@ import * as Components from 'hyperview/src/services/components';
 import * as Contexts from 'hyperview/src/contexts';
 import * as Dom from 'hyperview/src/services/dom';
 import * as Events from 'hyperview/src/services/events';
-import * as HvScreenProps from 'hyperview/src/core/components/hv-screen/types';
 import * as NavContexts from 'hyperview/src/contexts/navigation';
 import * as Navigation from 'hyperview/src/services/navigation';
 import * as Render from 'hyperview/src/services/render';
 import * as Services from 'hyperview/src/services';
 import * as Stylesheets from 'hyperview/src/services/stylesheets';
+import * as Types from './types';
 import * as UrlService from 'hyperview/src/services/url';
 import * as Xml from 'hyperview/src/services/xml';
 import {
@@ -39,7 +39,7 @@ import { Linking } from 'react-native';
 /**
  * Provides routing to the correct path based on the state passed in
  */
-export default class Hyperview extends PureComponent<HvScreenProps.Props> {
+export default class Hyperview extends PureComponent<Types.Props> {
   static createProps = Services.createProps;
 
   static createStyleProp = Services.createStyleProp;
@@ -56,7 +56,7 @@ export default class Hyperview extends PureComponent<HvScreenProps.Props> {
 
   parser: Dom.Parser;
 
-  constructor(props: HvScreenProps.Props) {
+  constructor(props: Types.Props) {
     super(props);
 
     this.parser = new Dom.Parser(

--- a/src/core/components/hv-root/types.ts
+++ b/src/core/components/hv-root/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Garuda Labs, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import * as NavigatorService from 'hyperview/src/services/navigator';
+import { ComponentType, ReactNode } from 'react';
+import type {
+  Fetch,
+  HvBehavior,
+  HvComponent,
+  NavigationRouteParams,
+  Route,
+} from 'hyperview/src/types';
+import type { Props as ErrorProps } from 'hyperview/src/core/components/load-error';
+import type { Props as LoadingProps } from 'hyperview/src/core/components/loading';
+import type { RefreshControlProps } from 'react-native';
+
+/**
+ * All of the props used by hv-screen
+ */
+export type Props = {
+  formatDate: (
+    date: Date | null | undefined,
+    format: string | undefined,
+  ) => string | undefined;
+  refreshControl?: ComponentType<RefreshControlProps>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  navigation?: any;
+  route?: NavigatorService.Route<string, { url?: string }>;
+  entrypointUrl: string;
+  fetch: Fetch;
+  onError?: (error: Error) => void;
+  onParseAfter?: (url: string) => void;
+  onParseBefore?: (url: string) => void;
+  onRouteBlur?: (route: Route) => void;
+  onRouteFocus?: (route: Route) => void;
+  url?: string;
+  back?: (params: NavigationRouteParams | object | undefined) => void;
+  closeModal?: (params: NavigationRouteParams | object | undefined) => void;
+  navigate?: (params: NavigationRouteParams | object, key: string) => void;
+  openModal?: (params: NavigationRouteParams | object) => void;
+  push?: (params: object) => void;
+  behaviors?: HvBehavior[];
+  components?: HvComponent[];
+  elementErrorComponent?: ComponentType<ErrorProps>;
+  errorScreen?: ComponentType<ErrorProps>;
+  loadingScreen?: ComponentType<LoadingProps>;
+  handleBack?: ComponentType<{ children: ReactNode }>;
+  doc?: Document;
+  registerPreload?: (id: number, element: Element) => void;
+};

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -6,54 +6,13 @@
  *
  */
 
-import * as NavigatorService from 'hyperview/src/services/navigator';
-import { ComponentType, ReactNode } from 'react';
-import type {
-  Fetch,
-  HvBehavior,
-  HvComponent,
-  HvComponentOnUpdate,
-  NavigationRouteParams,
-  Reload,
-  Route,
-} from 'hyperview/src/types';
-import type { Props as ErrorProps } from 'hyperview/src/core/components/load-error';
-import type { Props as LoadingProps } from 'hyperview/src/core/components/loading';
-import type { RefreshControlProps } from 'react-native';
+import type { HvComponentOnUpdate, Reload } from 'hyperview/src/types';
+import { Props as HvRootProps } from 'hyperview/src/core/components/hv-root/types';
 
 /**
  * All of the props used by hv-screen
  */
-export type Props = {
-  formatDate: (
-    date: Date | null | undefined,
-    format: string | undefined,
-  ) => string | undefined;
-  refreshControl?: ComponentType<RefreshControlProps>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  navigation?: any;
-  route?: NavigatorService.Route<string, { url?: string }>;
-  entrypointUrl: string;
-  fetch: Fetch;
-  onError?: (error: Error) => void;
-  onParseAfter?: (url: string) => void;
-  onParseBefore?: (url: string) => void;
-  onRouteBlur?: (route: Route) => void;
-  onRouteFocus?: (route: Route) => void;
+export type Props = HvRootProps & {
   onUpdate: HvComponentOnUpdate;
-  url?: string;
-  back?: (params: NavigationRouteParams | object | undefined) => void;
-  closeModal?: (params: NavigationRouteParams | object | undefined) => void;
-  navigate?: (params: NavigationRouteParams | object, key: string) => void;
-  openModal?: (params: NavigationRouteParams | object) => void;
-  push?: (params: object) => void;
-  behaviors?: HvBehavior[];
-  components?: HvComponent[];
-  elementErrorComponent?: ComponentType<ErrorProps>;
-  errorScreen?: ComponentType<ErrorProps>;
-  loadingScreen?: ComponentType<LoadingProps>;
-  handleBack?: ComponentType<{ children: ReactNode }>;
-  doc?: Document;
-  registerPreload?: (id: number, element: Element) => void;
   reload: Reload;
 };


### PR DESCRIPTION
In current release, HvRoot is sharing the same props as HvScreen. Some recent required props for HvScreen are causing HvRoot to include required props which it doesn't need.

Separating the two props out allows HvRoot to only require the external dependencies.

Asana: https://app.asana.com/0/1204008699308084/1206433111684035/f