### PR TITLE
feat(network-retry): add network retry action

### DIFF
--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -19,6 +19,7 @@ import {
   HvComponentOptions,
   NAV_ACTIONS,
   NavAction,
+  NetworkRetryAction,
   OnUpdateCallbacks,
   UPDATE_ACTIONS,
   UpdateAction,
@@ -145,6 +146,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
     root: Document,
     formData: FormData | null | undefined,
     onUpdateCallbacks: OnUpdateCallbacks,
+    networkRetryAction: NetworkRetryAction | null | undefined,
   ): Promise<Element | null> => {
     if (!href) {
       Logging.error(new Error('No href passed to fetchElement'));
@@ -170,6 +172,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
         url,
         formData || null,
         httpMethod,
+        networkRetryAction,
       );
       if (staleHeaderType) {
         // We are doing this to ensure that we keep the screen stale until a `reload` happens
@@ -336,6 +339,9 @@ export default class Hyperview extends PureComponent<Types.Props> {
       once,
       onEnd,
     } = opts;
+    const networkRetryAction = behaviorElement?.getAttribute(
+      'network-retry-action',
+    );
 
     const showIndicatorIdList = showIndicatorIds
       ? Xml.splitAttributeList(showIndicatorIds)
@@ -380,6 +386,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
           newRoot,
           formData,
           onUpdateCallbacks,
+          networkRetryAction,
         ).then(newElement => {
           // If a target is specified and exists, use it. Otherwise, the action target defaults
           // to the element triggering the action.

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -19,7 +19,6 @@ import {
   HvComponentOptions,
   NAV_ACTIONS,
   NavAction,
-  NetworkRetryAction,
   OnUpdateCallbacks,
   UPDATE_ACTIONS,
   UpdateAction,
@@ -28,6 +27,7 @@ import React, { PureComponent } from 'react';
 import HvRoute from 'hyperview/src/core/components/hv-route';
 import HvScreen from 'hyperview/src/core/components/hv-screen';
 import { Linking } from 'react-native';
+import { XNetworkRetryAction } from 'hyperview/src/services/dom/types';
 
 /**
  * Provides routing to the correct path based on the state passed in
@@ -146,7 +146,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
     root: Document,
     formData: FormData | null | undefined,
     onUpdateCallbacks: OnUpdateCallbacks,
-    networkRetryAction: NetworkRetryAction | null | undefined,
+    networkRetryAction: XNetworkRetryAction | null | undefined,
   ): Promise<Element | null> => {
     if (!href) {
       Logging.error(new Error('No href passed to fetchElement'));

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -341,7 +341,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
     } = opts;
     const networkRetryAction = behaviorElement?.getAttribute(
       'network-retry-action',
-    ) as XNetworkRetryAction;
+    ) as XNetworkRetryAction | null | undefined;
 
     const showIndicatorIdList = showIndicatorIds
       ? Xml.splitAttributeList(showIndicatorIds)

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -341,7 +341,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
     } = opts;
     const networkRetryAction = behaviorElement?.getAttribute(
       'network-retry-action',
-    );
+    ) as XNetworkRetryAction;
 
     const showIndicatorIdList = showIndicatorIds
       ? Xml.splitAttributeList(showIndicatorIds)

--- a/src/services/dom/parser.ts
+++ b/src/services/dom/parser.ts
@@ -14,7 +14,7 @@ import {
 } from './types';
 import { DOMParser } from '@instawork/xmldom';
 import { Dimensions } from 'react-native';
-import { LOCAL_NAME } from 'hyperview/src/types';
+import { LOCAL_NAME, NETWORK_RETRY_ACTIONS } from 'hyperview/src/types';
 import type { LocalName } from 'hyperview/src/types';
 import { getFirstTag } from './helpers';
 import { version } from 'hyperview/package.json';
@@ -58,6 +58,8 @@ export class Parser {
     data: FormData | null | undefined = undefined,
     httpMethod: HttpMethod | null | undefined = undefined,
     acceptContentType: string = CONTENT_TYPE.APPLICATION_VND_HYPERVIEW_XML,
+    // todo: fix type
+    networkRetryAction: string | null | undefined = undefined,
   ): Promise<{
     doc: Document;
     staleHeaderType: XResponseStaleReason | null | undefined;
@@ -81,9 +83,13 @@ export class Parser {
         [HTTP_HEADERS.ACCEPT]: `${CONTENT_TYPE.APPLICATION_XML}, ${acceptContentType}`,
         [HTTP_HEADERS.X_HYPERVIEW_VERSION]: version,
         [HTTP_HEADERS.X_HYPERVIEW_DIMENSIONS]: `${width}w ${height}h`,
+        ...(networkRetryAction && {
+          [HTTP_HEADERS.X_NETWORK_RETRY_ACTION]: networkRetryAction,
+        }),
       },
       method,
     } as const;
+    console.log('HV HEADERS', options.headers, networkRetryAction);
 
     const response: Response = await this.fetch(url, options);
     const responseText: string = await response.text();
@@ -163,6 +169,8 @@ export class Parser {
     baseUrl: string,
     data: FormData | null,
     method: HttpMethod | null = HTTP_METHODS.GET,
+    // todo: fix type
+    networkRetryAction: string | null | undefined,
   ): Promise<{
     doc: Document;
     staleHeaderType: XResponseStaleReason | null | undefined;
@@ -172,6 +180,7 @@ export class Parser {
       data,
       method,
       CONTENT_TYPE.APPLICATION_VND_HYPERVIEW_FRAGMENT_XML,
+      networkRetryAction,
     );
     const docElement = getFirstTag(doc, LOCAL_NAME.DOC);
     if (docElement) {

--- a/src/services/dom/parser.ts
+++ b/src/services/dom/parser.ts
@@ -89,7 +89,6 @@ export class Parser {
       },
       method,
     } as const;
-    console.log('HV HEADERS', options.headers, networkRetryAction);
 
     const response: Response = await this.fetch(url, options);
     const responseText: string = await response.text();

--- a/src/services/dom/parser.ts
+++ b/src/services/dom/parser.ts
@@ -4,6 +4,7 @@ import type {
   BeforeAfterParseHandler,
   Fetch,
   HttpMethod,
+  XNetworkRetryAction,
   XResponseStaleReason,
 } from './types';
 import {
@@ -14,7 +15,7 @@ import {
 } from './types';
 import { DOMParser } from '@instawork/xmldom';
 import { Dimensions } from 'react-native';
-import { LOCAL_NAME, NETWORK_RETRY_ACTIONS } from 'hyperview/src/types';
+import { LOCAL_NAME } from 'hyperview/src/types';
 import type { LocalName } from 'hyperview/src/types';
 import { getFirstTag } from './helpers';
 import { version } from 'hyperview/package.json';
@@ -58,8 +59,7 @@ export class Parser {
     data: FormData | null | undefined = undefined,
     httpMethod: HttpMethod | null | undefined = undefined,
     acceptContentType: string = CONTENT_TYPE.APPLICATION_VND_HYPERVIEW_XML,
-    // todo: fix type
-    networkRetryAction: string | null | undefined = undefined,
+    networkRetryAction: XNetworkRetryAction | null | undefined = undefined,
   ): Promise<{
     doc: Document;
     staleHeaderType: XResponseStaleReason | null | undefined;
@@ -169,8 +169,7 @@ export class Parser {
     baseUrl: string,
     data: FormData | null,
     method: HttpMethod | null = HTTP_METHODS.GET,
-    // todo: fix type
-    networkRetryAction: string | null | undefined,
+    networkRetryAction: XNetworkRetryAction | null | undefined,
   ): Promise<{
     doc: Document;
     staleHeaderType: XResponseStaleReason | null | undefined;

--- a/src/services/dom/types.ts
+++ b/src/services/dom/types.ts
@@ -3,6 +3,7 @@ export const HTTP_HEADERS = {
   CONTENT_TYPE: 'Content-Type',
   X_HYPERVIEW_DIMENSIONS: 'X-Hyperview-Dimensions',
   X_HYPERVIEW_VERSION: 'X-Hyperview-Version',
+  X_NETWORK_RETRY_ACTION: 'X-Network-Retry-Action',
   X_RESPONSE_STALE_REASON: 'X-Response-Stale-Reason',
 } as const;
 

--- a/src/services/dom/types.ts
+++ b/src/services/dom/types.ts
@@ -30,7 +30,9 @@ export const X_RESPONSE_STALE_REASON = {
 export type XResponseStaleReason = typeof X_RESPONSE_STALE_REASON[keyof typeof X_RESPONSE_STALE_REASON];
 
 export const X_NETWORK_RETRY_ACTION = {
+  DROP: 'drop',
   QUEUE: 'queue',
+  REPLACE: 'replace',
 } as const;
 
 // eslint-disable-next-line max-len

--- a/src/services/dom/types.ts
+++ b/src/services/dom/types.ts
@@ -29,6 +29,13 @@ export const X_RESPONSE_STALE_REASON = {
 // eslint-disable-next-line max-len
 export type XResponseStaleReason = typeof X_RESPONSE_STALE_REASON[keyof typeof X_RESPONSE_STALE_REASON];
 
+export const X_NETWORK_RETRY_ACTION = {
+  QUEUE: 'queue',
+} as const;
+
+// eslint-disable-next-line max-len
+export type XNetworkRetryAction = typeof X_NETWORK_RETRY_ACTION[keyof typeof X_NETWORK_RETRY_ACTION];
+
 export type Fetch = (
   url: string,
   options: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -427,11 +427,3 @@ export type Reload = (
   optHref: DOMString | null | undefined,
   opts: HvComponentOptions,
 ) => void;
-
-export const NETWORK_RETRY_ACTIONS = {
-  DROP: 'drop',
-  QUEUE: 'queue',
-  REPLACE: 'replace',
-} as const;
-
-export type NetworkRetryAction = typeof NETWORK_RETRY_ACTIONS[keyof typeof NETWORK_RETRY_ACTIONS];

--- a/src/types.ts
+++ b/src/types.ts
@@ -255,6 +255,7 @@ export const BEHAVIOR_ATTRIBUTES = {
   HREF: 'href',
   HREF_STYLE: 'href-style',
   IMMEDIATE: 'immediate',
+  NetworkRetryAction: 'network-retry-action',
   NEW_VALUE: 'new-value',
   ONCE: 'once',
   SHOW_DURING_LOAD: 'show-during-load',
@@ -426,3 +427,11 @@ export type Reload = (
   optHref: DOMString | null | undefined,
   opts: HvComponentOptions,
 ) => void;
+
+export const NETWORK_RETRY_ACTIONS = {
+  DROP: 'drop',
+  QUEUE: 'queue',
+  REPLACE: 'replace',
+} as const;
+
+export type NetworkRetryAction = typeof NETWORK_RETRY_ACTIONS[keyof typeof NETWORK_RETRY_ACTIONS];


### PR DESCRIPTION
This PR adds support for `network-retry-action`.
When the attribute is present, we will pass down the value in the request header (`X-Network-Retry-Action`).
This is meant for retrying non GET requests when the network call fails. It is up to the consumer of the Hyperview library to handle this header as part of the fetch implementation (passed in as a prop).