### PR TITLE
feat(behavior): add support for prefetch action

### DIFF
--- a/src/behaviors/hv-prefetch/index.ts
+++ b/src/behaviors/hv-prefetch/index.ts
@@ -31,10 +31,10 @@ export default {
     }
 
     Behaviors.setRanOnce(element);
-    const url = UrlService.getUrlFromHref(href, screenState.url || '');
+    const url = UrlService.getUrlFromHref(href, screenState?.url || '');
     // Wait for the current event loop to finish before prefetching the next screen
     setTimeout(async () => {
-      await parser.load(url);
+      await parser?.load(url);
     }, 0);
   },
 };

--- a/src/behaviors/hv-prefetch/index.ts
+++ b/src/behaviors/hv-prefetch/index.ts
@@ -1,3 +1,4 @@
+import * as Behaviors from 'hyperview/src/behaviors';
 import * as Dom from 'hyperview/src/services/dom';
 import * as Logging from 'hyperview/src/services/logging';
 import * as UrlService from 'hyperview/src/services/url';
@@ -16,14 +17,20 @@ export default {
     onUpdate: HvComponentOnUpdate,
     getRoot: HvGetRoot,
     updateRoot: HvUpdateRoot,
-    screenState: ScreenState,
-    parser: Dom.Parser,
+    screenState?: ScreenState,
+    parser?: Dom.Parser,
   ) => {
     const href = element.getAttribute('href');
     if (!href) {
       Logging.warn('[behaviors/prefetch] requires an "href" attribute');
       return;
     }
+
+    if (Behaviors.isOncePreviouslyApplied(element)) {
+      return;
+    }
+
+    Behaviors.setRanOnce(element);
     const url = UrlService.getUrlFromHref(href, screenState.url || '');
     // Wait for the current event loop to finish before prefetching the next screen
     setTimeout(async () => {

--- a/src/behaviors/hv-prefetch/index.ts
+++ b/src/behaviors/hv-prefetch/index.ts
@@ -1,0 +1,33 @@
+import * as Dom from 'hyperview/src/services/dom';
+import * as Logging from 'hyperview/src/services/logging';
+import * as UrlService from 'hyperview/src/services/url';
+import type {
+  HvComponentOnUpdate,
+  HvGetRoot,
+  HvUpdateRoot,
+  ScreenState,
+} from 'hyperview/src/types';
+import { ACTIONS } from 'hyperview/src/types';
+
+export default {
+  action: ACTIONS.PREFETCH,
+  callback: (
+    element: Element,
+    onUpdate: HvComponentOnUpdate,
+    getRoot: HvGetRoot,
+    updateRoot: HvUpdateRoot,
+    screenState: ScreenState,
+    parser: Dom.Parser,
+  ) => {
+    const href = element.getAttribute('href');
+    if (!href) {
+      Logging.warn('[behaviors/prefetch] requires an "href" attribute');
+      return;
+    }
+    const url = UrlService.getUrlFromHref(href, screenState.url || '');
+    // Wait for the current event loop to finish before prefetching the next screen
+    setTimeout(async () => {
+      await parser.load(url);
+    }, 0);
+  },
+};

--- a/src/behaviors/index.ts
+++ b/src/behaviors/index.ts
@@ -3,6 +3,7 @@ import HvAlert from 'hyperview/src/behaviors/hv-alert';
 import HvCopyToClipboard from 'hyperview/src/behaviors/hv-copy-to-clipboard';
 import HvHide from 'hyperview/src/behaviors/hv-hide';
 import HvOpenSettings from 'hyperview/src/behaviors/hv-open-settings';
+import HvPrefetch from 'hyperview/src/behaviors/hv-prefetch';
 import HvSelectAll from 'hyperview/src/behaviors/hv-select-all';
 import HvSetValue from 'hyperview/src/behaviors/hv-set-value';
 import HvShare from 'hyperview/src/behaviors/hv-share';
@@ -15,6 +16,7 @@ const HYPERVIEW_BEHAVIORS = [
   HvCopyToClipboard,
   HvHide,
   HvOpenSettings,
+  HvPrefetch,
   HvSelectAll,
   HvSetValue,
   HvShare,

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -130,6 +130,25 @@ export default class Hyperview extends PureComponent<Types.Props> {
     });
   };
 
+  prefetch = async (
+    href: DOMString | null | undefined,
+    opts: HvComponentOptions,
+  ) => {
+    const { onUpdateCallbacks } = opts;
+    if (!href) {
+      Logging.warn('Prefetch requires an href');
+      return;
+    }
+    const url = UrlService.getUrlFromHref(
+      href,
+      onUpdateCallbacks?.getState().url || '',
+    );
+    // Wait for the current event loop to finish before prefetching the next screen
+    setTimeout(async () => {
+      await this.parser.load(url);
+    }, 0);
+  };
+
   /**
    * Fetches the provided reference.
    * - If the references is an id reference (starting with #),
@@ -289,6 +308,8 @@ export default class Hyperview extends PureComponent<Types.Props> {
       } else {
         dispatch();
       }
+    } else if (action === ACTIONS.PREFETCH) {
+      this.prefetch(href, options);
     } else {
       const { behaviorElement } = options;
       this.onCustomUpdate(behaviorElement, options.onUpdateCallbacks);

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -130,20 +130,25 @@ export default class Hyperview extends PureComponent<Types.Props> {
     });
   };
 
-  prefetch = (href: DOMString | null | undefined, opts: HvComponentOptions) => {
-    const { onUpdateCallbacks } = opts;
-    if (!href) {
-      Logging.warn('Prefetch requires an href');
+  prefetch = (
+    behaviorElement: Element | null | undefined,
+    onUpdateCallbacks: OnUpdateCallbacks,
+  ) => {
+    if (!behaviorElement) {
+      Logging.warn('Custom behavior requires a behaviorElement');
       return;
     }
-    const url = UrlService.getUrlFromHref(
-      href,
-      onUpdateCallbacks?.getState().url || '',
+
+    const behavior = this.behaviorRegistry[ACTIONS.PREFETCH];
+    const updateRoot = () => ({});
+    behavior.callback(
+      behaviorElement,
+      onUpdateCallbacks.getOnUpdate(),
+      onUpdateCallbacks.getDoc,
+      updateRoot,
+      onUpdateCallbacks.getState(),
+      this.parser,
     );
-    // Wait for the current event loop to finish before prefetching the next screen
-    setTimeout(async () => {
-      await this.parser.load(url);
-    }, 0);
   };
 
   /**
@@ -306,7 +311,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
         dispatch();
       }
     } else if (action === ACTIONS.PREFETCH) {
-      this.prefetch(href, options);
+      this.prefetch(options.behaviorElement, options.onUpdateCallbacks);
     } else {
       const { behaviorElement } = options;
       this.onCustomUpdate(behaviorElement, options.onUpdateCallbacks);

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -135,7 +135,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
     onUpdateCallbacks: OnUpdateCallbacks,
   ) => {
     if (!behaviorElement) {
-      Logging.warn('Custom behavior requires a behaviorElement');
+      Logging.warn('Prefetch behavior requires a behaviorElement');
       return;
     }
 

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -130,10 +130,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
     });
   };
 
-  prefetch = async (
-    href: DOMString | null | undefined,
-    opts: HvComponentOptions,
-  ) => {
+  prefetch = (href: DOMString | null | undefined, opts: HvComponentOptions) => {
     const { onUpdateCallbacks } = opts;
     if (!href) {
       Logging.warn('Prefetch requires an href');

--- a/src/types.ts
+++ b/src/types.ts
@@ -330,6 +330,7 @@ export const ACTIONS = {
   DISPATCH_EVENT: 'dispatch-event',
   NAVIGATE: 'navigate',
   NEW: 'new',
+  PREFETCH: 'prefetch',
   PREPEND: 'prepend',
   PUSH: 'push',
   RELOAD: 'reload',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import * as Components from 'hyperview/src/services/components';
+import * as Dom from 'hyperview/src/services/dom';
 import * as Stylesheets from './services/stylesheets';
 import Navigation from './services/navigation';
 import type { Route as NavigatorRoute } from './services/navigator';
@@ -239,6 +240,8 @@ export type HvBehavior = {
     onUpdate: HvComponentOnUpdate,
     getRoot: HvGetRoot,
     updateRoot: HvUpdateRoot,
+    screenState?: ScreenState,
+    parser?: Dom.Parser,
   ) => void;
 };
 


### PR DESCRIPTION
Add support for new action called `prefetch`, this will fetch an URL in the background.
Offline mode(built internally at Instawork) will take advantage of this by prefetching the necessary screens and saving them in the cache.