### PR TITLE
chore: Remove transpilation

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,6 +14,7 @@ _examples_site/
 demo/
 docs/
 examples/
+lib/
 node_modules/
 scripts/
 stories/

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperview",
   "version": "0.78.0",
-  "main": "lib/index.js",
+  "main": "src/index.ts",
   "description": "React Native client for Hyperview XML",
   "homepage": "https://hyperview.org",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -24,10 +24,9 @@
     }
   },
   "scripts": {
-    "build": "babel src --extensions \".ts,.tsx,.js,.jsx\" --out-dir lib",
     "sync": "babel-node ./scripts/sync",
     "generate": "babel-node ./scripts/generate",
-    "preversion": "yarn test && yarn build",
+    "preversion": "yarn test",
     "prettify": "pretty-quick && prettier --write '**/*.xsd' '**/*.xml' '**/*.md'",
     "postversion": "yarn publish --new-version $npm_package_version && cd demo && yarn add hyperview@$npm_package_version && git add package.json yarn.lock && git commit -m\"chore(demo): update Hyperview to v$npm_package_version\" && cd .. && git push --follow-tags",
     "format-njk": "./scripts/format-njk.sh",


### PR DESCRIPTION
Hyperview does not require transpilation anymore.
- [chore: set package main to use src instead of lib](https://github.com/Instawork/hyperview/commit/3843e7934f19ba478f5a9e8e7e0a96e627ebb52d)
- [chore: remove build script](https://github.com/Instawork/hyperview/commit/75d25c3e9d730f73f3a7c67abb614d81a1638078)
- [chore: ignore lib in future npm releases](https://github.com/Instawork/hyperview/commit/19d03b344034ccf5ee56ea2d9e7f46757c4751ee)


Tested against MDS viewer.

Asana: https://app.asana.com/0/1204008699308084/1207079738575229/f