### PR TITLE
chore(logging): improve logging

### DIFF
--- a/src/core/hyper-ref/index.tsx
+++ b/src/core/hyper-ref/index.tsx
@@ -166,20 +166,20 @@ export default class HyperRef extends PureComponent<Props, State> {
         this.props.onUpdate,
       );
       handler(this.props.element);
-      if (__DEV__) {
-        const listenerElement: Element = behaviorElement.cloneNode(
-          false,
-        ) as Element;
-        const caughtEvent:
-          | string
-          | undefined
-          | null = behaviorElement.getAttribute('event-name');
-        const serializer = new XMLSerializer();
-        Logging.log(
-          `[on-event] trigger [${caughtEvent}] caught by:`,
-          serializer.serializeToString(listenerElement),
-        );
-      }
+
+      Logging.info(
+        '[on-event] trigger [',
+        Logging.deferredToString(() => {
+          return behaviorElement.getAttribute('event-name');
+        }),
+        '] caught by: ',
+        Logging.deferredToString(() => {
+          const listenerElement: Element = behaviorElement.cloneNode(
+            false,
+          ) as Element;
+          return new XMLSerializer().serializeToString(listenerElement);
+        }),
+      );
     });
   };
 

--- a/src/services/behaviors/index.ts
+++ b/src/services/behaviors/index.ts
@@ -1,4 +1,5 @@
 import * as Dom from 'hyperview/src/services/dom';
+import * as Logging from 'hyperview/src/services/logging';
 import {
   ACTIONS,
   BEHAVIOR_ATTRIBUTES,
@@ -10,6 +11,7 @@ import type {
   NavAction,
   UpdateAction,
 } from 'hyperview/src/types';
+import { XMLSerializer } from '@instawork/xmldom';
 import { shallowCloneToRoot } from 'hyperview/src/services';
 
 /**
@@ -111,6 +113,15 @@ export const performUpdate = (
   return shallowCloneToRoot(targetElement);
 };
 
+const logBehavior = (behaviorElement: Element, action: string | null) => {
+  Logging.info(
+    `[behavior] | action: ${action} |`,
+    Logging.deferredToString(() => {
+      return new XMLSerializer().serializeToString(behaviorElement);
+    }),
+  );
+};
+
 /**
  * Trigger all behaviors matching the given name
  */
@@ -141,6 +152,7 @@ export const trigger = (
       targetId,
       verb,
     });
+    logBehavior(behaviorElement, action);
   });
 };
 
@@ -180,6 +192,7 @@ export const createActionHandler = (
       );
       const delay = behaviorElement.getAttribute(BEHAVIOR_ATTRIBUTES.DELAY);
       onUpdate(href, action, element, { delay, showIndicatorId, targetId });
+      logBehavior(behaviorElement, action);
     };
   }
   if (
@@ -207,11 +220,14 @@ export const createActionHandler = (
         targetId,
         verb,
       });
+      logBehavior(behaviorElement, action);
     };
   }
   // Custom behavior
-  return (element: Element) =>
+  return (element: Element) => {
     onUpdate(null, action, element, { behaviorElement, custom: true });
+    logBehavior(behaviorElement, action);
+  };
 };
 
 /**

--- a/src/services/events/index.ts
+++ b/src/services/events/index.ts
@@ -5,9 +5,8 @@ import { TinyEmitter } from 'tiny-emitter';
 const tinyEmitter = new TinyEmitter();
 
 export const dispatch = (eventName: string) => {
-  if (__DEV__) {
-    Logging.log(`[dispatch-event] action [${eventName}] emitted.`);
-  }
+  Logging.info(`[dispatch-event] action [${eventName}] emitted.`);
+
   tinyEmitter.emit(ON_EVENT_DISPATCH, eventName);
 };
 


### PR DESCRIPTION
- Remove unneeded --DEV-- block on logging in `services/events/index`
- Replaced use of --DEV-- with deferredToString in `core/hyper-ref`
- Add logs to behaviors in `services/behaviors`
- Updated severity of `[on-event]` and `[dispatch-event]` to INFO to match new behavior logs.


Example logs:
```
  INFO  [behavior] | action: toggle | ["<view action=\"toggle\" delay=\"1000\" show-during-load=\"toggle3-spinner\" style=\"Button\" target=\"toggle3-content\" ran-once=\"true\" xmlns=\"https://hyperview.org/hyperview\"/>"]

 INFO  [behavior] | action: copy-to-clipboard  ["<view action=\"copy-to-clipboard\" trigger=\"press\" copy-to-clipboard-value=\"Hello World\" style=\"Button\" ran-once=\"true\" xmlns=\"https://hyperview.org/hyperview\">
    <text style=\"Button__Label\">Copy to clipboard</text>
  </view>"]

 INFO  [behavior] | action: alert  ["<behavior action=\"alert\" alert:message=\"One option on iOS appears as one long horizontal button.\" alert:title=\"One option\" trigger=\"press\" xmlns:alert=\"https://hyperview.org/hyperview-alert\" ran-once=\"true\" xmlns=\"https://hyperview.org/hyperview\">
      <alert:option alert:label=\"Custom option 1\"/>
      <alert:option alert:label=\"Custom option 2\"/>
    </behavior>"]

 INFO  [behavior] | action: dispatch-event | ["<behavior action=\"dispatch-event\" event-name=\"test-event\" trigger=\"press\" ran-once=\"true\" xmlns=\"https://hyperview.org/hyperview\"/>"]

 INFO  [behavior] | action: append | ["<view action=\"append\" href=\"/behaviors/_append_fragment.xml\" style=\"Button\" xmlns=\"https://hyperview.org/hyperview\">
          <text style=\"Button__Label\">Press me</text>
        </view>"]

 INFO  [behavior] | action: toggle | ["<view action=\"toggle\" style=\"Button\" target=\"toggle1-content\" ran-once=\"true\" xmlns=\"https://hyperview.org/hyperview\">
          <text style=\"Button__Label\">Toggle</text>
        </view>"]
```

Asana: https://app.asana.com/0/1204008699308084/1206423717112478/f