### PR TITLE
fix: inactive tab should not be able to block back navigation

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -591,7 +591,11 @@ function HvRouteFC(props: Types.Props) {
           // Check for elements registered to interrupt back action via a trigger of BACK
           const { get, onUpdate } = backContext || {};
           const elements: Element[] = (get && get()) || [];
-          if (elements.length > 0 && onUpdate) {
+          if (
+            elements.length > 0 &&
+            onUpdate &&
+            props.navigation?.isFocused()
+          ) {
             // Process the elements
             event.preventDefault();
             elements.forEach(behaviorElement => {

--- a/src/services/navigator/types.ts
+++ b/src/services/navigator/types.ts
@@ -39,6 +39,7 @@ export type NavigationProp = {
     eventName: string,
     callback: (event: { preventDefault: () => void }) => void,
   ) => () => void;
+  isFocused: () => boolean;
 };
 
 /**


### PR DESCRIPTION
The tab navigator was allowing unfocused screens to block navigation because the "before remove" is applied to all open tabs in the navigator.

Use the 'isFocused()' check to ensure a screen which is not focused can't prevent back navigation.
- For tab navigators, only the active tab is focused
- For stack navigators, a modal does not defocus the screen below so it will maintain focus on multiple screens at once

In the following, the back blocker was applied only to tab-1

| Before | After |
| --- | --- |
| ![before](https://github.com/Instawork/hyperview/assets/127122858/2c6e54bd-3b72-4ccc-8f6b-5b5e453abc88) | ![after](https://github.com/Instawork/hyperview/assets/127122858/c35fb8e9-9899-4705-841e-210e84b365eb) |
