### PR TITLE
chore: create script to update readme from package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "scripts": {
     "sync": "babel-node ./scripts/sync",
     "generate": "babel-node ./scripts/generate",
-    "preversion": "yarn test",
+    "preversion": "yarn test && ./scripts/update-version",
     "prettify": "pretty-quick && prettier --write '**/*.xsd' '**/*.xml' '**/*.md'",
-    "postversion": "yarn publish --new-version $npm_package_version && cd demo && yarn add hyperview@$npm_package_version && git add package.json yarn.lock && git commit -m\"chore(demo): update Hyperview to v$npm_package_version\" && cd .. && git push --follow-tags",
+    "postversion": "yarn publish --new-version $npm_package_version && cd demo && yarn add hyperview@$npm_package_version && git add package.json yarn.lock README.md && git commit -m\"chore(demo): update Hyperview to v$npm_package_version\" && cd .. && git push --follow-tags",
     "format-njk": "./scripts/format-njk.sh",
     "release:patch": "yarn version --patch",
     "release:minor": "yarn version --minor",

--- a/scripts/update-readme
+++ b/scripts/update-readme
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+
+# Replace the dependencies in the README.md file with the actual dependencies from the package.json file
+# Requires jq to be installed though will graceully exit if not included
+
+if ! command -v jq &> /dev/null
+then
+    echo "jq is required to run update-readme. This will not block the build process but the README.md file will not be updated."
+    exit 0
+fi
+
+PACKAGE_JSON=$(cat package.json)
+DEPENDENCIES=($(jq -r '.dependencies | to_entries | map("\(.key)=\(.value)")|.[]' <<< $PACKAGE_JSON))
+PEER_DEPENDENCIES=($(jq -r '.peerDependencies | to_entries | map("\(.key)=\(.value)")|.[]' <<< $PACKAGE_JSON))
+
+formatDependency() {
+  dep=$1
+  if [[ $dep == *"^"* ]]; then dep="${dep//[=]/ >= }"; else dep="${dep//[=]/ = }"; fi
+  dep="${dep//[\^]/}"
+  echo $dep
+}
+
+document=""
+replacing=false
+while IFS= read -r line; do
+  # Inject the required dependencies
+  if [[ $line == *"required dependencies:"* ]]; then
+    replacing=true
+    document="$document\n$line\n"
+    for d in "${DEPENDENCIES[@]}"; do
+      document="$document\n- $(formatDependency $d)"
+    done
+    document="$document\n"
+  fi
+
+  # Inject the peer dependencies
+  if [[ $line == *"peer dependencies:"* ]]; then
+    replacing=true
+    document="$document\n$line\n"
+    for d in "${PEER_DEPENDENCIES[@]}"; do
+      document="$document\n- $(formatDependency $d)"
+    done
+    document="$document\n"
+  fi
+
+  if [[ $line == *"### Getting Started"* ]]; then
+    replacing=false
+  fi
+
+  if [[ $replacing == false ]]; then
+    if [[ $document == "" ]]; then document="$line"; else document="$document\n$line"; fi
+  fi
+done < README.md
+
+echo "$document" > README.md


### PR DESCRIPTION
- Added a shell script to automatically update parts of the readme with the dependencies and peer dependencies.
  - Requires [jq](https://jqlang.github.io/jq/) to run but will exit early and not block the remaining script if not included.
- Updated pre-version to run this script
- Updated post-version to include readme in git commit

| package.json | readme.md |
| --- | --- |
| ![package](https://github.com/Instawork/hyperview/assets/127122858/9629a708-f837-4231-a2b3-9d941a0c889e) | ![readme](https://github.com/Instawork/hyperview/assets/127122858/f0a42dcc-f1d6-469c-9b6b-5d951c569b19) |

Asana: https://app.asana.com/0/1204008699308084/1207182290354073/f