### PR TITLE
fix(android): `HvDateField` "cancel" action

### DIFF
--- a/src/components/hv-date-field/index.tsx
+++ b/src/components/hv-date-field/index.tsx
@@ -210,7 +210,8 @@ export default class HvDateField extends PureComponent<HvComponentProps> {
       );
     }
     const onChange = (evt: DateTimePickerEvent, date?: Date) => {
-      if (date === undefined) {
+      // Covers press on "cancel" and Hardware back button on Android
+      if (evt.type === 'dismissed') {
         this.onCancel();
       } else {
         this.onDone(date);


### PR DESCRIPTION
Fix issue on Android with date field element, where selection would be made even when the cancel button was pressed. https://app.asana.com/0/491474088351836/1206790355289524/f

| Before | After |
|-------|-------|
| ![before](https://github.com/Instawork/hyperview/assets/309515/e97ef88d-5dd1-437f-8417-4141d38d1d8e) | ![after](https://github.com/Instawork/hyperview/assets/309515/216a939c-1e79-479a-9c9d-710f899c5f9f) |
