### PR TITLE
feat(lists): Add support for `keyboardShouldPersistTaps`

### DIFF
--- a/docs/reference_list.md
+++ b/docs/reference_list.md
@@ -36,6 +36,7 @@ A `<list>` element will only render `<item>` and `<items>` children elements. Ot
 - [`scroll-orientation`](#scroll-orientation)
 - [`shows-scroll-indicator`](#shows-scroll-indicator)
 - [`keyboard-dismiss-mode`](#keyboard-dismiss-mode)
+- [`keyboard-should-persist-taps`](#keyboard-should-persist-taps)
 
 #### Behavior attributes
 
@@ -96,3 +97,11 @@ An attribute indicating whether the scroll bar should be shown.
 | **none** (default), `on-drag`, `interactive` | No       |
 
 An attribute that controls the virtual keyboard behavior when the scrollable view is interacted with. Note: `interactive` value is only supported on iOS. When set to this value, the keyboard is dismissed interactively with the drag and moves in synchrony with the touch, dragging upwards cancels the dismissal. On Android this is not supported and it will have the same behavior as `none`.
+
+#### `keyboard-should-persist-taps`
+
+| Type                                     | Required |
+| ---------------------------------------- | -------- |
+| **never** (default), `always`, `handled` | No       |
+
+An attribute that controls the virtual keyboard behavior when the scrollable view is tapped.

--- a/docs/reference_sectionlist.md
+++ b/docs/reference_sectionlist.md
@@ -38,6 +38,7 @@ A `<section-list>` element will only render `<section-title>` and `<item>` child
 - [`hide`](#hide)
 - [`sticky-section-titles`](#sticky-section-titles)
 - [`keyboard-dismiss-mode`](#keyboard-dismiss-mode)
+- [`keyboard-should-persist-taps`](#keyboard-should-persist-taps)
 
 #### Behavior attributes
 
@@ -82,3 +83,11 @@ When set to `"true"`, the section titles will remain sticky at the top of their 
 | **none** (default), `on-drag`, `interactive` | No       |
 
 An attribute that controls the virtual keyboard behavior when the scrollable view is interacted with. Note: `interactive` value is only supported on iOS. When set to this value, the keyboard is dismissed interactively with the drag and moves in synchrony with the touch, dragging upwards cancels the dismissal. On Android this is not supported and it will have the same behavior as `none`.
+
+#### `keyboard-should-persist-taps`
+
+| Type                                     | Required |
+| ---------------------------------------- | -------- |
+| **never** (default), `always`, `handled` | No       |
+
+An attribute that controls the virtual keyboard behavior when the scrollable view is tapped.

--- a/examples/_includes/macros/text-field/index.xml.njk
+++ b/examples/_includes/macros/text-field/index.xml.njk
@@ -1,0 +1,11 @@
+{% macro text_field(name, attributes={}) %}
+  <text-field
+    name="{{ name }}"
+    {% for attr, val in attributes %}
+      {{ attr }}="{{ val }}"
+    {% endfor %}
+    {% if "style" not in attributes %}
+      style="input"
+    {% endif %}
+  />
+{% endmacro %}

--- a/examples/_includes/macros/text-field/styles.xml.njk
+++ b/examples/_includes/macros/text-field/styles.xml.njk
@@ -1,0 +1,17 @@
+<style
+  id="input"
+  borderBottomColor="#E1E1E1"
+  borderBottomWidth="1"
+  borderColor="#4E4D4D"
+  flex="1"
+  fontSize="16"
+  fontWeight="normal"
+  paddingBottom="8"
+  paddingTop="8">
+  <modifier pressed="true">
+  <style borderBottomColor="green"/>
+  </modifier>
+  <modifier focused="true">
+  <style borderBottomColor="#4778FF"/>
+  </modifier>
+</style>

--- a/examples/_includes/templates/styles.xml.njk
+++ b/examples/_includes/templates/styles.xml.njk
@@ -5,6 +5,7 @@
 {% include 'macros/container/styles.xml.njk' %}
 {% include 'macros/contact/styles.xml.njk' %}
 {% include 'macros/tab/styles.xml.njk' %}
+{% include 'macros/text-field/styles.xml.njk' %}
 
 <style
   id="header"

--- a/examples/ui/ui-elements/list/keyboard-dismiss/index.xml.njk
+++ b/examples/ui/ui-elements/list/keyboard-dismiss/index.xml.njk
@@ -5,31 +5,12 @@ hv_title: "Dismiss Keyboard on Drag"
 hv_button_behavior: "back"
 ---
 {% extends 'templates/base.xml.njk' %}
-
-{% block styles %}
-  <style
-    id="input"
-    borderBottomColor="#E1E1E1"
-    borderBottomWidth="1"
-    borderColor="#4E4D4D"
-    flex="1"
-    fontSize="16"
-    fontWeight="normal"
-    paddingBottom="8"
-    paddingTop="8">
-    <modifier pressed="true">
-    <style borderBottomColor="green"/>
-    </modifier>
-    <modifier focused="true">
-    <style borderBottomColor="#4778FF"/>
-    </modifier>
-  </style>
-{% endblock %}
+{% from 'macros/text-field/index.xml.njk' import text_field %}
 
 {% block container %}
   <list keyboard-dismiss-mode="on-drag">
     <item key="field" style="item">
-      <text-field name="field" style="input" auto-focus="true" placeholder="Scroll!" />
+      {{ text_field("field", {"auto-focus":"true", "placeholder":"Scroll!"}) }}
     </item>
     {% for i in range(1, 21) %}
       <item key="{{ i }}" style="item">

--- a/examples/ui/ui-elements/list/keyboard-persist-tap/index.xml.njk
+++ b/examples/ui/ui-elements/list/keyboard-persist-tap/index.xml.njk
@@ -1,0 +1,48 @@
+---
+permalink: "/ui/ui-elements/list/keyboard-persist-tap/index.xml"
+tags: "List"
+hv_title: "Keyboard Persist Tap"
+hv_button_behavior: "back"
+---
+{% extends 'templates/base.xml.njk' %}
+
+{% block styles %}
+  <style
+    id="input"
+    borderBottomColor="#E1E1E1"
+    borderBottomWidth="1"
+    borderColor="#4E4D4D"
+    flex="1"
+    fontSize="16"
+    fontWeight="normal"
+    paddingBottom="8"
+    paddingTop="8">
+    <modifier pressed="true">
+    <style borderBottomColor="green"/>
+    </modifier>
+    <modifier focused="true">
+    <style borderBottomColor="#4778FF"/>
+    </modifier>
+  </style>
+{% endblock %}
+
+{% block container %}
+  <list keyboard-should-persist-taps="handled">
+    <item key="field" style="item">
+      <text-field name="field" style="input" auto-focus="true" placeholder="Tap!" />
+    </item>
+    {% for i in range(1, 21) %}
+      <item key="{{ i }}" style="item">
+        <text style="item-label">List {{ i }}</text>
+        <behavior
+          xmlns:alert="https://hyperview.org/hyperview-alert"
+          trigger="press"
+          action="alert"
+          alert:title="List {{ i }} selected"
+        >
+          <alert:option alert:label="Cancel" />
+        </behavior>
+      </item>
+    {% endfor %}
+  </list>
+{% endblock %}

--- a/examples/ui/ui-elements/list/keyboard-persist-tap/index.xml.njk
+++ b/examples/ui/ui-elements/list/keyboard-persist-tap/index.xml.njk
@@ -5,31 +5,12 @@ hv_title: "Keyboard Persist Tap"
 hv_button_behavior: "back"
 ---
 {% extends 'templates/base.xml.njk' %}
-
-{% block styles %}
-  <style
-    id="input"
-    borderBottomColor="#E1E1E1"
-    borderBottomWidth="1"
-    borderColor="#4E4D4D"
-    flex="1"
-    fontSize="16"
-    fontWeight="normal"
-    paddingBottom="8"
-    paddingTop="8">
-    <modifier pressed="true">
-    <style borderBottomColor="green"/>
-    </modifier>
-    <modifier focused="true">
-    <style borderBottomColor="#4778FF"/>
-    </modifier>
-  </style>
-{% endblock %}
+{% from 'macros/text-field/index.xml.njk' import text_field %}
 
 {% block container %}
   <list keyboard-should-persist-taps="handled">
     <item key="field" style="item">
-      <text-field name="field" style="input" auto-focus="true" placeholder="Tap!" />
+      {{ text_field("field", {"auto-focus":"true", "placeholder":"Tap!"}) }}
     </item>
     {% for i in range(1, 21) %}
       <item key="{{ i }}" style="item">

--- a/examples/ui/ui-elements/section-list/dismiss-keyboard/index.xml.njk
+++ b/examples/ui/ui-elements/section-list/dismiss-keyboard/index.xml.njk
@@ -5,31 +5,12 @@ hv_title: "Dismiss Keyboard on Drag"
 hv_button_behavior: "back"
 ---
 {% extends 'templates/base.xml.njk' %}
-
-{% block styles %}
-  <style
-    id="input"
-    borderBottomColor="#E1E1E1"
-    borderBottomWidth="1"
-    borderColor="#4E4D4D"
-    flex="1"
-    fontSize="16"
-    fontWeight="normal"
-    paddingBottom="8"
-    paddingTop="8">
-    <modifier pressed="true">
-    <style borderBottomColor="green"/>
-    </modifier>
-    <modifier focused="true">
-    <style borderBottomColor="#4778FF"/>
-    </modifier>
-  </style>
-{% endblock %}
+{% from 'macros/text-field/index.xml.njk' import text_field %}
 
 {% block container %}
   <section-list keyboard-dismiss-mode="on-drag">
     <item key="field" style="item">
-      <text-field name="field" style="input" auto-focus="true" placeholder="Scroll!" />
+      {{ text_field("field", {"auto-focus":"true", "placeholder":"Scroll!"}) }}
     </item>
     <section-title style="list-header">
       <text style="list-header-text">Section 1</text>

--- a/examples/ui/ui-elements/section-list/keyboard-persist-tap/index.xml.njk
+++ b/examples/ui/ui-elements/section-list/keyboard-persist-tap/index.xml.njk
@@ -5,31 +5,12 @@ hv_title: "Keyboard Persist Tap"
 hv_button_behavior: "back"
 ---
 {% extends 'templates/base.xml.njk' %}
-
-{% block styles %}
-  <style
-    id="input"
-    borderBottomColor="#E1E1E1"
-    borderBottomWidth="1"
-    borderColor="#4E4D4D"
-    flex="1"
-    fontSize="16"
-    fontWeight="normal"
-    paddingBottom="8"
-    paddingTop="8">
-    <modifier pressed="true">
-    <style borderBottomColor="green"/>
-    </modifier>
-    <modifier focused="true">
-    <style borderBottomColor="#4778FF"/>
-    </modifier>
-  </style>
-{% endblock %}
+{% from 'macros/text-field/index.xml.njk' import text_field %}
 
 {% block container %}
   <section-list keyboard-should-persist-taps="handled">
     <item key="field" style="item">
-      <text-field name="field" style="input" auto-focus="true" placeholder="Tap!" />
+      {{ text_field("field", {"auto-focus":"true", "placeholder":"Tap!"}) }}
     </item>
     <section-title style="list-header">
       <text style="list-header-text">Section 1</text>

--- a/examples/ui/ui-elements/section-list/keyboard-persist-tap/index.xml.njk
+++ b/examples/ui/ui-elements/section-list/keyboard-persist-tap/index.xml.njk
@@ -1,0 +1,60 @@
+---
+permalink: "/ui/ui-elements/section-list/keyboard-persist-tap/index.xml"
+tags: "Section List"
+hv_title: "Keyboard Persist Tap"
+hv_button_behavior: "back"
+---
+{% extends 'templates/base.xml.njk' %}
+
+{% block styles %}
+  <style
+    id="input"
+    borderBottomColor="#E1E1E1"
+    borderBottomWidth="1"
+    borderColor="#4E4D4D"
+    flex="1"
+    fontSize="16"
+    fontWeight="normal"
+    paddingBottom="8"
+    paddingTop="8">
+    <modifier pressed="true">
+    <style borderBottomColor="green"/>
+    </modifier>
+    <modifier focused="true">
+    <style borderBottomColor="#4778FF"/>
+    </modifier>
+  </style>
+{% endblock %}
+
+{% block container %}
+  <section-list keyboard-should-persist-taps="handled">
+    <item key="field" style="item">
+      <text-field name="field" style="input" auto-focus="true" placeholder="Tap!" />
+    </item>
+    <section-title style="list-header">
+      <text style="list-header-text">Section 1</text>
+    </section-title>
+    {% for item in range(1, 11) %}
+      <item key="{{ item }}" style="item">
+        <text style="item-label">List {{ item }}</text>
+        <behavior
+          xmlns:alert="https://hyperview.org/hyperview-alert"
+          trigger="press"
+          action="alert"
+          alert:title="List {{ item }} selected"
+        >
+          <alert:option alert:label="Cancel" />
+        </behavior>
+      </item>
+    {% endfor %}
+
+    <section-title style="list-header">
+      <text style="list-header-text">Section 2</text>
+    </section-title>
+    {% for item in range(11, 21) %}
+      <item key="{{ item }}" style="item">
+        <text style="item-label">List {{ item }}</text>
+      </item>
+    {% endfor %}
+  </section-list>
+{% endblock %}

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -869,6 +869,15 @@
       <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="value" type="xs:string" />
+      <xs:attribute name="keyboard-should-persist-taps">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="never" />
+            <xs:enumeration value="always" />
+            <xs:enumeration value="handled" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
       <xs:attributeGroup ref="hv:scrollAttributes" />
       <xs:attributeGroup ref="hv:behaviorAttributes" />
     </xs:complexType>
@@ -892,14 +901,23 @@
       <xs:attribute name="value" type="xs:string" />
       <xs:attribute name="sticky-section-titles" type="xs:boolean" />
       <xs:attribute name="keyboard-dismiss-mode">
-      <xs:simpleType>
-        <xs:restriction base="xs:string">
-          <xs:enumeration value="none" />
-          <xs:enumeration value="on-drag" />
-          <xs:enumeration value="interactive" />
-        </xs:restriction>
-      </xs:simpleType>
-    </xs:attribute>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="none" />
+            <xs:enumeration value="on-drag" />
+            <xs:enumeration value="interactive" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="keyboard-should-persist-taps">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="never" />
+            <xs:enumeration value="always" />
+            <xs:enumeration value="handled" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
       <xs:attributeGroup ref="hv:behaviorAttributes" />
     </xs:complexType>
   </xs:element>

--- a/src/components/hv-list/index.tsx
+++ b/src/components/hv-list/index.tsx
@@ -245,6 +245,9 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
               keyboardDismissMode={Keyboard.getKeyboardDismissMode(
                 this.props.element,
               )}
+              keyboardShouldPersistTaps={Keyboard.getKeyboardShouldPersistTaps(
+                this.props.element,
+              )}
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               keyExtractor={(item: any) => item && item.getAttribute('key')}
               refreshControl={

--- a/src/components/hv-section-list/index.tsx
+++ b/src/components/hv-section-list/index.tsx
@@ -357,6 +357,9 @@ export default class HvSectionList extends PureComponent<
               keyboardDismissMode={Keyboard.getKeyboardDismissMode(
                 this.props.element,
               )}
+              keyboardShouldPersistTaps={Keyboard.getKeyboardShouldPersistTaps(
+                this.props.element,
+              )}
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               keyExtractor={(item: any) => item.getAttribute('key')}
               refreshControl={

--- a/src/services/keyboard/index.ts
+++ b/src/services/keyboard/index.ts
@@ -1,4 +1,5 @@
 type KeyboardDismissMode = 'none' | 'on-drag' | 'interactive';
+type KeyboardShouldPersistTaps = 'never' | 'always' | 'handled';
 
 export const getKeyboardDismissMode = (
   element: Element,
@@ -11,5 +12,19 @@ export const getKeyboardDismissMode = (
       return mode;
     default:
       return undefined;
+  }
+};
+
+export const getKeyboardShouldPersistTaps = (
+  element: Element,
+): KeyboardShouldPersistTaps => {
+  const mode = element.getAttribute('keyboard-should-persist-taps');
+  switch (mode) {
+    case 'never':
+    case 'always':
+    case 'handled':
+      return mode;
+    default:
+      return 'never';
   }
 };


### PR DESCRIPTION
Add support for `keyboardShouldPersistTaps` to List and SectionList. 

| List  | SectionList  |
|---|---|
| ![list](https://github.com/user-attachments/assets/29116f31-bce5-42ff-9ba4-42b8fe1efc65)  |  ![sectionlist](https://github.com/user-attachments/assets/116decd9-31af-4a0a-9f00-291666a09405) |