### PR TITLE
fix: avoid duplicate loads

### DIFF
--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -143,6 +143,8 @@ export default class HvScreen extends React.Component {
     // this.navigation.preloadScreens to prevent memory leaks.
 
     if (newUrl && newUrl !== oldUrl) {
+      // Injecting a passed document as a single-use document
+      this.initialDoc = nextProps.doc;
       this.needsLoad = true;
 
       const preloadScreen = newPreloadScreen


### PR DESCRIPTION
When the url is changed, route is performing a load and then screen is performing a load. Make sure the updated doc from route is passed to screen to avoid a second load.

Asana: https://app.asana.com/0/1204008699308084/1207291078589952/f