### PR TITLE
fix(navigation): resolve back and close issues

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -29,6 +29,7 @@ import LoadError from 'hyperview/src/core/components/load-error';
 import Loading from 'hyperview/src/core/components/loading';
 // eslint-disable-next-line instawork/import-services
 import Navigation from 'hyperview/src/services/navigation';
+import { NavigationContainerRefContext } from '@react-navigation/native';
 
 /**
  * Implementation of an HvRoute component
@@ -38,6 +39,8 @@ import Navigation from 'hyperview/src/services/navigation';
  * - Handles errors
  */
 class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
+  static contextType = NavigationContainerRefContext;
+
   parser?: DomService.Parser;
 
   navLogic: NavigatorService.Navigator;
@@ -83,6 +86,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
       this.props.onParseBefore || null,
       this.props.onParseAfter || null,
     );
+    this.navLogic.setContext(this.context);
 
     // When a nested navigator is found, the document is not loaded from url
     if (this.props.element === undefined) {

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -16,7 +16,7 @@ export const isDynamicRoute = (id: string): boolean => {
 };
 
 export const isModalRouteName = (name: string): boolean => {
-  return name === Types.ID_MODAL;
+  return name.startsWith(Types.ID_MODAL);
 };
 
 /**

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -327,6 +327,10 @@ const buildCloseRequest = (
         ];
       }
     }
+    // If the first route is a modal, perform a close action
+    if (isRouteModal(state, 0)) {
+      return [NAV_ACTIONS.CLOSE, navigation, '', routeParams];
+    }
   }
   const parent = navigation.getParent();
   if (!parent) {

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -4,6 +4,7 @@ import * as Imports from './imports';
 import * as Types from './types';
 import type { NavAction, NavigationRouteParams } from 'hyperview/src/types';
 import { NAV_ACTIONS } from 'hyperview/src/types';
+import { NavigationContainerRefContext } from '@react-navigation/native';
 
 /**
  * Provide navigation action implementations
@@ -11,9 +12,19 @@ import { NAV_ACTIONS } from 'hyperview/src/types';
 export class Navigator {
   props: HvRoute.Props;
 
+  context:
+    | React.ContextType<typeof NavigationContainerRefContext>
+    | undefined = undefined;
+
   constructor(props: HvRoute.Props) {
     this.props = props;
   }
+
+  setContext = (
+    context: React.ContextType<typeof NavigationContainerRefContext>,
+  ) => {
+    this.context = context;
+  };
 
   /**
    * Process the request by changing params before going back


### PR DESCRIPTION
Resolving a few issues:
1. When a background route calls "back" it should not close the current modal
2. Close should close the closest modal
  a. In a stack, this means going to the route before the modal
  b. It must also handle cases where the first route is a modal
3. Back and close must target the correct route with any param updates 