### PR TITLE
fix(demo): BottomTabBar infinite loop

### DIFF
--- a/demo/src/Components/BottomTabBar.tsx
+++ b/demo/src/Components/BottomTabBar.tsx
@@ -30,7 +30,7 @@ const BottomTabBar = (props: HvComponentProps) => {
     }
     ctx.setElementProps?.(navigator, props);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [navigator, props]); // Exclude setElementProps from dependencies to avoid infinite loop
+  }, [navigator, props]); // Exclude ctx from dependencies to avoid infinite loop
   return null;
 };
 

--- a/demo/src/Components/BottomTabBar.tsx
+++ b/demo/src/Components/BottomTabBar.tsx
@@ -29,7 +29,8 @@ const BottomTabBar = (props: HvComponentProps) => {
       return;
     }
     ctx.setElementProps?.(navigator, props);
-  }, [navigator, props, ctx]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [navigator, props]); // Exclude setElementProps from dependencies to avoid infinite loop
   return null;
 };
 


### PR DESCRIPTION
Remove `ctx` dependency of effect to avoid infinite loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the dependency array in the Bottom Tab Bar component to prevent potential infinite loops.

- **Documentation**
	- Added a comment to clarify the change regarding ESLint rule for exhaustive dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->