### PR TITLE
chore: add back trigger to examples

### DIFF
--- a/examples/navigator/back/index.xml.njk
+++ b/examples/navigator/back/index.xml.njk
@@ -1,0 +1,31 @@
+---
+title: "Back trigger"
+permalink: "/navigator/back/index.xml"
+tags: navigator
+---
+
+{% extends 'scrollview.xml.njk' %}
+{% block content %}
+  <text style="Description">When behaviors with a "trigger" of "back" are
+    included, standard back and close functionality is blocked. Remove or hide the
+    behaviors to restore functionality.</text>
+  <text style="Description">Note: this will only work when using the Hyperview Navigator.</text>
+  <view id="go_back" style="Button" action="back">
+    <text style="Button__Label">Go back</text>
+  </view>
+  <view id="back_behaviors">
+    <behavior
+      trigger="back"
+      action="alert"
+      alert:message="Are you sure you want to go back?"
+      alert:title="Back confirmation"
+      xmlns:alert="https://hyperview.org/hyperview-alert">
+      <alert:option alert:label="OK">
+        <behavior action="hide" target="back_behaviors"/>
+        <!-- the "delay" attribute is used to ensure the hide completes before 'back' is performed -->
+        <behavior action="back" delay="1"/>
+      </alert:option>
+      <alert:option alert:label="Cancel"/>
+    </behavior>
+  </view>
+{% endblock %}

--- a/examples/navigator/index.xml.njk
+++ b/examples/navigator/index.xml.njk
@@ -1,0 +1,12 @@
+---
+title: "Navigator"
+permalink: "/navigator/index.xml"
+tags: hvroot
+list_tag: navigator
+list_href: "/navigator/list.xml"
+---
+
+{% extends 'base.xml.njk' %}
+{% block container %}
+  {% include "./list.xml.njk" %}
+{% endblock %}


### PR DESCRIPTION
- Created a new 'navigator' section for the examples. This section will only appear when the `Hyperview Navigator` switch is enabled
- Added an example of using the `trigger="back"` behavior


https://github.com/Instawork/hyperview/assets/127122858/1aa805c3-d1af-4ccd-8130-e273588da4a1



Asana: https://app.asana.com/0/1204008699308084/1206596675964910/f
Asana: https://app.asana.com/0/1204008699308084/1206596675964914/f