### PR TITLE
chore: upgrade xml validation to support schema v1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - run: yarn test:ts
       - run: yarn test:unit
       - run: yarn test:render
-      - run: sudo apt-get update && sudo apt-get install libxml2-utils
+      - run: pip install xmlschema
       - run: yarn test:validate-xml
       - run: pip install djhtml
       - run: yarn test:lint

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:render": "npx patch-package && jest test/render.test.ts --forceExit",
     "test:unit": "jest --testPathPattern src",
     "test:xmlserver": "eleventy --serve --port=8085",
-    "test:validate-xml": "eleventy; find _examples_site test/schema -name '*.xml' -not -path '*/advanced_behaviors/instawork.xml' -not -path '*/advanced_behaviors/custom_share.xml' -not -path '*/advanced_behaviors/alert/behavior.xml' -not -path '*/case_studies/business_rating.xml' -not -path '*/case_studies/_rating_save.xml' -not -path '*/index.xml' -not -path '*/index_hyperview.xml' | xargs xmllint --schema schema/hyperview.xsd --noout",
+    "test:validate-xml": "eleventy; find _examples_site test/schema -name '*.xml' -not -path '*/advanced_behaviors/instawork.xml' -not -path '*/advanced_behaviors/custom_share.xml' -not -path '*/advanced_behaviors/alert/behavior.xml' -not -path '*/case_studies/business_rating.xml' -not -path '*/case_studies/_rating_save.xml' -not -path '*/index.xml' -not -path '*/index_hyperview.xml' | xargs xmlschema-validate --schema schema/hyperview.xsd --version 1.1",
     "test": "yarn generate test && yarn test:ts && yarn test:lint && yarn test:render && yarn test:unit && yarn test:validate-xml"
   },
   "dependencies": {

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -6,6 +6,8 @@
   xmlns:hv="https://hyperview.org/hyperview"
   xmlns:alert="https://hyperview.org/hyperview-alert"
   xmlns:scroll="https://hyperview.org/hyperview-scroll"
+  xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
+  vc:minVersion="1.1"
 >
 
   <xs:import

--- a/schema/hyperview.xsd
+++ b/schema/hyperview.xsd
@@ -4,6 +4,8 @@
   elementFormDefault="qualified"
   targetNamespace="https://hyperview.org/hyperview"
   xmlns:hv="https://hyperview.org/hyperview"
+  xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
+  vc:minVersion="1.1"
 >
   <xs:redefine schemaLocation="core.xsd">
     <xs:simpleType name="action">


### PR DESCRIPTION
- Added new `xmlschema` installation in circleCI
- Removed previous `xmllint` installation from circleCI
- Updated `validate-xml` test to use new `xmlschema-validation`
- Updated schema version of core.xsd and hyperview.xsd

Asana: https://app.asana.com/0/1204008699308084/1205539800446895/f