### PR TITLE
fix: avoid duplicate loads

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -121,6 +121,17 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
   };
 
   /**
+   * Fix for both route and screen loading the document when url changes
+   * The route will not perform a load if a screen has already been rendered
+   */
+  shouldReloadLoad = (): boolean => {
+    return (
+      !this.localDoc ||
+      !(this.getRenderElement()?.localName === LOCAL_NAME.SCREEN)
+    );
+  };
+
+  /**
    * Load the url and resolve the xml.
    */
   load = async (): Promise<void> => {
@@ -137,7 +148,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
       // When a modal is included, a wrapper stack navigator is created
       // The route which contains the navigator should not load the document
       // The code below prevents the route from loading the document
-      if (this.props.route?.params?.isModal) {
+      if (this.props.route?.params?.isModal || !this.shouldReloadLoad()) {
         return;
       }
 

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -124,7 +124,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
    * Fix for both route and screen loading the document when url changes
    * The route will not perform a load if a screen has already been rendered
    */
-  shouldReloadLoad = (): boolean => {
+  shouldReload = (): boolean => {
     return (
       !this.localDoc ||
       !(this.getRenderElement()?.localName === LOCAL_NAME.SCREEN)
@@ -148,7 +148,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
       // When a modal is included, a wrapper stack navigator is created
       // The route which contains the navigator should not load the document
       // The code below prevents the route from loading the document
-      if (this.props.route?.params?.isModal || !this.shouldReloadLoad()) {
+      if (this.props.route?.params?.isModal || !this.shouldReload()) {
         return;
       }
 

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -143,8 +143,6 @@ export default class HvScreen extends React.Component {
     // this.navigation.preloadScreens to prevent memory leaks.
 
     if (newUrl && newUrl !== oldUrl) {
-      // Injecting a passed document as a single-use document
-      this.initialDoc = nextProps.doc;
       this.needsLoad = true;
 
       const preloadScreen = newPreloadScreen


### PR DESCRIPTION
HvRoute should not load new documents once an HvScreen has been created. The HvScreen will handle its own reloads.

Asana: https://app.asana.com/0/1204008699308084/1207291078589952/f