### PR TITLE
chore: add support for example filtering

### DIFF
--- a/examples/_includes/directory_list.xml.njk
+++ b/examples/_includes/directory_list.xml.njk
@@ -1,11 +1,13 @@
 {# Standard template for showing a list of links to other screens. List is generated from a collection of screens with the given "list_tag" #}
 <list xmlns="https://hyperview.org/hyperview" trigger="refresh" action="replace" target="directory-list" id="directory-list" href="{% if list_href %}{{ list_href }}{% else %}{{ permalink }}{% endif %}">
-  {% for screen in collections[list_tag]|sortCollection %}
-    <item href="{{ screen.data.permalink }}" key="{{ screen.data.title | slug }}" show-during-load="loadingScreen" style="Item">
-      <view style="Item__Left">
-        <text style="Item__Label">{{ screen.data.title }}</text>
-      </view>
-      <text style="Item__Chevron">&gt;</text>
-    </item>
+  {% for tag in list_tag.split(',') %}
+    {% for screen in collections[tag]|sortCollection %}
+      <item href="{{ screen.data.permalink }}" key="{{ screen.data.title | slug }}" show-during-load="loadingScreen" style="Item">
+        <view style="Item__Left">
+          <text style="Item__Label">{{ screen.data.title }}</text>
+        </view>
+        <text style="Item__Chevron">&gt;</text>
+      </item>
+    {% endfor %}
   {% endfor %}
 </list>

--- a/examples/index_hyperview.xml.njk
+++ b/examples/index_hyperview.xml.njk
@@ -1,7 +1,7 @@
 ---
 title: "Hyperview"
 permalink: "index_hyperview.xml"
-list_tag: "root"
+list_tag: "root,hvroot"
 hide_back_button: true
 list_href: "list.xml"
 hyperview_toggle_enabled: true


### PR DESCRIPTION
- Updated the directory to split the "list_tag" field
- Updated the index_hyperview to look for both 'root' and 'hvroot' entries

This will allow `index_hyperview.xml` to include all of the "root" examples and will add any "hvroot" examples. The original `index.xml` will not include the "hvroot" and will therefore not provide examples it can't support.

Note: the 'navigators' section isn't yet committed, pending some additional examples.

https://github.com/Instawork/hyperview/assets/127122858/b34bca7e-12a2-4d95-b2b7-81b25a054f35