### PR TITLE
chore: automatically create github PR attachment on asana ticket

### DIFF
--- a/.github/workflows/create-asana-attachment.yaml
+++ b/.github/workflows/create-asana-attachment.yaml
@@ -1,0 +1,18 @@
+name: 'Create Asana Attachment'
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  create-asana-attachment-job:
+    runs-on: ubuntu-latest
+    name: Create pull request attachments on Asana tasks
+    timeout-minutes: 1
+    steps:
+      - name: Create pull request attachments
+        uses: Asana/create-app-attachment-github-action@latest
+        id: postAttachment
+        with:
+          asana-secret: ${{ secrets.ASANA_SECRET }}
+      - name: Log output status
+        run: echo "Status is ${{ steps.postAttachment.outputs.status }}"


### PR DESCRIPTION
This creates github attachment on asana ticket soon after it's opened. Similar to instawork repo

TBD:
Follow the guide: https://asana.com/guide/help/api/github