### PR TITLE
fix(hv-screen): include `onUpdateCallbacks` in the render options

### DIFF
--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -266,6 +266,7 @@ export default class HvScreen extends React.Component {
       this.onUpdate,
       {
         componentRegistry: this.componentRegistry,
+        onUpdateCallbacks: this.updateCallbacks,
         screenUrl: this.state.url,
         staleHeaderType: this.state.staleHeaderType,
       },


### PR DESCRIPTION
Resolving an issue where `onUpdateCallbacks` were not passed to the rendered screen elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `HvScreen` component with new callback functionalities for improved state management and navigation during updates.

- **Bug Fixes**
	- Improved handling of element errors and state updates within the `HvScreen` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->