### PR TITLE
fix: scroll to target

### DIFF
--- a/src/components/hv-list/index.tsx
+++ b/src/components/hv-list/index.tsx
@@ -72,8 +72,7 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
       console.warn('[behaviors/scroll]: missing "target" attribute');
       return;
     }
-    const doc: Document | null | undefined =
-      typeof this.context === 'function' ? this.context() : null;
+    const doc: Document | null | undefined = this.context.getDoc();
     const targetElement: Element | null | undefined = Dom.getElementById(
       doc,
       targetId,


### PR DESCRIPTION
As reported in https://github.com/Instawork/hyperview/issues/776 the scroll to target was broken during TS migration.

Updated how the doc is retrieved from the updated DocContext.

Asana: https://app.asana.com/0/1204008699308084/1206433111684039/f


| Before | After |
| -- | -- |
| ![before](https://github.com/Instawork/hyperview/assets/127122858/b34e09a8-0dc1-40e4-835e-bfadfb417a50) | ![after](https://github.com/Instawork/hyperview/assets/127122858/d8aadfff-ecd3-46f2-a22f-50ae3c2d481c) |
