### PR TITLE
chore(logging): reduce length of behavior logs

### DIFF
--- a/src/core/hyper-ref/index.tsx
+++ b/src/core/hyper-ref/index.tsx
@@ -177,6 +177,7 @@ export default class HyperRef extends PureComponent<Props, State> {
           const listenerElement: Element = behaviorElement.cloneNode(
             false,
           ) as Element;
+          listenerElement.textContent = '';
           return new XMLSerializer().serializeToString(listenerElement);
         }),
       );

--- a/src/services/behaviors/index.ts
+++ b/src/services/behaviors/index.ts
@@ -117,7 +117,9 @@ const logBehavior = (behaviorElement: Element, action: string | null) => {
   Logging.info(
     `[behavior] | action: ${action} |`,
     Logging.deferredToString(() => {
-      return new XMLSerializer().serializeToString(behaviorElement);
+      const be = behaviorElement.cloneNode(true) as Element;
+      be.textContent = '';
+      return new XMLSerializer().serializeToString(be);
     }),
   );
 };


### PR DESCRIPTION
Logs for behaviors are resulting in lengthy console logs when the element has children. Remove the children from the cloned element prior to serializing.

Before:
```xml
 INFO  2024-07-22T18:39:19.909Z | core-mobile/src/components/hyperview | [behavior] | action: add-styles | <behavior trigger="load" immediate="true" once="true" action="add-styles" ran-once="true" xmlns="https://hyperview.org/hyperview">
      <styles>




    </styles>
    </behavior>

 INFO  2024-07-22T18:39:19.777Z | core-mobile/src/components/hyperview | [on-event] trigger [ open-gigs-money-cta-call ] caught by:  <behavior trigger="on-event" event-name="open-gigs-money-cta-call" action="replace" target="money-cta-open-gigs" href="/worker_app/earnings-tab/open-gigs-iw-card-cta" xmlns="https://hyperview.org/hyperview"/>
```

After:
```xml
 INFO  2024-07-22T18:33:30.963Z | core-mobile/src/components/hyperview | [behavior] | action: add-styles | <behavior trigger="load" immediate="true" once="true" action="add-styles" ran-once="true" xmlns="https://hyperview.org/hyperview">

 INFO  2024-07-22T18:33:30.986Z | core-mobile/src/components/hyperview | [on-event] trigger [ reload-notification-bell ] caught by:  <behavior trigger="on-event" event-name="reload-notification-bell" href="/notifications/bell" action="replace" target="notification-bell" xmlns="https://hyperview.org/hyperview"/>
```


Asana: https://app.asana.com/0/1204008699308084/1207868342406073/f