### PR TITLE
fix: url is reverted after navigation change

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -556,6 +556,7 @@ function HvRouteFC(props: Types.Props) {
   );
 
   React.useEffect(() => {
+    const id = props.route?.params?.id || props.route?.key;
     if (props.navigation) {
       const unsubscribeBlur: () => void = props.navigation.addListener(
         'blur',
@@ -571,7 +572,6 @@ function HvRouteFC(props: Types.Props) {
         'focus',
         () => {
           const doc = docContext?.getDoc();
-          const id = props.route?.params?.id || props.route?.key;
           NavigatorService.setSelected(doc, id, docContext?.setDoc);
           NavigatorService.addStackRoute(
             doc,
@@ -625,10 +625,24 @@ function HvRouteFC(props: Types.Props) {
         },
       );
 
+      // Update the urls in each route when the state updates the params
+      const unsubscribeState: () => void = props.navigation.addListener(
+        'state',
+        event => {
+          NavigatorService.updateRouteUrlFromState(
+            docContext?.getDoc(),
+            id,
+            event.data?.state,
+            docContext?.setDoc,
+          );
+        },
+      );
+
       return () => {
         unsubscribeBlur();
         unsubscribeFocus();
         unsubscribeRemove();
+        unsubscribeState();
       };
     }
     return undefined;

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -162,5 +162,6 @@ export {
   mergeDocument,
   removeStackRoute,
   setSelected,
+  updateRouteUrlFromState,
 } from './helpers';
 export { ID_CARD, ID_MODAL, KEY_MODAL, NAVIGATOR_TYPE } from './types';

--- a/src/services/navigator/types.ts
+++ b/src/services/navigator/types.ts
@@ -37,7 +37,10 @@ export type NavigationProp = {
   getParent: (id?: string) => NavigationProp | undefined;
   addListener: (
     eventName: string,
-    callback: (event: { preventDefault: () => void }) => void,
+    callback: (event: {
+      data: { state: NavigationState | undefined } | undefined;
+      preventDefault: () => void;
+    }) => void,
   ) => () => void;
   isFocused: () => boolean;
 };


### PR DESCRIPTION
When navigating between multiple screens, if the url is updated in a screen, that change is lost when navigating away and back again.

**Resolution:**
Ensure the DOM is updated with the new href value

| Before | After |
| --- | --- |
| ![before](https://github.com/Instawork/hyperview/assets/127122858/032d88ac-0099-44ee-9def-59b1d3af3911) | ![after](https://github.com/Instawork/hyperview/assets/127122858/75aac815-4094-48d7-aba8-380ed554cbde) |

Asana: https://app.asana.com/0/1204008699308084/1207291078589952/f