### PR TITLE
feat(docs): render live demo app

### DIFF
--- a/docs/example_live.md
+++ b/docs/example_live.md
@@ -1,0 +1,7 @@
+---
+id: example_live
+title: Live examples
+sidebar_label: Live examples
+---
+
+<iframe src="https://instawork.github.io/hyperview/" height="560" width="420"></iframe>

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -10,7 +10,8 @@
 
   "examples": {
     "Examples": [
-       "example_index"
+       "example_index",
+       "example_live"
     ],
     "Interactions": [
        "example_navigation",


### PR DESCRIPTION
Add new page that renders an iframe pointing to our web demo app.

<img width="1389" alt="Screenshot 2024-08-13 at 12 23 56 PM" src="https://github.com/user-attachments/assets/00f025a3-7b10-43fe-a591-228c25b43536">
