### PR TITLE
chore(tabbar): add support for overriding the tab bar component

### DIFF
--- a/src/core/components/navigator-tab/index.tsx
+++ b/src/core/components/navigator-tab/index.tsx
@@ -47,6 +47,8 @@ const CustomTabNavigator = (props: Types.Props) => {
   return (
     <NavigationContent>
       <BottomTabView
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
         descriptors={descriptors}
         navigation={navigation}
         state={state}

--- a/src/core/components/navigator-tab/types.tsx
+++ b/src/core/components/navigator-tab/types.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
-import { BottomTabNavigationOptions } from '@react-navigation/bottom-tabs';
+import {
+  BottomTabBarProps,
+  BottomTabNavigationOptions,
+} from '@react-navigation/bottom-tabs';
 
 export type Props = {
   id: string;
@@ -7,6 +10,7 @@ export type Props = {
   initialRouteName: string;
   children: React.ReactNode;
   screenOptions: BottomTabNavigationOptions;
+  tabBar?: ((props: BottomTabBarProps) => React.ReactNode) | undefined;
 };
 
 export type ParamListBase = Record<string, object | undefined>;


### PR DESCRIPTION
Adding ability to override tab bar component.

The UI is still disabled and no component is being injected so the tab bar won't be shown yet.

