### PR TITLE
fix(webview): Hide webview loader when page renders before the loading of subresources

### DIFF
--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -1199,10 +1199,12 @@
       <xs:attribute name="allows-inline-media-playback" type="xs:boolean" />
       <xs:attribute name="injected-java-script" type="xs:string" />
       <xs:attribute name="show-loading-indicator">
-        <xs:restriction base="xs:string">
-          <xs:enumeration value="all"/>
-          <xs:enumeration value="document-only"/>
-        </xs:restriction>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="all"/>
+            <xs:enumeration value="document-only"/>
+          </xs:restriction>
+        </xs:simpleType>
       </xs:attribute>
       <xs:attribute name="id" type="hv:ID" />
       <xs:attribute name="key" type="hv:KEY" />

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -1201,8 +1201,8 @@
       <xs:attribute name="show-loading-indicator">
         <xs:simpleType>
           <xs:restriction base="xs:string">
-            <xs:enumeration value="all"/>
-            <xs:enumeration value="document-only"/>
+            <xs:enumeration value="all" />
+            <xs:enumeration value="document-only" />
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -1198,6 +1198,12 @@
       <xs:attribute name="activity-indicator-color" type="hv:color" />
       <xs:attribute name="allows-inline-media-playback" type="xs:boolean" />
       <xs:attribute name="injected-java-script" type="xs:string" />
+      <xs:attribute name="show-loading-indicator">
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="all"/>
+          <xs:enumeration value="document-only"/>
+        </xs:restriction>
+      </xs:attribute>
       <xs:attribute name="id" type="hv:ID" />
       <xs:attribute name="key" type="hv:KEY" />
     </xs:complexType>

--- a/src/components/hv-select-single/index.ts
+++ b/src/components/hv-select-single/index.ts
@@ -72,7 +72,7 @@ export default class HvSelectSingle extends PureComponent<HvComponentProps> {
       if (opt) {
         const value = opt.getAttribute('value');
         const current = value === selectedValue;
-        if (current && allowDeselect) {
+        if (current && allowDeselect === 'true') {
           // when deselection is allowed and user presses the option
           const selected = opt.getAttribute('selected') === 'true';
           opt.setAttribute('selected', selected ? 'false' : 'true');

--- a/src/components/hv-select-single/index.ts
+++ b/src/components/hv-select-single/index.ts
@@ -72,7 +72,7 @@ export default class HvSelectSingle extends PureComponent<HvComponentProps> {
       if (opt) {
         const value = opt.getAttribute('value');
         const current = value === selectedValue;
-        if (current && allowDeselect === 'true') {
+        if (current && allowDeselect) {
           // when deselection is allowed and user presses the option
           const selected = opt.getAttribute('selected') === 'true';
           opt.setAttribute('selected', selected ? 'false' : 'true');

--- a/src/components/hv-web-view/index.tsx
+++ b/src/components/hv-web-view/index.tsx
@@ -14,10 +14,6 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
 
   static localNameAliases = [];
 
-  behaviorMapping: { [key: string]: string } = {
-    stopLoader: 'window.ReactNativeWebView.postMessage("stopLoader");',
-  };
-
   state = {
     renderLoading: true,
   };
@@ -33,7 +29,9 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
       return;
     }
     const matches = event.nativeEvent.data.match(/^hyperview:(.*)$/);
-    const stopLoaderEvent = event.nativeEvent.data.match(/^stopLoader$/);
+    const stopLoaderEvent = event.nativeEvent.data.match(
+      /^hv-web-view:stopLoader$/,
+    );
     if (matches) {
       Events.dispatch(matches[1]);
     } else if (stopLoaderEvent) {
@@ -52,10 +50,12 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
       ? props['allows-inline-media-playback'] === 'true'
       : undefined;
     const color = props['activity-indicator-color'] || '#8d9494';
-    const documentLoadBehavior = props['document-load-behavior'];
-    const injectedJavaScript =
-      props['injected-java-script'] +
-      (this.behaviorMapping[documentLoadBehavior] || '');
+    const loadBehavior = props['show-load-indicator'];
+    let injectedJavaScript = props['injected-java-script'];
+    if (loadBehavior === 'document-only') {
+      injectedJavaScript +=
+        'window.ReactNativeWebView.postMessage("hv-web-view:stopLoader");';
+    }
     const source = { html: props.html, uri: props.url } as const;
     return (
       <WebView

--- a/src/components/hv-web-view/index.tsx
+++ b/src/components/hv-web-view/index.tsx
@@ -14,8 +14,12 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
 
   static localNameAliases = [];
 
+  behaviorMapping: { [key: string]: string } = {
+    stopLoader: 'window.ReactNativeWebView.postMessage("stopLoader");',
+  }
+
   state = {
-    loading: true,
+    renderLoading: true,
   };
 
   onMessage = (
@@ -33,17 +37,9 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
     if (matches) {
       Events.dispatch(matches[1]);
     } else if (stopLoaderEvent) {
-      this.setState({loading: false});
+      this.setState({renderLoading: false});
     }
   };
-
-  renderLoading = (color:string) => {
-    return this.state.loading ? 
-    <ActivityIndicator
-      color={color}
-      style={StyleSheet.absoluteFillObject}
-    /> : <View/>
-  }
 
   render() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -56,15 +52,19 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
       ? props['allows-inline-media-playback'] === 'true'
       : undefined;
     const color = props['activity-indicator-color'] || '#8d9494';
-    const domContentBehavior = props['dom-content-behavior'] || "";
-    const injectedJavaScript = props['injected-java-script'] + domContentBehavior;
+    const documentLoadBehavior = props['document-load-behavior'];
+    const injectedJavaScript = props['injected-java-script'] + (this.behaviorMapping[documentLoadBehavior] || "");
     const source = { html: props.html, uri: props.url } as const;
     return (
       <WebView
         allowsInlineMediaPlayback={allowsInlineMediaPlayback}
         injectedJavaScript={injectedJavaScript}
         onMessage={this.onMessage}
-        renderLoading={() => this.renderLoading(color)}
+        renderLoading={() => this.state.renderLoading ? 
+          <ActivityIndicator
+            color={color}
+            style={StyleSheet.absoluteFillObject}
+          /> : <View/>}
         source={source}
         startInLoadingState
       />

--- a/src/components/hv-web-view/index.tsx
+++ b/src/components/hv-web-view/index.tsx
@@ -1,6 +1,6 @@
 import * as Events from 'hyperview/src/services/events';
 import * as Namespaces from 'hyperview/src/services/namespaces';
-import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, StyleSheet } from 'react-native';
 import React, { PureComponent } from 'react';
 import type { HvComponentProps } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';

--- a/src/components/hv-web-view/index.tsx
+++ b/src/components/hv-web-view/index.tsx
@@ -16,7 +16,7 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
 
   behaviorMapping: { [key: string]: string } = {
     stopLoader: 'window.ReactNativeWebView.postMessage("stopLoader");',
-  }
+  };
 
   state = {
     renderLoading: true,
@@ -37,7 +37,7 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
     if (matches) {
       Events.dispatch(matches[1]);
     } else if (stopLoaderEvent) {
-      this.setState({renderLoading: false});
+      this.setState({ renderLoading: false });
     }
   };
 
@@ -53,18 +53,25 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
       : undefined;
     const color = props['activity-indicator-color'] || '#8d9494';
     const documentLoadBehavior = props['document-load-behavior'];
-    const injectedJavaScript = props['injected-java-script'] + (this.behaviorMapping[documentLoadBehavior] || "");
+    const injectedJavaScript =
+      props['injected-java-script'] +
+      (this.behaviorMapping[documentLoadBehavior] || '');
     const source = { html: props.html, uri: props.url } as const;
     return (
       <WebView
         allowsInlineMediaPlayback={allowsInlineMediaPlayback}
         injectedJavaScript={injectedJavaScript}
         onMessage={this.onMessage}
-        renderLoading={() => this.state.renderLoading ? 
-          <ActivityIndicator
-            color={color}
-            style={StyleSheet.absoluteFillObject}
-          /> : <View/>}
+        renderLoading={() => {
+          return this.state.renderLoading ? (
+            <ActivityIndicator
+              color={color}
+              style={StyleSheet.absoluteFillObject}
+            />
+          ) : (
+            <View />
+          );
+        }}
         source={source}
         startInLoadingState
       />

--- a/src/components/hv-web-view/index.tsx
+++ b/src/components/hv-web-view/index.tsx
@@ -29,8 +29,7 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
       return;
     }
 
-
-    if (event.nativeEvent.data === "hv-web-view:render-loading:false") {
+    if (event.nativeEvent.data === 'hv-web-view:render-loading:false') {
       this.setState({ renderLoading: false });
     }
     const matches = event.nativeEvent.data.match(/^hyperview:(.*)$/);

--- a/src/components/hv-web-view/index.tsx
+++ b/src/components/hv-web-view/index.tsx
@@ -1,6 +1,6 @@
 import * as Events from 'hyperview/src/services/events';
 import * as Namespaces from 'hyperview/src/services/namespaces';
-import { ActivityIndicator, StyleSheet } from 'react-native';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import React, { PureComponent } from 'react';
 import type { HvComponentProps } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
@@ -14,6 +14,10 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
 
   static localNameAliases = [];
 
+  state = {
+    loading: true,
+  };
+
   onMessage = (
     event: {
       nativeEvent: {
@@ -25,10 +29,21 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
       return;
     }
     const matches = event.nativeEvent.data.match(/^hyperview:(.*)$/);
+    const stopLoaderEvent = event.nativeEvent.data.match(/^stopLoader$/);
     if (matches) {
       Events.dispatch(matches[1]);
+    } else if (stopLoaderEvent) {
+      this.setState({loading: false});
     }
   };
+
+  renderLoading = (color:string) => {
+    return this.state.loading ? 
+    <ActivityIndicator
+      color={color}
+      style={StyleSheet.absoluteFillObject}
+    /> : <View/>
+  }
 
   render() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -41,19 +56,15 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
       ? props['allows-inline-media-playback'] === 'true'
       : undefined;
     const color = props['activity-indicator-color'] || '#8d9494';
-    const injectedJavaScript = props['injected-java-script'];
+    const domContentBehavior = props['dom-content-behavior'] || "";
+    const injectedJavaScript = props['injected-java-script'] + domContentBehavior;
     const source = { html: props.html, uri: props.url } as const;
     return (
       <WebView
         allowsInlineMediaPlayback={allowsInlineMediaPlayback}
         injectedJavaScript={injectedJavaScript}
         onMessage={this.onMessage}
-        renderLoading={() => (
-          <ActivityIndicator
-            color={color}
-            style={StyleSheet.absoluteFillObject}
-          />
-        )}
+        renderLoading={() => this.renderLoading(color)}
         source={source}
         startInLoadingState
       />

--- a/src/components/hv-web-view/index.tsx
+++ b/src/components/hv-web-view/index.tsx
@@ -28,14 +28,14 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
     if (!event) {
       return;
     }
+
+
+    if (event.nativeEvent.data === "hv-web-view:render-loading:false") {
+      this.setState({ renderLoading: false });
+    }
     const matches = event.nativeEvent.data.match(/^hyperview:(.*)$/);
-    const stopLoaderEvent = event.nativeEvent.data.match(
-      /^hv-web-view:stopLoader$/,
-    );
     if (matches) {
       Events.dispatch(matches[1]);
-    } else if (stopLoaderEvent) {
-      this.setState({ renderLoading: false });
     }
   };
 
@@ -50,11 +50,11 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
       ? props['allows-inline-media-playback'] === 'true'
       : undefined;
     const color = props['activity-indicator-color'] || '#8d9494';
-    const loadBehavior = props['show-load-indicator'];
+    const loadBehavior = props['show-loading-indicator'];
     let injectedJavaScript = props['injected-java-script'];
     if (loadBehavior === 'document-only') {
       injectedJavaScript +=
-        'window.ReactNativeWebView.postMessage("hv-web-view:stopLoader");';
+        'window.ReactNativeWebView.postMessage("hv-web-view:render-loading:false");';
     }
     const source = { html: props.html, uri: props.url } as const;
     return (

--- a/src/components/hv-web-view/index.tsx
+++ b/src/components/hv-web-view/index.tsx
@@ -69,7 +69,7 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
               style={StyleSheet.absoluteFillObject}
             />
           ) : (
-            <View />
+            <></>
           );
         }}
         source={source}


### PR DESCRIPTION
[Asana Ticket](https://app.asana.com/0/491474088351836/1207417081499074/f)

### Summary
1. WebView might render the document before other sub-resources have finished loading
2. This forces HvWebView to show a loading spinner rendering the WebView non-interactive.
3. Adding a custom javascript snipped to close the spinner upon initial render fixes this problem
4. Added Custom handler to capture document load event


### Screenshots
| Before | After |
| -- | -- |
| ![before](https://github.com/Instawork/instawork/assets/171086373/53b52294-b081-4b2f-8110-2f7f6238a2af) | ![after](https://github.com/Instawork/instawork/assets/171086373/adbecc51-0dd3-456a-a7bc-1789f0920050) |





### To-do