### PR TITLE
feat(logging): support deferred toString() operations

### DIFF
--- a/src/services/logging/default-logger.ts
+++ b/src/services/logging/default-logger.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * The default logger performs toString() operations on each param passed to the logging actions
+ */
+export class DefaultLogger {
+  // Provides a forced toString conversion of any params which support a toString() function
+  asString = (o: any): any => {
+    return typeof o.toString === 'function' ? String(o) : o;
+  };
+
+  log = (m?: any, ...p: any[]): void =>
+    console.log(this.asString(m), this.asString(p));
+
+  info = (m?: any, ...p: any[]): void =>
+    console.info(this.asString(m), this.asString(p));
+
+  warn = (m?: any, ...p: any[]): void =>
+    console.warn(this.asString(m), this.asString(p));
+
+  error = (m?: any, ...p: any[]): void =>
+    console.error(this.asString(m), this.asString(p));
+}

--- a/src/services/logging/default-logger.ts
+++ b/src/services/logging/default-logger.ts
@@ -3,32 +3,27 @@
  * The default logger performs toString() operations on each param passed to the logging actions
  */
 export class DefaultLogger {
-  // Provides a forced toString conversion of any params which support a toString() function
-  asString = (o: any): any => {
-    return typeof o.toString === 'function' ? String(o) : o;
-  };
-
   log = (m?: any, ...p: any[]): void =>
     console.log(
-      this.asString(m),
-      p.map(param => this.asString(param)),
+      String(m),
+      p.map(param => String(param)),
     );
 
   info = (m?: any, ...p: any[]): void =>
     console.info(
-      this.asString(m),
-      p.map(param => this.asString(param)),
+      String(m),
+      p.map(param => String(param)),
     );
 
   warn = (m?: any, ...p: any[]): void =>
     console.warn(
-      this.asString(m),
-      p.map(param => this.asString(param)),
+      String(m),
+      p.map(param => String(param)),
     );
 
   error = (m?: any, ...p: any[]): void =>
     console.error(
-      this.asString(m),
-      p.map(param => this.asString(param)),
+      String(m),
+      p.map(param => String(param)),
     );
 }

--- a/src/services/logging/default-logger.ts
+++ b/src/services/logging/default-logger.ts
@@ -9,14 +9,26 @@ export class DefaultLogger {
   };
 
   log = (m?: any, ...p: any[]): void =>
-    console.log(this.asString(m), this.asString(p));
+    console.log(
+      this.asString(m),
+      p.map(param => this.asString(param)),
+    );
 
   info = (m?: any, ...p: any[]): void =>
-    console.info(this.asString(m), this.asString(p));
+    console.info(
+      this.asString(m),
+      p.map(param => this.asString(param)),
+    );
 
   warn = (m?: any, ...p: any[]): void =>
-    console.warn(this.asString(m), this.asString(p));
+    console.warn(
+      this.asString(m),
+      p.map(param => this.asString(param)),
+    );
 
   error = (m?: any, ...p: any[]): void =>
-    console.error(this.asString(m), this.asString(p));
+    console.error(
+      this.asString(m),
+      p.map(param => this.asString(param)),
+    );
 }

--- a/src/services/logging/index.ts
+++ b/src/services/logging/index.ts
@@ -15,3 +15,4 @@ export const warn = (m?: any, ...p: any[]): void => logger.warn(m, p);
 export const error = (m?: any, ...p: any[]): void => logger.error(m, p);
 
 export type { Logger } from './types';
+export { deferredToString } from './tostring-helper';

--- a/src/services/logging/index.ts
+++ b/src/services/logging/index.ts
@@ -31,10 +31,10 @@ export function initialize(loggerInstance: Logger | undefined): void {
   }
 }
 
-export const log = (m?: any, ...p: any[]): void => logger.log(m, p);
-export const info = (m?: any, ...p: any[]): void => logger.info(m, p);
-export const warn = (m?: any, ...p: any[]): void => logger.warn(m, p);
-export const error = (m?: any, ...p: any[]): void => logger.error(m, p);
+export const log = (m?: any, ...p: any[]): void => logger.log(m, ...p);
+export const info = (m?: any, ...p: any[]): void => logger.info(m, ...p);
+export const warn = (m?: any, ...p: any[]): void => logger.warn(m, ...p);
+export const error = (m?: any, ...p: any[]): void => logger.error(m, ...p);
 
 export type { Logger } from './types';
 export { deferredToString } from './tostring-helper';

--- a/src/services/logging/index.ts
+++ b/src/services/logging/index.ts
@@ -1,27 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { DefaultLogger } from './default-logger';
 import type { Logger } from './types';
-
-/**
- * The default logger performs toString() operations on each param passed to the logging actions
- */
-export class DefaultLogger {
-  // Provides a forced toString conversion of any params which support a toString() function
-  asString = (o: any): any => {
-    return typeof o.toString === 'function' ? String(o) : o;
-  };
-
-  log = (m?: any, ...p: any[]): void =>
-    console.log(this.asString(m), this.asString(p));
-
-  info = (m?: any, ...p: any[]): void =>
-    console.info(this.asString(m), this.asString(p));
-
-  warn = (m?: any, ...p: any[]): void =>
-    console.warn(this.asString(m), this.asString(p));
-
-  error = (m?: any, ...p: any[]): void =>
-    console.error(this.asString(m), this.asString(p));
-}
 
 let logger: Logger = new DefaultLogger();
 

--- a/src/services/logging/index.ts
+++ b/src/services/logging/index.ts
@@ -1,7 +1,29 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Logger } from './types';
 
-let logger: Logger = console;
+/**
+ * The default logger performs toString() operations on each param passed to the logging actions
+ */
+export class DefaultLogger {
+  // Provides a forced toString conversion of any params which support a toString() function
+  asString = (o: any): any => {
+    return typeof o.toString === 'function' ? String(o) : o;
+  };
+
+  log = (m?: any, ...p: any[]): void =>
+    console.log(this.asString(m), this.asString(p));
+
+  info = (m?: any, ...p: any[]): void =>
+    console.info(this.asString(m), this.asString(p));
+
+  warn = (m?: any, ...p: any[]): void =>
+    console.warn(this.asString(m), this.asString(p));
+
+  error = (m?: any, ...p: any[]): void =>
+    console.error(this.asString(m), this.asString(p));
+}
+
+let logger: Logger = new DefaultLogger();
 
 export function initialize(loggerInstance: Logger | undefined): void {
   if (loggerInstance) {

--- a/src/services/logging/tostring-helper.test.ts
+++ b/src/services/logging/tostring-helper.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { DefaultLogger } from '.';
+
+import { DefaultLogger } from './default-logger';
 import { deferredToString } from './tostring-helper';
 
 const logger = new DefaultLogger();

--- a/src/services/logging/tostring-helper.test.ts
+++ b/src/services/logging/tostring-helper.test.ts
@@ -1,0 +1,80 @@
+import { deferredToString } from './tostring-helper';
+
+describe('deferredToString', () => {
+  describe('with string', () => {
+    const helper = deferredToString('foo');
+    const helperSpy = jest.spyOn(helper, 'toString');
+
+    afterEach(() => {
+      helperSpy.mockClear();
+    });
+
+    it('is NOT called during construction', () => {
+      expect(helperSpy).not.toHaveBeenCalled();
+    });
+
+    it('is NOT called from console.log', () => {
+      console.log('helper', helper);
+      expect(helperSpy).not.toHaveBeenCalled();
+    });
+
+    it('is called when wrapped in String()', () => {
+      const helperVal = String(helper);
+      expect(helperSpy).toHaveBeenCalledTimes(1);
+      expect(helperVal).toEqual('foo');
+    });
+
+    it('does call when string converted', () => {
+      const helperVal = `${helper}`;
+      expect(helperSpy).toHaveBeenCalledTimes(1);
+      expect(helperVal).toEqual('foo');
+    });
+
+    it('does call when toString() is called', () => {
+      const helperVal = helper.toString();
+      expect(helperSpy).toHaveBeenCalledTimes(1);
+      expect(helperVal).toEqual('foo');
+    });
+  });
+
+  describe('with func', () => {
+    const expensiveMock = jest.fn(() => 'this was expensive');
+
+    const helper = deferredToString(expensiveMock);
+
+    afterEach(() => {
+      expensiveMock.mockClear();
+    });
+
+    it('is NOT called during construction', () => {
+      expect(expensiveMock).not.toHaveBeenCalled();
+    });
+
+    it('is NOT called from console.log', () => {
+      console.log('helper', helper);
+      expect(expensiveMock).not.toHaveBeenCalled();
+    });
+
+    afterEach(() => {
+      expensiveMock.mockClear();
+    });
+
+    it('is called when wrapped in String()', () => {
+      const helperVal = String(helper);
+      expect(expensiveMock).toHaveBeenCalledTimes(1);
+      expect(helperVal).toEqual('this was expensive');
+    });
+
+    it('does call when string converted', () => {
+      const helperVal = `${helper}`;
+      expect(expensiveMock).toHaveBeenCalledTimes(1);
+      expect(helperVal).toEqual('this was expensive');
+    });
+
+    it('does call when toString() is called', () => {
+      const helperVal = helper.toString();
+      expect(expensiveMock).toHaveBeenCalledTimes(1);
+      expect(helperVal).toEqual('this was expensive');
+    });
+  });
+});

--- a/src/services/logging/tostring-helper.test.ts
+++ b/src/services/logging/tostring-helper.test.ts
@@ -1,4 +1,8 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { DefaultLogger } from '.';
 import { deferredToString } from './tostring-helper';
+
+const logger = new DefaultLogger();
 
 describe('deferredToString', () => {
   describe('with string', () => {
@@ -35,11 +39,20 @@ describe('deferredToString', () => {
       expect(helperSpy).toHaveBeenCalledTimes(1);
       expect(helperVal).toEqual('foo');
     });
+
+    it('does call toString when using custom logger', () => {
+      logger.log('helper', helper);
+      expect(helperSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does call toString on each param when using custom logger', () => {
+      logger.log('helper', helper, helper, helper);
+      expect(helperSpy).toHaveBeenCalledTimes(3);
+    });
   });
 
   describe('with func', () => {
     const expensiveMock = jest.fn(() => 'this was expensive');
-
     const helper = deferredToString(expensiveMock);
 
     afterEach(() => {
@@ -75,6 +88,16 @@ describe('deferredToString', () => {
       const helperVal = helper.toString();
       expect(expensiveMock).toHaveBeenCalledTimes(1);
       expect(helperVal).toEqual('this was expensive');
+    });
+
+    it('does call toString when using custom logger', () => {
+      logger.log('helper', helper);
+      expect(expensiveMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does call toString on each param when using custom logger', () => {
+      logger.log('helper', helper, helper, helper);
+      expect(expensiveMock).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/src/services/logging/tostring-helper.ts
+++ b/src/services/logging/tostring-helper.ts
@@ -1,0 +1,34 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * A helper class for working with expensive string conversions
+ * The toString() is deferred until the class is stringified
+ * If a function is passed in, the function will be called during stringification
+ * Example:
+ *  import { deferredToString } from 'hyperview/src/services/logging';
+ *  const stringData = deferredToString('foo');
+ *  const expensiveData = deferredToString(()=>{return 'expensive string process'});
+ *  console.log(`string: ${stringData} expensive: ${expensiveData}`);
+ */
+class ToStringHelper {
+  obj: any;
+
+  constructor(obj: any) {
+    this.obj = obj;
+  }
+
+  toString = () => {
+    if (typeof this.obj === 'function') {
+      return this.obj();
+    }
+
+    return this.obj;
+  };
+}
+
+/**
+ * Create a helper instance with the passed obj
+ */
+export const deferredToString = (obj: any): ToStringHelper => {
+  return new ToStringHelper(obj);
+};

--- a/src/services/logging/tostring-helper.ts
+++ b/src/services/logging/tostring-helper.ts
@@ -4,11 +4,12 @@
  * A helper class for working with expensive string conversions
  * The toString() is deferred until the class is stringified
  * If a function is passed in, the function will be called during stringification
+ * The implementation of the logger will need to call the toString on each param
  * Example:
  *  import { deferredToString } from 'hyperview/src/services/logging';
  *  const stringData = deferredToString('foo');
  *  const expensiveData = deferredToString(()=>{return 'expensive string process'});
- *  console.log(`string: ${stringData} expensive: ${expensiveData}`);
+ *  logger.log('string:', stringData, 'expensive:', expensiveData);
  */
 class ToStringHelper {
   obj: any;


### PR DESCRIPTION
The new logging system supports filtering out logs. In some places in the code, an expensive operation is implemented to pass data into the log. If the log is not dispatched, the expensive operation will have still run.

Create a util which allows deferring the toString() operation until the content is required.
- Supports passing `any` type
- If the passed value is a function, it will only be called when toString() is called

Example usage:
```javascript
import { deferredToString } from 'hyperview/src/services/logging';

class Logger {
  log = (m?: any): void => console.log(String(m));
}

const logger = new Logger();

// Create instance of the helper, function is not called yet
const expensiveData = deferredToString(()=>{return 'expensive string process'});

// Function is called when `expensiveData` is stringified by the logger
logger.log('expensive:', expensiveData);
```

> **_NOTE:_**  `console` does not call `toString()` on an object passed in. The object must be stringified. The following code would not result in the function being called:
```javascript
console.log(expensiveData);
```


Asana: https://app.asana.com/0/1204008699308084/1207615845753887/f