### PR TITLE
fix(navigation): get navigation from higher in the tree

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -21,10 +21,6 @@ import type {
   NavigationRouteParams,
   ScreenState,
 } from 'hyperview/src/types';
-import {
-  NavigationContainerRefContext,
-  useNavigation,
-} from '@react-navigation/native';
 import React, { JSXElementConstructor, PureComponent, useContext } from 'react';
 import HvNavigator from 'hyperview/src/core/components/hv-navigator';
 import HvScreen from 'hyperview/src/core/components/hv-screen';
@@ -33,6 +29,7 @@ import LoadError from 'hyperview/src/core/components/load-error';
 import Loading from 'hyperview/src/core/components/loading';
 // eslint-disable-next-line instawork/import-services
 import Navigation from 'hyperview/src/services/navigation';
+import { NavigationContainerRefContext } from '@react-navigation/native';
 
 /**
  * Implementation of an HvRoute component
@@ -562,7 +559,7 @@ function HvRouteFC(props: Types.Props) {
   const docContext = useContext(Contexts.DocContext);
 
   const url = getRouteUrl(props, navigationContext);
-  const rootNavigation = useNavigation();
+  const rootNavigation = useContext(NavigationContainerRefContext);
   const nav =
     props.navigation || (rootNavigation as NavigatorService.NavigationProp);
 


### PR DESCRIPTION
The `useNavigation` syntax throws an exception if navigation is not found higher in the tree. This was failing some existing tests. Using the context instead provides a safe way to get the navigation if it exists and otherwise return undefined without throwing.