### PR TITLE
feature (navigation): allow nesting navigation with broken inheritance chain

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -21,6 +21,10 @@ import type {
   NavigationRouteParams,
   ScreenState,
 } from 'hyperview/src/types';
+import {
+  NavigationContainerRefContext,
+  useNavigation,
+} from '@react-navigation/native';
 import React, { JSXElementConstructor, PureComponent, useContext } from 'react';
 import HvNavigator from 'hyperview/src/core/components/hv-navigator';
 import HvScreen from 'hyperview/src/core/components/hv-screen';
@@ -29,7 +33,6 @@ import LoadError from 'hyperview/src/core/components/load-error';
 import Loading from 'hyperview/src/core/components/loading';
 // eslint-disable-next-line instawork/import-services
 import Navigation from 'hyperview/src/services/navigation';
-import { NavigationContainerRefContext } from '@react-navigation/native';
 
 /**
  * Implementation of an HvRoute component
@@ -559,6 +562,7 @@ function HvRouteFC(props: Types.Props) {
   const docContext = useContext(Contexts.DocContext);
 
   const url = getRouteUrl(props, navigationContext);
+  const rootNavigation = useNavigation();
 
   // Get the navigator element from the context
   const element: Element | undefined = getNestedNavigator(
@@ -665,6 +669,11 @@ function HvRouteFC(props: Types.Props) {
     navigationContext,
   ]);
 
+  const nav =
+    props.navigation || rootNavigation.getState()
+      ? (rootNavigation as NavigatorService.NavigationProp)
+      : undefined;
+
   return (
     <HvRouteInner
       behaviors={navigationContext.behaviors}
@@ -677,7 +686,7 @@ function HvRouteFC(props: Types.Props) {
       getPreload={navigatorMapContext.getPreload}
       handleBack={navigationContext.handleBack}
       loadingScreen={navigationContext.loadingScreen}
-      navigation={props.navigation}
+      navigation={nav}
       onParseAfter={navigationContext.onParseAfter}
       onParseBefore={navigationContext.onParseBefore}
       onUpdate={navigationContext.onUpdate}

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -564,10 +564,7 @@ function HvRouteFC(props: Types.Props) {
   const url = getRouteUrl(props, navigationContext);
   const rootNavigation = useNavigation();
   const nav =
-    props.navigation ||
-    (rootNavigation.getState()
-      ? (rootNavigation as NavigatorService.NavigationProp)
-      : undefined);
+    props.navigation || (rootNavigation as NavigatorService.NavigationProp);
 
   // Get the navigator element from the context
   const element: Element | undefined = getNestedNavigator(

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -564,9 +564,10 @@ function HvRouteFC(props: Types.Props) {
   const url = getRouteUrl(props, navigationContext);
   const rootNavigation = useNavigation();
   const nav =
-    props.navigation || rootNavigation.getState()
+    props.navigation ||
+    (rootNavigation.getState()
       ? (rootNavigation as NavigatorService.NavigationProp)
-      : undefined;
+      : undefined);
 
   // Get the navigator element from the context
   const element: Element | undefined = getNestedNavigator(


### PR DESCRIPTION
When HVScreens are rendered outside of normal inheritance chains, the navigation property may be missing. This update allows Hyperview to automatically inject a higher-level navigation property into the new screen.

Works by using ReactNavigation's context to get the navigation and only use it if:
- There is no navigation passed in via props
- The parent navigation has already been set up (has a state). This is to prevent the top-level HVRoute from also inheriting the root unnecessarily.


https://github.com/Instawork/hyperview/assets/127122858/98f95895-f456-464f-b547-93f50ff42a8f

