### PR TITLE
chore(error): supply onError to hv-route

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -661,6 +661,7 @@ function HvRouteFC(props: Types.Props) {
       handleBack={navigationContext.handleBack}
       loadingScreen={navigationContext.loadingScreen}
       navigation={nav}
+      onError={navigationContext.onError}
       onParseAfter={navigationContext.onParseAfter}
       onParseBefore={navigationContext.onParseBefore}
       onUpdate={navigationContext.onUpdate}

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -15,6 +15,7 @@ import type { Props as LoadingProps } from 'hyperview/src/core/components/loadin
 export type NavigationContextProps = {
   entrypointUrl: string;
   fetch: Fetch;
+  onError?: (error: Error) => void;
   onParseAfter?: (url: string) => void;
   onParseBefore?: (url: string) => void;
   onRouteBlur?: (route: Route) => void;


### PR DESCRIPTION
This change corrects the issue in Hyperview which makes the experience inconsistent. A separate PR will be raised in the `mobile` repo to change the error behavior.

hv-route was not properly forwarding the `onError` to the inner `route` component. This caused an inconsistent error behavior between `hyperview_navigation_pro_app` experiment enabled and disabled.



| | Experiment On | Experiment Off |
| - | -- | -- |
| Before | <img width="697" alt="before-on" src="https://github.com/user-attachments/assets/c3b1181c-3642-4366-8916-f6f3849ac78a"> | <img width="697" alt="before-off" src="https://github.com/user-attachments/assets/6feda32a-4a20-42a9-8b3e-904037485de0"> |
| After | <img width="697" alt="after-on" src="https://github.com/user-attachments/assets/76112a2b-1d34-41e0-b291-e1fb52b211f5"> | <img width="697" alt="after-off" src="https://github.com/user-attachments/assets/231f5087-d27e-415e-bdd5-48a7012903e9"> |

Asana: https://app.asana.com/0/1204008699308084/1208057126268164/f






