### PR TITLE
[Demo] Adds missing dependency: faker

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@babel/preset-env": "^7.22.20",
+    "@faker-js/faker": "^9.0.3",
     "@react-native-community/datetimepicker": "7.6.2",
     "@react-native-picker/picker": "2.6.1",
     "@react-navigation/bottom-tabs": "^6.5.9",

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -2197,6 +2197,11 @@
     find-up "^5.0.0"
     js-yaml "^4.1.0"
 
+"@faker-js/faker@^9.0.3":
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-9.0.3.tgz#be817db896b07d1716bc65d9aad1ba587b499826"
+  integrity sha512-lWrrK4QNlFSU+13PL9jMbMKLJYXDFu3tQfayBsMXX7KL/GiQeqfB1CzHkqD5UHBUtPAuPo6XwGbMFNdVMZObRA==
+
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"


### PR DESCRIPTION
Otherwise demo would not run:

```sh
$ cd demo
$ yarn server
yarn run v1.22.22
$ eleventy --serve --port=8085
[11ty] Cannot find module '@faker-js/faker'

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new dependency for enhanced data generation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->