### PR TITLE
fix(logging): object debugging

### DIFF
--- a/src/services/logging/default-logger.ts
+++ b/src/services/logging/default-logger.ts
@@ -1,29 +1,39 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { ToStringHelper } from './tostring-helper';
+
 /**
  * The default logger performs toString() operations on each param passed to the logging actions
  */
 export class DefaultLogger {
+  toString = (m?: any): any => {
+    if (m instanceof ToStringHelper) {
+      return m.toString();
+    }
+    return m;
+  };
+
   log = (m?: any, ...p: any[]): void =>
     console.log(
-      String(m),
-      p.map(param => String(param)),
+      this.toString(m),
+      p.map(param => this.toString(param)),
     );
 
   info = (m?: any, ...p: any[]): void =>
     console.info(
-      String(m),
-      p.map(param => String(param)),
+      this.toString(m),
+      p.map(param => this.toString(param)),
     );
 
   warn = (m?: any, ...p: any[]): void =>
     console.warn(
-      String(m),
-      p.map(param => String(param)),
+      this.toString(m),
+      p.map(param => this.toString(param)),
     );
 
   error = (m?: any, ...p: any[]): void =>
     console.error(
-      String(m),
-      p.map(param => String(param)),
+      this.toString(m),
+      p.map(param => this.toString(param)),
     );
 }

--- a/src/services/logging/default-logger.ts
+++ b/src/services/logging/default-logger.ts
@@ -3,10 +3,10 @@
 import { ToStringHelper } from './tostring-helper';
 
 /**
- * The default logger performs toString() operations on each param passed to the logging actions
+ * Handles deferredToString objects by calling toString() prior to forwarding to console
  */
 export class DefaultLogger {
-  toString = (m?: any): any => {
+  convertDeferred = (m?: any): any => {
     if (m instanceof ToStringHelper) {
       return m.toString();
     }
@@ -15,25 +15,25 @@ export class DefaultLogger {
 
   log = (m?: any, ...p: any[]): void =>
     console.log(
-      this.toString(m),
-      p.map(param => this.toString(param)),
+      this.convertDeferred(m),
+      p.map(param => this.convertDeferred(param)),
     );
 
   info = (m?: any, ...p: any[]): void =>
     console.info(
-      this.toString(m),
-      p.map(param => this.toString(param)),
+      this.convertDeferred(m),
+      p.map(param => this.convertDeferred(param)),
     );
 
   warn = (m?: any, ...p: any[]): void =>
     console.warn(
-      this.toString(m),
-      p.map(param => this.toString(param)),
+      this.convertDeferred(m),
+      p.map(param => this.convertDeferred(param)),
     );
 
   error = (m?: any, ...p: any[]): void =>
     console.error(
-      this.toString(m),
-      p.map(param => this.toString(param)),
+      this.convertDeferred(m),
+      p.map(param => this.convertDeferred(param)),
     );
 }

--- a/src/services/logging/tostring-helper.ts
+++ b/src/services/logging/tostring-helper.ts
@@ -11,7 +11,7 @@
  *  const expensiveData = deferredToString(()=>{return 'expensive string process'});
  *  logger.log('string:', stringData, 'expensive:', expensiveData);
  */
-class ToStringHelper {
+export class ToStringHelper {
   obj: any;
 
   constructor(obj: any) {


### PR DESCRIPTION
Forcing all params in DefaultLogger to string caused any objects to be converted to `[object Object]` making it impossible to inspect the element in Chrome.

Checking whether `toString` was available yielded false positive as all objects contain this function.

**Solution**
Relying on `instanceof` to ensure only `ToStringHelper` params are converted.

Before
<img width="1193" alt="before" src="https://github.com/Instawork/hyperview/assets/127122858/34d6c534-329f-4241-aab1-acad3c059697">


After
<img width="1122" alt="after" src="https://github.com/Instawork/hyperview/assets/127122858/3736d7b4-aa18-4fcc-b1b4-4d49a26a217c">
