### PR TITLE
fix: storybook fails with newer Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "release:patch": "yarn version --patch",
     "release:minor": "yarn version --minor",
     "release:major": "yarn version --major",
-    "storybook": "storybook start -p 7007",
+    "storybook": "NODE_OPTIONS=--openssl-legacy-provider storybook start -p 7007",
     "test:ts": "tsc",
     "test:generators": "yarn generate test && git diff --quiet HEAD",
     "test:lint": "eslint src && prettier --check '**/*.xsd' '**/*.xml' '**/*.md' && yarn format-njk -c",


### PR DESCRIPTION
Was receiving the following error when running `yarn storybook`:


```
opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
library: 'digital envelope routines',
reason: 'unsupported',
code: 'ERR_OSSL_EVP_UNSUPPORTED'
```

Adding `NODE_OPTIONS=--openssl-legacy-provider` before starting the storybook server resolves the issue