### PR TITLE
fix: VisibilityDectectingView requires a default style

### DIFF
--- a/src/VisibilityDetectingView.tsx
+++ b/src/VisibilityDetectingView.tsx
@@ -111,7 +111,7 @@ export default class VisibilityDetectingView extends PureComponent<Props> {
         ref={this.onRef}
         // collapsable has to be false for view.measure to work on Android
         collapsable={false}
-        style={this.props.style}
+        style={this.props.style || { flex: 1 }}
       >
         {this.props.children}
       </View>


### PR DESCRIPTION
The partner app exhibits issues with layout when using a behavior with a trigger of `visible`. The root cause is the lack of styles assigned to `href-style` in the partner app templates.

- Apply a default style with `flex: 1` if no style is assigned.

| Before | After |
| -- | -- |
| ![before](https://github.com/user-attachments/assets/13d03393-3afc-4382-a635-f7f01e6f5aac) | ![after](https://github.com/user-attachments/assets/1cac02f5-4098-4f86-bdea-828f825b2b71) |

Asana: https://app.asana.com/0/1204008699308084/1207827683736609/f