### PR TITLE
Fix: Parse <select-single>'s allowDeselect attribute correctly

### DIFF
--- a/src/components/hv-select-single/index.ts
+++ b/src/components/hv-select-single/index.ts
@@ -72,7 +72,7 @@ export default class HvSelectSingle extends PureComponent<HvComponentProps> {
       if (opt) {
         const value = opt.getAttribute('value');
         const current = value === selectedValue;
-        if (current && allowDeselect) {
+        if (current && allowDeselect === 'true') {
           // when deselection is allowed and user presses the option
           const selected = opt.getAttribute('selected') === 'true';
           opt.setAttribute('selected', selected ? 'false' : 'true');


### PR DESCRIPTION
HvSelectSingle component's on select function does not parse allow-deselect properly.
Right now, setting allow-deselect to any value causes the option to be de-selectable. It should only be the case when the attribute is set to true

Asana ticket:
https://app.asana.com/0/1204008699308084/1207361925394121/f

Fix:
1. check if allowDeselect === "true" rather than just asserting on allowDeselect

Testing:
1. open file: hyperview/examples/ui_elements/forms/select_single/index.xml.njk and set allow-deselect = "asdf"
2. Open the Hyperview demo app. UI Elements > Forms > Single Select
3. Test the changes for the "Optional Select" select group by selecting an option.
4. Deselect should not work as allow-deselect is set to arbitary string.
5. Perform steps 1-5 by setting allow-deselect = "true". deselect should work as expected
6. All other select groups should not support deselect ( allow-deselect prop not passed )

Screenshots of testing:
1. with allow-deselect = "true"

https://github.com/Instawork/hyperview/assets/46896318/368bc700-f901-4bcd-8b88-cb0086ce6206



2.  with allow-deselect = "adsf"

https://github.com/Instawork/hyperview/assets/46896318/e25a6a16-3144-4ae8-8d51-4415312d44f1


