### PR TITLE
fix (error component): error component is covering tabor

### DIFF
--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -281,13 +281,13 @@ export default class HvScreen extends React.Component {
         }}
       >
         <Contexts.DateFormatContext.Provider value={this.props.formatDate}>
-          {screenElement}
           {elementErrorComponent
             ? React.createElement(elementErrorComponent, {
                 error: this.state.elementError,
                 onPressReload: () => this.reload(),
               })
             : null}
+          {screenElement}
         </Contexts.DateFormatContext.Provider>
       </Contexts.DocContext.Provider>
     );

--- a/src/core/components/load-element-error/styles.ts
+++ b/src/core/components/load-element-error/styles.ts
@@ -3,7 +3,7 @@ import { StyleSheet } from 'react-native';
 export default StyleSheet.create({
   btnWrapper: {
     paddingLeft: 8,
-    paddingTop: 8,
+    paddingTop: 2,
   },
   button: {
     alignSelf: 'center',
@@ -14,16 +14,17 @@ export default StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     justifyContent: 'center',
-    paddingBottom: 8,
+    paddingBottom: 2,
     paddingHorizontal: 8,
   },
   safeArea: {
+    backgroundColor: '#ffffff',
     bottom: 0,
-    position: 'absolute',
+    position: 'relative',
     width: '100%',
   },
   textWrapper: {
-    paddingTop: 8,
+    paddingTop: 2,
   },
   title: {
     color: 'black',


### PR DESCRIPTION
The internal `load-element-error` component was rendering at the bottom of the HVScreen. In applications which use ReactNavigation's tab bars, the bottom of the screen was above the tab bar. When tabs are rendered within the screen, the component floated part way up the tab bar (see 'original' below).

By moving the error to the top of the screen and pushing content down, we retain safe area boundaries and avoid floating over existing content.

| Original | Updated |
| -- | -- |
| ![shifts-before](https://github.com/Instawork/hyperview/assets/127122858/519c878c-1ef9-4983-90bd-7700cd7cae36) | ![updated](https://github.com/Instawork/hyperview/assets/127122858/db0b59d1-e45b-4801-81fe-de8cd2e1d83f) |


The following show a few other examples of how the change affects screen appearance.

| Connected | Disconnected |
| -- | -- |
| ![refer-before](https://github.com/Instawork/hyperview/assets/127122858/e31d37a2-5a65-455d-bad9-7f0feddd313b) | ![refer-error](https://github.com/Instawork/hyperview/assets/127122858/a76a419b-289b-47f7-af13-6628831467c1)
| ![messages-before](https://github.com/Instawork/hyperview/assets/127122858/167f27c5-c690-412f-ac5a-eab9ea61489c) | ![messages-error](https://github.com/Instawork/hyperview/assets/127122858/6a7ca8c8-fd3e-44b2-a6e4-ba6c5d729f33) |


Also tested in the demo using the default component and a custom component

| Default | Custom |
| -- | -- |
| ![default](https://github.com/Instawork/hyperview/assets/127122858/fb5248f9-c35d-48a1-9e0b-9d26fd6febde) | ![custom](https://github.com/Instawork/hyperview/assets/127122858/52ed434a-43b9-41df-ac71-f8133721eb8b) |



Asana: https://app.asana.com/0/1204008699308084/1207426043394013/f