### PR TITLE
chore: add simple stack example

### DIFF
--- a/examples/navigator/simple_stack/index.xml.njk
+++ b/examples/navigator/simple_stack/index.xml.njk
@@ -1,0 +1,12 @@
+---
+title: "Simple Stack Navigator"
+permalink: "/navigator/simple_stack/index.xml"
+tags: navigator
+---
+
+{# Example of a simple stack navigator #}
+<doc xmlns="https://hyperview.org/hyperview">
+  <navigator id="simple-stack-navigator" type="stack">
+    <nav-route id="simple-screen-route" href="/navigator/simple_stack/screen.xml"/>
+  </navigator>
+</doc>

--- a/examples/navigator/simple_stack/modal_1.xml.njk
+++ b/examples/navigator/simple_stack/modal_1.xml.njk
@@ -1,0 +1,19 @@
+---
+title: "Modal Screen 1"
+permalink: "/navigator/simple_stack/modal_1.xml"
+---
+
+{% extends 'base.xml.njk' %}
+{% block container %}
+  <view scroll="true">
+    <text style="Description">This screen was dynamically opened on the stack.</text>
+    <text style="Description">Pushing the button below will push another screen onto the stack.</text>
+    <view
+      action="push"
+      href="/navigator/simple_stack/modal_2.xml"
+      style="Button"
+    >
+      <text style="Button__Label">Push on stack</text>
+    </view>
+  </view>
+{% endblock %}

--- a/examples/navigator/simple_stack/modal_2.xml.njk
+++ b/examples/navigator/simple_stack/modal_2.xml.njk
@@ -1,0 +1,17 @@
+---
+title: "Modal Screen 2"
+permalink: "/navigator/simple_stack/modal_2.xml"
+---
+
+{% extends 'base.xml.njk' %}
+{% block container %}
+  <view scroll="true">
+    <text style="Description">This screen was dynamically opened on the stack.</text>
+    <view
+      action="close"
+      style="Button"
+    >
+      <text style="Button__Label">Back to beginning</text>
+    </view>
+  </view>
+{% endblock %}

--- a/examples/navigator/simple_stack/push_1.xml.njk
+++ b/examples/navigator/simple_stack/push_1.xml.njk
@@ -1,0 +1,19 @@
+---
+title: "Push Screen 1"
+permalink: "/navigator/simple_stack/push_1.xml"
+---
+
+{% extends 'base.xml.njk' %}
+{% block container %}
+  <view scroll="true">
+    <text style="Description">This screen was dynamically pushed to the stack.</text>
+    <text style="Description">Pushing the button below will push another screen onto the stack.</text>
+    <view
+      action="push"
+      href="/navigator/simple_stack/push_2.xml"
+      style="Button"
+    >
+      <text style="Button__Label">Push on stack</text>
+    </view>
+  </view>
+{% endblock %}

--- a/examples/navigator/simple_stack/push_2.xml.njk
+++ b/examples/navigator/simple_stack/push_2.xml.njk
@@ -1,0 +1,18 @@
+---
+title: "Push Screen 2"
+permalink: "/navigator/simple_stack/push_2.xml"
+---
+
+{% extends 'base.xml.njk' %}
+{% block container %}
+  <view scroll="true">
+    <text style="Description">This screen was dynamically pushed to the stack.</text>
+    <view
+      action="navigate"
+      href="#simple-screen-route"
+      style="Button"
+    >
+      <text style="Button__Label">Back to beginning</text>
+    </view>
+  </view>
+{% endblock %}

--- a/examples/navigator/simple_stack/screen.xml.njk
+++ b/examples/navigator/simple_stack/screen.xml.njk
@@ -1,0 +1,26 @@
+---
+title: "Simple Stack"
+permalink: "/navigator/simple_stack/screen.xml"
+---
+
+{% extends 'base.xml.njk' %}
+{% block container %}
+  <view scroll="true">
+    <text style="Description">Tapping the button below will push a screen onto this stack.</text>
+    <view
+      action="push"
+      href="/navigator/simple_stack/push_1.xml"
+      style="Button"
+    >
+      <text style="Button__Label">Push</text>
+    </view>
+    <text style="Description">Tapping the button below will create a modal screen on this stack.</text>
+    <view
+      action="new"
+      href="/navigator/simple_stack/modal_1.xml"
+      style="Button"
+    >
+      <text style="Button__Label">New</text>
+    </view>
+  </view>
+{% endblock %}


### PR DESCRIPTION
Adding a simple stack navigation example. This shows developers how to create a stack navigator and how "push" and "new" behaviors respond. It also shows a navigate with href to "go back to beginning".

https://github.com/Instawork/hyperview/assets/127122858/9331dc30-4c16-4367-99b6-b50182f6044e

Asana: https://app.asana.com/0/1204008699308084/1206627007566088/f