### PR TITLE
fix(text-field): `set-value` triggers `change` behaviors

### DIFF
--- a/examples/advanced_behaviors/set_value/index.xml.njk
+++ b/examples/advanced_behaviors/set_value/index.xml.njk
@@ -107,6 +107,7 @@ tags: advanced_behaviors
       </style>
       <style id="links" flexDirection="row"/>
       <style id="link" color="#4778FF" fontWeight="bold" marginTop="8" marginRight="16"/>
+      <style id="field-changed" color="green" fontWeight="bold" position="absolute" right="0" top="12" />
     </styles>
     <body style="Body" safe-area="true">
       <header style="Header">
@@ -175,7 +176,13 @@ tags: advanced_behaviors
         <text style="section">Text fields</text>
         <view style="FormGroup">
           <text style="label" hide="true" id="id_tf_loading">Loading...</text>
-          <text-field id="id_tf" name="tf" placeholder="Text field" placeholderTextColor="#8D9494" style="input"/>
+          <view style="field">
+            <text-field id="id_tf" name="tf" placeholder="Text field" placeholderTextColor="#8D9494" style="input">
+              <behavior trigger="change" action="show" target="id_tf_changed" />
+              <behavior trigger="change" action="hide" delay="1000" target="id_tf_changed" />
+            </text-field>
+            <text style="field-changed" id="id_tf_changed" hide="true">Changed!</text>
+          </view>
           <text style="link" action="set-value" new-value="Test" target="id_tf">
             Set value to "Test"
           </text>
@@ -186,7 +193,11 @@ tags: advanced_behaviors
         <text style="section">Text areas</text>
         <view style="FormGroup">
           <text style="label" hide="true" id="id_ta_loading">Loading...</text>
-          <text-area id="id_ta" name="ta" placeholder="Text area" placeholderTextColor="#8D9494" style="input"/>
+          <text-area id="id_ta" name="ta" placeholder="Text area" placeholderTextColor="#8D9494" style="input">
+            <behavior trigger="change" action="show" target="id_ta_changed" />
+            <behavior trigger="change" action="hide" delay="1000" target="id_ta_changed" />
+          </text-area>
+          <text style="field-changed" id="id_ta_changed" hide="true">Changed!</text>
           <text style="link" action="set-value" new-value="Test&#10;Multi&#10;Line" target="id_ta">
             Set multi-line value
           </text>

--- a/src/components/hv-text-field/index.tsx
+++ b/src/components/hv-text-field/index.tsx
@@ -2,7 +2,7 @@ import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Logging from 'hyperview/src/services/logging';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import type { HvComponentProps, TextContextType } from 'hyperview/src/types';
-import React, { MutableRefObject, useCallback, useRef } from 'react';
+import React, { MutableRefObject, useCallback, useEffect, useRef } from 'react';
 import {
   createProps,
   getNameValueFormInputValues,
@@ -76,6 +76,14 @@ const HvTextField = (props: HvComponentProps) => {
   const textInputRef: MutableRefObject<TextInput | null> = useRef(
     null as TextInput | null,
   );
+
+  const prevDefaultValue = useRef<string | undefined>(defaultValue);
+  useEffect(() => {
+    if (prevDefaultValue.current !== defaultValue) {
+      onChangeText(defaultValue || '');
+    }
+    prevDefaultValue.current = defaultValue;
+  }, [defaultValue]);
 
   const p = {
     ...createProps(props.element, props.stylesheets, {

--- a/src/components/hv-text-field/index.tsx
+++ b/src/components/hv-text-field/index.tsx
@@ -64,15 +64,14 @@ const HvTextField = (props: HvComponentProps) => {
   );
 
   // This handler takes care of handling the state, so it shouldn't be debounced
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const onChangeText = useCallback((value: string) => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks, react-hooks/exhaustive-deps
+  const onChangeText = (value: string) => {
     const formattedValue = HvTextField.getFormattedValue(props.element, value);
     const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('value', formattedValue);
     props.onUpdate(null, 'swap', props.element, { newElement });
     triggerChangeBehaviors(newElement);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  };
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const textInputRef: MutableRefObject<TextInput | null> = useRef(

--- a/src/components/hv-text-field/index.tsx
+++ b/src/components/hv-text-field/index.tsx
@@ -64,26 +64,30 @@ const HvTextField = (props: HvComponentProps) => {
   );
 
   // This handler takes care of handling the state, so it shouldn't be debounced
-  const onChangeText = (value: string) => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const onChangeText = useCallback((value: string) => {
     const formattedValue = HvTextField.getFormattedValue(props.element, value);
     const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('value', formattedValue);
     props.onUpdate(null, 'swap', props.element, { newElement });
     triggerChangeBehaviors(newElement);
-  };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const textInputRef: MutableRefObject<TextInput | null> = useRef(
     null as TextInput | null,
   );
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const prevDefaultValue = useRef<string | undefined>(defaultValue);
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
     if (prevDefaultValue.current !== defaultValue) {
       onChangeText(defaultValue || '');
     }
     prevDefaultValue.current = defaultValue;
-  }, [defaultValue]);
+  }, [defaultValue, onChangeText]);
 
   const p = {
     ...createProps(props.element, props.stylesheets, {


### PR DESCRIPTION
React to text-field value being changed from props, and correctly call change handler.

Relates to #914.

Note - we currently have only two field types that support "change" event: `text-field` and `switch`. This PR only addresses the issue with `text-field` as this component was already migrated to a functional component, and the use of `useEffect`/`useRef` is trivial. Follow up needed:
- The switch component should be refactored to a functional component, then implement the same fix
- The "change" behavior trigger should be extended to other type of fields (related: https://github.com/Instawork/hyperview/issues/298)


https://github.com/user-attachments/assets/105fb0ac-9239-480a-b86c-e1234a07b28a

