### PR TITLE
chore(navigation): skip animation for first stack screen

### DIFF
--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -119,7 +119,7 @@ export default class HvNavigator extends PureComponent<Props> {
   };
 
   /**
-   * Build an individual tab screen
+   * Build an individual screen
    */
   buildScreen = (
     id: string,
@@ -230,6 +230,10 @@ export default class HvNavigator extends PureComponent<Props> {
             `No href provided for route '${id}'`,
           );
         }
+        // The first screen in each stack will omit the animation
+        // This is to prevent the initial screen from animating in,
+        //  including when the navigation hierarchy is reset
+        // This relies on the schema requirement that each <navigator> has at least one <nav-route>
         screens.push(
           this.buildScreen(id, type, href || undefined, isModal, index === 0),
         );

--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -126,6 +126,7 @@ export default class HvNavigator extends PureComponent<Props> {
     type: string,
     href: string | undefined,
     isModal: boolean,
+    isFirstScreen: boolean = false,
   ): React.ReactElement => {
     const initialParams = NavigatorService.isDynamicRoute(id)
       ? {}
@@ -149,6 +150,7 @@ export default class HvNavigator extends PureComponent<Props> {
           initialParams={initialParams}
           name={id}
           options={{
+            animationEnabled: !isFirstScreen,
             cardStyleInterpolator: isModal
               ? NavigatorService.CardStyleInterpolators.forVerticalIOS
               : undefined,
@@ -205,7 +207,7 @@ export default class HvNavigator extends PureComponent<Props> {
     // the dynamic screens are added later
     // This iteration will also process nested navigators
     //    and retrieve additional urls from child routes
-    elements.forEach((navRoute: Element) => {
+    elements.forEach((navRoute: Element, index: number) => {
       if (navRoute.localName === LOCAL_NAME.NAV_ROUTE) {
         const id: string | null | undefined = navRoute.getAttribute('id');
         if (!id) {
@@ -228,7 +230,9 @@ export default class HvNavigator extends PureComponent<Props> {
             `No href provided for route '${id}'`,
           );
         }
-        screens.push(this.buildScreen(id, type, href || undefined, isModal));
+        screens.push(
+          this.buildScreen(id, type, href || undefined, isModal, index === 0),
+        );
       }
     });
 


### PR DESCRIPTION
When navigating to a new root navigation structure, we are seeing a push animation as if the new structure is being pushed onto the stack.

Using the index of the defined screens, the first screen will inhibit its animations. Subsequent screens will retain their correct animations.

> If a nested stack exists, it is a route within its parent so it will still animate in correctly

| Before | After |
| -- | -- |
| ![before](https://github.com/Instawork/hyperview/assets/127122858/8917e2b9-5429-4599-a24e-f944a918ce86) | ![after](https://github.com/Instawork/hyperview/assets/127122858/e4c9c7a4-3152-493b-843a-7b9b3e66854a) |


Example navigating beyond the initial reload
![before](https://github.com/Instawork/hyperview/assets/127122858/b0ec9d8f-b701-4de3-a363-08617c784084)

Asana: https://app.asana.com/0/1204008699308084/1205888766113004/f