### PR TITLE
fix(error): improve error component placement

### DIFF
--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -281,13 +281,14 @@ export default class HvScreen extends React.Component {
         }}
       >
         <Contexts.DateFormatContext.Provider value={this.props.formatDate}>
-          {screenElement}
           {elementErrorComponent
             ? React.createElement(elementErrorComponent, {
                 error: this.state.elementError,
                 onPressReload: () => this.reload(),
+                onPressClose: () => this.setState({ elementError: null }),
               })
             : null}
+          {screenElement}
         </Contexts.DateFormatContext.Provider>
       </Contexts.DocContext.Provider>
     );

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -284,8 +284,8 @@ export default class HvScreen extends React.Component {
           {elementErrorComponent
             ? React.createElement(elementErrorComponent, {
                 error: this.state.elementError,
-                onPressReload: () => this.reload(),
                 onPressClose: () => this.setState({ elementError: null }),
+                onPressReload: () => this.reload(),
               })
             : null}
           {screenElement}

--- a/src/core/components/load-element-error/index.tsx
+++ b/src/core/components/load-element-error/index.tsx
@@ -19,11 +19,6 @@ const LoadElementError = (props: Props) => {
 
   return (
     <SafeAreaView style={styles.safeArea}>
-      <TouchableOpacity onPress={props.onPressClose}>
-        <View style={styles.container}>
-          <Text style={styles.closeButton}>X</Text>
-        </View>
-      </TouchableOpacity>
       <TouchableOpacity onPress={props.onPressReload}>
         <View style={styles.container}>
           <View style={styles.textWrapper}>
@@ -31,6 +26,13 @@ const LoadElementError = (props: Props) => {
           </View>
           <View style={styles.btnWrapper}>
             <Text style={styles.button}>Reload</Text>
+          </View>
+        </View>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={props.onPressClose}>
+        <View style={styles.container}>
+          <View style={styles.textWrapper}>
+            <Text style={styles.button}>Close</Text>
           </View>
         </View>
       </TouchableOpacity>

--- a/src/core/components/load-element-error/index.tsx
+++ b/src/core/components/load-element-error/index.tsx
@@ -19,23 +19,24 @@ const LoadElementError = (props: Props) => {
 
   return (
     <SafeAreaView style={styles.safeArea}>
-      <TouchableOpacity onPress={props.onPressReload}>
-        <View style={styles.container}>
-          <View style={styles.textWrapper}>
-            <Text style={styles.title}>{getError()}</Text>
-          </View>
+      <View style={styles.container}>
+        <View style={styles.textWrapper}>
+          <Text style={styles.title}>{getError()}</Text>
+        </View>
+        <TouchableOpacity onPress={props.onPressReload}>
           <View style={styles.btnWrapper}>
             <Text style={styles.button}>Reload</Text>
           </View>
+        </TouchableOpacity>
+        <View style={styles.textWrapper}>
+          <Text style={styles.title}>or</Text>
         </View>
-      </TouchableOpacity>
-      <TouchableOpacity onPress={props.onPressClose}>
-        <View style={styles.container}>
-          <View style={styles.textWrapper}>
-            <Text style={styles.button}>Close</Text>
+        <TouchableOpacity onPress={props.onPressClose}>
+          <View style={styles.btnWrapper}>
+            <Text style={styles.button}>Hide</Text>
           </View>
-        </View>
-      </TouchableOpacity>
+        </TouchableOpacity>
+      </View>
     </SafeAreaView>
   );
 };

--- a/src/core/components/load-element-error/index.tsx
+++ b/src/core/components/load-element-error/index.tsx
@@ -19,6 +19,11 @@ const LoadElementError = (props: Props) => {
 
   return (
     <SafeAreaView style={styles.safeArea}>
+      <TouchableOpacity onPress={props.onPressClose}>
+        <View style={styles.container}>
+          <Text style={styles.closeButton}>X</Text>
+        </View>
+      </TouchableOpacity>
       <TouchableOpacity onPress={props.onPressReload}>
         <View style={styles.container}>
           <View style={styles.textWrapper}>

--- a/src/core/components/load-element-error/styles.ts
+++ b/src/core/components/load-element-error/styles.ts
@@ -1,4 +1,4 @@
-import { StyleSheet } from 'react-native';
+import { Platform, StatusBar, StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
   btnWrapper: {
@@ -9,8 +9,13 @@ export default StyleSheet.create({
     alignSelf: 'center',
     color: '#4778FF',
   },
+  closeButton: {
+    color: '#4778FF',
+    fontSize: 24,
+    fontWeight: 'bold',
+    top: 2,
+  },
   container: {
-    backgroundColor: '#ffffff',
     flexDirection: 'row',
     flexWrap: 'wrap',
     justifyContent: 'center',
@@ -18,9 +23,15 @@ export default StyleSheet.create({
     paddingHorizontal: 8,
   },
   safeArea: {
-    bottom: 0,
+    backgroundColor: '#ffffff',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0,
     position: 'absolute',
+    top: 0,
     width: '100%',
+    zIndex: 99,
   },
   textWrapper: {
     paddingTop: 8,

--- a/src/core/components/load-element-error/styles.ts
+++ b/src/core/components/load-element-error/styles.ts
@@ -9,12 +9,6 @@ export default StyleSheet.create({
     alignSelf: 'center',
     color: '#4778FF',
   },
-  closeButton: {
-    color: '#4778FF',
-    fontSize: 24,
-    fontWeight: 'bold',
-    top: 2,
-  },
   container: {
     flexDirection: 'row',
     flexWrap: 'wrap',
@@ -29,7 +23,6 @@ export default StyleSheet.create({
     justifyContent: 'center',
     paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0,
     position: 'absolute',
-    top: 0,
     width: '100%',
     zIndex: 99,
   },

--- a/src/core/components/load-element-error/styles.ts
+++ b/src/core/components/load-element-error/styles.ts
@@ -2,7 +2,7 @@ import { Platform, StatusBar, StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
   btnWrapper: {
-    paddingLeft: 8,
+    paddingHorizontal: 4,
     paddingTop: 8,
   },
   button: {
@@ -14,7 +14,7 @@ export default StyleSheet.create({
     flexWrap: 'wrap',
     justifyContent: 'center',
     paddingBottom: 8,
-    paddingHorizontal: 8,
+    paddingHorizontal: 4,
   },
   safeArea: {
     backgroundColor: '#ffffff',
@@ -31,6 +31,5 @@ export default StyleSheet.create({
   },
   title: {
     color: 'black',
-    textAlign: 'center',
   },
 });

--- a/src/core/components/load-element-error/types.ts
+++ b/src/core/components/load-element-error/types.ts
@@ -1,4 +1,5 @@
 export type Props = {
   error: Error;
   onPressReload: () => void;
+  onPressClose: () => void;
 };


### PR DESCRIPTION
- Moved the component to the top
- Use top padding to provide safe area for Android
- Add a close button to dismiss the component

Android shows the close action, iOS shows the reload action.

| Android | iOS |
| -- | -- |
| ![android](https://github.com/Instawork/hyperview/assets/127122858/cf51e118-c1cf-4484-b425-efaec4b52c02) | ![iOS](https://github.com/Instawork/hyperview/assets/127122858/b9b9a080-4fdd-4ff6-8370-2cd7c6f96e0c) |


Asana: https://app.asana.com/0/1204008699308084/1207426043394013/f