### PR TITLE
chore: update @react-native-picker/picker

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@babel/preset-env": "^7.22.20",
     "@react-native-community/datetimepicker": "7.2.0",
-    "@react-native-picker/picker": "2.4.10",
+    "@react-native-picker/picker": "2.6.1",
     "@react-navigation/bottom-tabs": "^6.5.9",
     "@react-navigation/native": "^6.1.8",
     "@react-navigation/stack": "^6.3.18",

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -2324,10 +2324,10 @@
   dependencies:
     invariant "^2.2.4"
 
-"@react-native-picker/picker@2.4.10":
-  version "2.4.10"
-  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.4.10.tgz#339c7bfc6e1d9a5e934122eaaa7767dc1c5fb725"
-  integrity sha512-EvAlHmPEPOwvbP6Pjg/gtDV3XJzIjIxr10fXFNlX5r9HeHw582G1Zt2o8FLyB718nOttgj8HYUTGxvhu4N65sQ==
+"@react-native-picker/picker@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.6.1.tgz#3b20ddd1385fab0487db103dc6519570f8892e6d"
+  integrity sha512-oJftvmLOj6Y6/bF4kPcK6L83yNBALGmqNYugf94BzP0FQGpHBwimVN2ygqkQ2Sn2ZU3pGUZMs0jV6+Gku2GyYg==
 
 "@react-native/assets-registry@^0.72.0":
   version "0.72.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "@react-native-community/datetimepicker": "^6.1.1",
-    "@react-native-picker/picker": "^2.4.0",
+    "@react-native-picker/picker": "^2.6.1",
     "@react-navigation/bottom-tabs": "^6.5.7",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/stack": "^6.3.16",
@@ -74,7 +74,7 @@
     "@faker-js/faker": "^8.0.2",
     "@prettier/plugin-xml": "0.13.0",
     "@react-native-community/datetimepicker": "6.1.1",
-    "@react-native-picker/picker": "2.4.0",
+    "@react-native-picker/picker": "2.6.1",
     "@react-navigation/bottom-tabs": "6.5.7",
     "@react-navigation/native": "6.1.6",
     "@react-navigation/stack": "6.3.16",

--- a/src/components/hv-picker-field/index.tsx
+++ b/src/components/hv-picker-field/index.tsx
@@ -141,7 +141,15 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
         return null;
       }
       const enabled = ['', 'true', null].includes(item.getAttribute('enabled'));
-      return <Picker.Item key={l + v} enabled={enabled} label={l} value={v} />;
+      return (
+        <Picker.Item
+          key={l + v}
+          enabled={enabled}
+          label={l}
+          style={{ fontSize: 16 }}
+          value={v}
+        />
+      );
     });
 
     // If there are no items, or the first item has a value,
@@ -155,6 +163,7 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
           // fix inspired by https://github.com/react-native-picker/picker/issues/95#issuecomment-935718568
           enabled={this.props.element.getAttribute('focused') !== 'true'}
           label={this.props.element.getAttribute('placeholder') || undefined}
+          style={{ fontSize: 16 }}
           value=""
         />,
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2261,10 +2261,10 @@
   dependencies:
     invariant "^2.2.4"
 
-"@react-native-picker/picker@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.4.0.tgz#7ca2e01a3bdf854ee01ca752762ffa73c0e83313"
-  integrity sha512-duGZc3a8Qa21YPrA4U3oR9NAUzBA66FTjubGK2CodA6rNjiwN+xC32hOZ5unkf4qD3DqLWeoPjg3fYf54bVMjA==
+"@react-native-picker/picker@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.6.1.tgz#3b20ddd1385fab0487db103dc6519570f8892e6d"
+  integrity sha512-oJftvmLOj6Y6/bF4kPcK6L83yNBALGmqNYugf94BzP0FQGpHBwimVN2ygqkQ2Sn2ZU3pGUZMs0jV6+Gku2GyYg==
 
 "@react-native/assets@1.0.0":
   version "1.0.0"


### PR DESCRIPTION
Updating @react-native-picker/picker from 2.4.0 to 2.6.1

- [updated package references]()
- [chore run `yarn`]()
- [updated demo package references]()
- [chore run `yarn` in demo]()
- [Resolved Android render issues]()

On Android, starting after v2.5.1, an issue occurs where a zero font size is used for the picker. See notes: https://github.com/react-native-picker/picker/issues/536

Upgrading Expo seems to resolve the issue. However, we decided that it would be better to include a fix in our wrapper.
- A default fontSize has been added to `<Picker.item>`
- iOS is not affected by this issue and has not been changed


Illustration of bug: https://github.com/Instawork/hyperview/assets/127122858/71029ef9-c335-4ef1-bdcb-ef3272dac9b5


| v2.4.0 | v2.6.2 (w/ 16 default) |
| -- | -- |
| ![v-2-4-0](https://github.com/Instawork/hyperview/assets/127122858/590b0836-66d1-4af8-a0f2-34bf41dd5d39) | ![v-2-6-0-size16](https://github.com/Instawork/hyperview/assets/127122858/19c5d52a-d425-413f-8a3c-148eba1dbc8d) |





Asana: https://app.asana.com/0/0/1206718044236459/f