### PR TITLE
fix: hv-navigator buildScreens has mismatched argument signature

### DIFF
--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -192,8 +192,11 @@ export default class HvNavigator extends PureComponent<Props> {
   /**
    * Build all screens from received routes
    */
-  buildScreens = (element: Element, type: string): React.ReactNode => {
+  buildScreens = (type: string, element?: Element): React.ReactNode => {
     const screens: React.ReactElement[] = [];
+    if (!element) {
+      return screens;
+    }
     const elements: Element[] = NavigatorService.getChildElements(element);
 
     // For tab navigators, the screens are appended
@@ -270,7 +273,7 @@ export default class HvNavigator extends PureComponent<Props> {
             id={id}
             screenOptions={({ route }) => this.stackScreenOptions(route)}
           >
-            {this.buildScreens(this.props.element, type)}
+            {this.buildScreens(type, this.props.element)}
           </Stack.Navigator>
         );
       case NavigatorService.NAVIGATOR_TYPE.TAB:
@@ -281,7 +284,7 @@ export default class HvNavigator extends PureComponent<Props> {
             initialRouteName={selectedId}
             screenOptions={({ route }) => this.tabScreenOptions(route)}
           >
-            {this.buildScreens(this.props.element, type)}
+            {this.buildScreens(type, this.props.element)}
           </BottomTab.Navigator>
         );
       default:


### PR DESCRIPTION
The component props contains a nullable value: `element?: Element;`. The `buildScreens` method was expecting a valid value `element:Element`. For some reason this was not caught by TypeScript.

Updated `buildScreens` to accept a nullable element, which required switching the order of the args.