### PR TITLE
refactor(demo): consistent 11ty tags formatting

### DIFF
--- a/demo/.eleventy.js
+++ b/demo/.eleventy.js
@@ -3,6 +3,7 @@ const {
   highlightFilter,
   paginateFilter,
   pageCountFilter,
+  sectionTitleFilter,
 } = require('./.eleventy/filters.js');
 
 module.exports = function (eleventyConfig) {
@@ -49,6 +50,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addNunjucksFilter('highlight', highlightFilter);
   eleventyConfig.addNunjucksFilter('paginate', paginateFilter);
   eleventyConfig.addNunjucksFilter('pageCount', pageCountFilter);
+  eleventyConfig.addNunjucksFilter('sectionTitle', sectionTitleFilter);
   // Output into demo folder for serving both github pages and local development
   return {
     dir: {

--- a/demo/.eleventy/filters.js
+++ b/demo/.eleventy/filters.js
@@ -33,9 +33,15 @@ const paginateFilter = (list, pageNumber, itemsPerPage = 20) =>
 const pageCountFilter = (list, itemsPerPage = 20) =>
   Math.ceil(list.length / itemsPerPage);
 
+const sectionTitleFilter = tag => {
+  const segments = tag.split('/');
+  return segments[segments.length - 1];
+};
+
 module.exports = {
   sortCollectionFilter,
   highlightFilter,
   paginateFilter,
   pageCountFilter,
+  sectionTitleFilter,
 };

--- a/demo/backend/_includes/templates/section-list.xml.njk
+++ b/demo/backend/_includes/templates/section-list.xml.njk
@@ -11,7 +11,7 @@
 >
   {% for section_tag in hv_section_list_tag.split(',') %}
     <section-title style="list-header item-first">
-      <text style="list-header-text">{{section_tag}}</text>
+      <text style="list-header-text">{{ section_tag | sectionTitle }}</text>
     </section-title>
     {% for screen in collections[section_tag]|sortCollection %}
       {% set item_style = "item" %}

--- a/demo/backend/advanced/case-studies/advanced-forms/index.xml.njk
+++ b/demo/backend/advanced/case-studies/advanced-forms/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/advanced/case-studies/advanced-forms/index.xml"
-tags: "case_studies"
+tags: "Advanced/Case Studies"
 hv_title: "Advanced Forms"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/advanced/case-studies/basic-forms/index.xml.njk
+++ b/demo/backend/advanced/case-studies/basic-forms/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/advanced/case-studies/basic-forms/index.xml"
-tags: "case_studies"
+tags: "Advanced/Case Studies"
 hv_title: "Basic Forms"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/advanced/case-studies/business-rating/index.xml.njk
+++ b/demo/backend/advanced/case-studies/business-rating/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/advanced/case-studies/business-rating/index.xml"
-tags: "case_studies"
+tags: "Advanced/Case Studies"
 hv_title: "Rate by Business"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/advanced/case-studies/cascader/index.xml.njk
+++ b/demo/backend/advanced/case-studies/cascader/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/advanced/case-studies/cascader/index.xml"
-tags: "case_studies"
+tags: "Advanced/Case Studies"
 hv_title: "Cascader"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/advanced/case-studies/contacts/index.xml.njk
+++ b/demo/backend/advanced/case-studies/contacts/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/advanced/case-studies/contacts/index.xml"
-tags: "case_studies"
+tags: "Advanced/Case Studies"
 hv_title: "Contacts"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/advanced/case-studies/content.xml.njk
+++ b/demo/backend/advanced/case-studies/content.xml.njk
@@ -1,2 +1,2 @@
-{% set hv_list_tag = "case_studies" %}
+{% set hv_list_tag = "Advanced/Case Studies" %}
 {% include "templates/list.xml.njk" %}

--- a/demo/backend/advanced/case-studies/custom-android-back/index.xml.njk
+++ b/demo/backend/advanced/case-studies/custom-android-back/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/advanced/case-studies/custom-android-back/index.xml"
-tags: "case_studies"
+tags: "Advanced/Case Studies"
 hv_title: "Custom Android Back"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/advanced/case-studies/delayed-navigation/index.xml.njk
+++ b/demo/backend/advanced/case-studies/delayed-navigation/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/advanced/case-studies/delayed-navigation/index.xml"
-tags: "case_studies"
+tags: "Advanced/Case Studies"
 hv_title: "Delayed Navigation"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/advanced/case-studies/feedback-widget/index.xml.njk
+++ b/demo/backend/advanced/case-studies/feedback-widget/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/advanced/case-studies/feedback-widget/index.xml"
-tags: "case_studies"
+tags: "Advanced/Case Studies"
 hv_title: "Feedback Widget"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/advanced/case-studies/infinite-scroll/index.xml.njk
+++ b/demo/backend/advanced/case-studies/infinite-scroll/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/advanced/case-studies/infinite-scroll/index.xml"
-tags: "case_studies"
+tags: "Advanced/Case Studies"
 hv_title: "Infinite Scroll"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/advanced/case-studies/lazy-load/index.xml.njk
+++ b/demo/backend/advanced/case-studies/lazy-load/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/advanced/case-studies/lazy-load/index.xml"
-tags: "case_studies"
+tags: "Advanced/Case Studies"
 hv_title: "Lazy Load"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/advanced/case-studies/navigation/index.xml.njk
+++ b/demo/backend/advanced/case-studies/navigation/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/advanced/case-studies/navigation/actions/index.xml"
-tags: "case_studies"
+tags: "Advanced/Case Studies"
 hv_title: "Navigation"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/advanced/case-studies/photos/index.xml.njk
+++ b/demo/backend/advanced/case-studies/photos/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/advanced/case-studies/photos/index.xml"
-tags: "case_studies"
+tags: "Advanced/Case Studies"
 hv_title: "Photo Sharing App"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/advanced/case-studies/pull-to-refresh/index.xml.njk
+++ b/demo/backend/advanced/case-studies/pull-to-refresh/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/advanced/case-studies/pull-to-refresh/index.xml"
-tags: "case_studies"
+tags: "Advanced/Case Studies"
 hv_title: "Pull To Refresh"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/advanced/case-studies/tabs/index.xml.njk
+++ b/demo/backend/advanced/case-studies/tabs/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/advanced/case-studies/tabs/index.xml"
-tags: "case_studies"
+tags: "Advanced/Case Studies"
 hv_title: "Tabs"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/advanced/community/behaviors/share/index.xml.njk
+++ b/demo/backend/advanced/community/behaviors/share/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/advanced/community/behaviors/share/index.xml"
-tags: "Behaviors"
+tags: "Advanced/Community/Behaviors"
 hv_title: "Share"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/advanced/community/content.xml.njk
+++ b/demo/backend/advanced/community/content.xml.njk
@@ -1,2 +1,2 @@
-{% set hv_section_list_tag = "Elements,Behaviors" %}
+{% set hv_section_list_tag = "Advanced/Community/Elements,Advanced/Community/Behaviors" %}
 {% include "templates/section-list.xml.njk" %}

--- a/demo/backend/advanced/community/elements/filter/index.xml.njk
+++ b/demo/backend/advanced/community/elements/filter/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/backend/advanced/community/filter.xml"
-tags: "Elements"
+tags: "Advanced/Community/Elements"
 hv_button_behavior: "back"
 hv_title: "Filter"
 ---

--- a/demo/backend/advanced/community/elements/svg-image/index.xml.njk
+++ b/demo/backend/advanced/community/elements/svg-image/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/backend/advanced/community/svg_image.xml"
-tags: "Elements"
+tags: "Advanced/Community/Elements"
 hv_button_behavior: "back"
 hv_title: "SVG Image"
 ---

--- a/demo/backend/behaviors/advanced/content.xml.njk
+++ b/demo/backend/behaviors/advanced/content.xml.njk
@@ -1,2 +1,2 @@
-{% set hv_list_tag = "advanced" %}
+{% set hv_list_tag = "Behaviors/Advanced" %}
 {% include "templates/list.xml.njk" %}

--- a/demo/backend/behaviors/advanced/copy-to-clipboard/index.xml.njk
+++ b/demo/backend/behaviors/advanced/copy-to-clipboard/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/advanced/copy-to-clipboard/index.xml"
-tags: "advanced"
+tags: "Behaviors/Advanced"
 hv_title: "Copy To Clipboard"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/advanced/dispatch-multiple/index.xml.njk
+++ b/demo/backend/behaviors/advanced/dispatch-multiple/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/advanced/dispatch-multiple/index.xml"
-tags: "advanced"
+tags: "Behaviors/Advanced"
 hv_title: "Dispatch Events Multiple"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/advanced/dispatch/index.xml.njk
+++ b/demo/backend/behaviors/advanced/dispatch/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/advanced/dispatch/index.xml"
-tags: "advanced"
+tags: "Behaviors/Advanced"
 hv_title: "Dispatch Event"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/advanced/multiple-different/index.xml.njk
+++ b/demo/backend/behaviors/advanced/multiple-different/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/advanced/multiple-different/index.xml"
-tags: "advanced"
+tags: "Behaviors/Advanced"
 hv_title: "Multiple Different Behaviors"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/advanced/multiple-same/index.xml.njk
+++ b/demo/backend/behaviors/advanced/multiple-same/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/advanced/multiple-same/index.xml"
-tags: "advanced"
+tags: "Behaviors/Advanced"
 hv_title: "Multiple Same Behaviors"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/advanced/scroll/index.xml.njk
+++ b/demo/backend/behaviors/advanced/scroll/index.xml.njk
@@ -1,9 +1,9 @@
 ---
 permalink: "/behaviors/advanced/scroll/index.xml"
-tags: "advanced"
+tags: "Behaviors/Advanced"
 hv_title: "Scroll"
 hv_button_behavior: "back"
-hv_list_tag: "list"
+hv_list_tag: "Behaviors/Advanced/Scroll"
 ---
 {% extends 'templates/base.xml.njk' %}
 

--- a/demo/backend/behaviors/advanced/scroll/list/index.xml.njk
+++ b/demo/backend/behaviors/advanced/scroll/list/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/advanced/scroll/list/index.xml"
-tags: "list"
+tags: "Behaviors/Advanced/Scroll"
 hv_title: "List"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/advanced/scroll/section-list/index.xml.njk
+++ b/demo/backend/behaviors/advanced/scroll/section-list/index.xml.njk
@@ -1,7 +1,7 @@
 ---
 permalink: "/behaviors/advanced/scroll/section-list/index.xml"
-tags: "list"
-hv_title: "Section List"
+tags: "Behaviors/Advanced/Scroll"
+hv_title: "UI/UI Elements/Section List"
 hv_button_behavior: "back"
 ---
 {% extends 'templates/base.xml.njk' %}

--- a/demo/backend/behaviors/advanced/set-value/index.xml.njk
+++ b/demo/backend/behaviors/advanced/set-value/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/advanced/set-value/index.xml"
-tags: "advanced"
+tags: "Behaviors/Advanced"
 hv_title: "Set Value"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/actions/append/index.xml.njk
+++ b/demo/backend/behaviors/basic/actions/append/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/append/index.xml"
-tags: "Actions"
+tags: "Behaviors/Basic/Actions"
 hv_title: "Append"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/actions/hide/index.xml.njk
+++ b/demo/backend/behaviors/basic/actions/hide/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/hide/index.xml"
-tags: "Actions"
+tags: "Behaviors/Basic/Actions"
 hv_title: "Hide"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/actions/prepend/index.xml.njk
+++ b/demo/backend/behaviors/basic/actions/prepend/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/prepend/index.xml"
-tags: "Actions"
+tags: "Behaviors/Basic/Actions"
 hv_title: "Prepend"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/actions/replace-inner/index.xml.njk
+++ b/demo/backend/behaviors/basic/actions/replace-inner/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/replace-inner/index.xml"
-tags: "Actions"
+tags: "Behaviors/Basic/Actions"
 hv_title: "Replace Inner"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/actions/replace/index.xml.njk
+++ b/demo/backend/behaviors/basic/actions/replace/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/replace/index.xml"
-tags: "Actions"
+tags: "Behaviors/Basic/Actions"
 hv_title: "Replace"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/actions/select-all/index.xml.njk
+++ b/demo/backend/behaviors/basic/actions/select-all/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/select-all/index.xml"
-tags: "Actions"
+tags: "Behaviors/Basic/Actions"
 hv_title: "Select All"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/actions/show/index.xml.njk
+++ b/demo/backend/behaviors/basic/actions/show/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/show/index.xml"
-tags: "Actions"
+tags: "Behaviors/Basic/Actions"
 hv_title: "Show"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/actions/toggle/index.xml.njk
+++ b/demo/backend/behaviors/basic/actions/toggle/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/toggle/index.xml"
-tags: "Actions"
+tags: "Behaviors/Basic/Actions"
 hv_title: "Toggle"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/actions/unselect-all/index.xml.njk
+++ b/demo/backend/behaviors/basic/actions/unselect-all/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/unselect-all/index.xml"
-tags: "Actions"
+tags: "Behaviors/Basic/Actions"
 hv_title: "Unselect All"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/content.xml.njk
+++ b/demo/backend/behaviors/basic/content.xml.njk
@@ -1,2 +1,2 @@
-{% set hv_section_list_tag = "Actions,Triggers,Target,Indicators,Fragments,Once" %}
+{% set hv_section_list_tag = "Behaviors/Basic/Actions,Behaviors/Basic/Triggers,Behaviors/Basic/Target,Behaviors/Basic/Indicators,Behaviors/Basic/Fragments,Behaviors/Basic/Once" %}
 {% include "templates/section-list.xml.njk" %}

--- a/demo/backend/behaviors/basic/fragments/fragment-replace/index.xml.njk
+++ b/demo/backend/behaviors/basic/fragments/fragment-replace/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/fragment-replace/index.xml"
-tags: "Fragments"
+tags: "Behaviors/Basic/Fragments"
 hv_title: "Fragments"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/fragments/rating/index.xml.njk
+++ b/demo/backend/behaviors/basic/fragments/rating/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/rating/index.xml"
-tags: "Fragments"
+tags: "Behaviors/Basic/Fragments"
 hv_title: "Rating"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/indicators/hide-indicator-multiple/index.xml.njk
+++ b/demo/backend/behaviors/basic/indicators/hide-indicator-multiple/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/hide-indicator-multiple/index.xml"
-tags: "Indicators"
+tags: "Behaviors/Basic/Indicators"
 hv_title: "Hide Multiple Indicators"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/indicators/hide-indicator/index.xml.njk
+++ b/demo/backend/behaviors/basic/indicators/hide-indicator/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/hide-indicator/index.xml"
-tags: "Indicators"
+tags: "Behaviors/Basic/Indicators"
 hv_title: "Hide Indicator"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/indicators/inline-indicator/index.xml.njk
+++ b/demo/backend/behaviors/basic/indicators/inline-indicator/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/inline-indicator/index.xml"
-tags: "Indicators"
+tags: "Behaviors/Basic/Indicators"
 hv_title: "Inline Indicator"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/indicators/shimmer-indicator/index.xml.njk
+++ b/demo/backend/behaviors/basic/indicators/shimmer-indicator/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/shimmer-indicator/index.xml"
-tags: "Indicators"
+tags: "Behaviors/Basic/Indicators"
 hv_title: "Shimmer Indicator"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/indicators/show-hide-indicators/index.xml.njk
+++ b/demo/backend/behaviors/basic/indicators/show-hide-indicators/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/show-hide-indicators/index.xml"
-tags: "Indicators"
+tags: "Behaviors/Basic/Indicators"
 hv_title: "Show/Hide Indicators"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/indicators/show-indicator/index.xml.njk
+++ b/demo/backend/behaviors/basic/indicators/show-indicator/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/show-indicator/index.xml"
-tags: "Indicators"
+tags: "Behaviors/Basic/Indicators"
 hv_title: "Show Indicator"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/indicators/show-multiple-indicators/index.xml.njk
+++ b/demo/backend/behaviors/basic/indicators/show-multiple-indicators/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/show-multiple-indicators/index.xml"
-tags: "Indicators"
+tags: "Behaviors/Basic/Indicators"
 hv_title: "Show Multiple Indicators"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/once/index.xml.njk
+++ b/demo/backend/behaviors/basic/once/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/once/index.xml"
-tags: "Once"
+tags: "Behaviors/Basic/Once"
 hv_title: "Once"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/target/target-child/index.xml.njk
+++ b/demo/backend/behaviors/basic/target/target-child/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/target-child/index.xml"
-tags: "Target"
+tags: "Behaviors/Basic/Target"
 hv_title: "Target Child"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/target/target-parent-element/index.xml.njk
+++ b/demo/backend/behaviors/basic/target/target-parent-element/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/target-parent-element/index.xml"
-tags: "Target"
+tags: "Behaviors/Basic/Target"
 hv_title: "Target Parent Element"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/target/target-parent/index.xml.njk
+++ b/demo/backend/behaviors/basic/target/target-parent/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/target-parent/index.xml"
-tags: "Target"
+tags: "Behaviors/Basic/Target"
 hv_title: "Target Parent"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/target/target-sibling-append/index.xml.njk
+++ b/demo/backend/behaviors/basic/target/target-sibling-append/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/target-sibling-append/index.xml"
-tags: "Target"
+tags: "Behaviors/Basic/Target"
 hv_title: "Target Sibling Append"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/target/target-sibling/index.xml.njk
+++ b/demo/backend/behaviors/basic/target/target-sibling/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/target-sibling/index.xml"
-tags: "Target"
+tags: "Behaviors/Basic/Target"
 hv_title: "Target Sibling"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/triggers/back/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/back/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/back/index.xml"
-tags: "Triggers"
+tags: "Behaviors/Basic/Triggers"
 hv_title: "Back"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/triggers/blur/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/blur/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/blur/index.xml"
-tags: "Triggers"
+tags: "Behaviors/Basic/Triggers"
 hv_title: "Blur"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/triggers/change/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/change/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/change/index.xml"
-tags: "Triggers"
+tags: "Behaviors/Basic/Triggers"
 hv_title: "Change"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/triggers/deselect/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/deselect/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/deselect/index.xml"
-tags: "Triggers"
+tags: "Behaviors/Basic/Triggers"
 hv_title: "Deselect"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/triggers/focus/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/focus/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/focus/index.xml"
-tags: "Triggers"
+tags: "Behaviors/Basic/Triggers"
 hv_title: "Focus"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/triggers/load/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/load/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/load/index.xml"
-tags: "Triggers"
+tags: "Behaviors/Basic/Triggers"
 hv_title: "Load"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/triggers/long-press/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/long-press/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/long-press/index.xml"
-tags: "Triggers"
+tags: "Behaviors/Basic/Triggers"
 hv_title: "Long Press"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/triggers/press-in/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/press-in/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/press-in/index.xml"
-tags: "Triggers"
+tags: "Behaviors/Basic/Triggers"
 hv_title: "Press In"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/triggers/press-out/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/press-out/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/press-out/index.xml"
-tags: "Triggers"
+tags: "Behaviors/Basic/Triggers"
 hv_title: "Press Out"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/triggers/press/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/press/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/press/index.xml"
-tags: "Triggers"
+tags: "Behaviors/Basic/Triggers"
 hv_title: "Press"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/triggers/refresh/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/refresh/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/refresh/index.xml"
-tags: "Triggers"
+tags: "Behaviors/Basic/Triggers"
 hv_title: "Refresh"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/triggers/select/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/select/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/select/index.xml"
-tags: "Triggers"
+tags: "Behaviors/Basic/Triggers"
 hv_title: "Select"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/triggers/visible-once/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/visible-once/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/visible-once/index.xml"
-tags: "Triggers"
+tags: "Behaviors/Basic/Triggers"
 hv_title: "Visible Once"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/behaviors/basic/triggers/visible/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/visible/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/behaviors/basic/visible/index.xml"
-tags: "Triggers"
+tags: "Behaviors/Basic/Triggers"
 hv_title: "Visible"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/navigation/actions/back/index.xml.njk
+++ b/demo/backend/navigation/actions/back/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/navigation/actions/back/index.xml"
-tags: "actions"
+tags: "Navigation/Actions"
 hv_title: "Back"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/navigation/actions/close/index.xml.njk
+++ b/demo/backend/navigation/actions/close/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/navigation/actions/close/index.xml"
-tags: "actions"
+tags: "Navigation/Actions"
 hv_title: "Close"
 hv_button_behavior: "close"
 hv_open_modal: "true"

--- a/demo/backend/navigation/actions/content.xml.njk
+++ b/demo/backend/navigation/actions/content.xml.njk
@@ -1,2 +1,2 @@
-{% set hv_list_tag = "actions" %}
+{% set hv_list_tag = "Navigation/Actions" %}
 {% include "templates/list.xml.njk" %}

--- a/demo/backend/navigation/actions/deep-links/index.xml.njk
+++ b/demo/backend/navigation/actions/deep-links/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/navigation/actions/deep-links/index.xml"
-tags: "actions"
+tags: "Navigation/Actions"
 hv_title: "Deep Links"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/navigation/actions/index.xml.njk
+++ b/demo/backend/navigation/actions/index.xml.njk
@@ -2,5 +2,5 @@
 permalink: "/navigation/actions/index.xml"
 ---
 
-{% set hv_list_tag = "actions" %}
+{% set hv_list_tag = "Navigation/Actions" %}
 {% include "./content.xml.njk" %}

--- a/demo/backend/navigation/actions/modal/index.xml.njk
+++ b/demo/backend/navigation/actions/modal/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/navigation/actions/modal/index.xml"
-tags: "actions"
+tags: "Navigation/Actions"
 hv_title: "Modal"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/navigation/actions/navigate/index.xml.njk
+++ b/demo/backend/navigation/actions/navigate/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/navigation/actions/navigate/index.xml"
-tags: "actions"
+tags: "Navigation/Actions"
 hv_title: "Navigate"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/navigation/actions/new/index.xml.njk
+++ b/demo/backend/navigation/actions/new/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/navigation/actions/new/index.xml"
-tags: "actions"
+tags: "Navigation/Actions"
 hv_title: "New"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/navigation/actions/push/index.xml.njk
+++ b/demo/backend/navigation/actions/push/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/navigation/actions/push/index.xml"
-tags: "actions"
+tags: "Navigation/Actions"
 hv_title: "Push"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/navigation/actions/reload/index.xml.njk
+++ b/demo/backend/navigation/actions/reload/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/navigation/actions/reload/index.xml"
-tags: "actions"
+tags: "Navigation/Actions"
 hv_title: "Reload"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/navigation/navigator/back-trigger/index.xml.njk
+++ b/demo/backend/navigation/navigator/back-trigger/index.xml.njk
@@ -1,7 +1,7 @@
 ---
 hv_title: "Back Trigger"
 permalink: "/navigation/navigator/back-trigger/index.xml"
-tags: "navigator"
+tags: "Navigation/Navigator"
 hv_button_behavior: "back"
 ---
 {# Todo rohanbayya: Back trigger does not work on web browser #}

--- a/demo/backend/navigation/navigator/bottom-tabs/index.xml.njk
+++ b/demo/backend/navigation/navigator/bottom-tabs/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/navigation/navigator/bottom-tabs/index.xml"
-tags: navigator
+tags: "Navigation/Navigator"
 hv_title: "Bottom Tabs Navigator"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/navigation/navigator/content.xml.njk
+++ b/demo/backend/navigation/navigator/content.xml.njk
@@ -1,2 +1,2 @@
-{% set hv_list_tag = "navigator" %}
+{% set hv_list_tag = "Navigation/Navigator" %}
 {% include "templates/list.xml.njk" %}

--- a/demo/backend/navigation/navigator/simple-tab/index.xml.njk
+++ b/demo/backend/navigation/navigator/simple-tab/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/navigation/navigator/simple-tab/index.xml"
-tags: navigator
+tags: "Navigation/Navigator"
 hv_title: "Simple Tab Navigator"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/navigation/navigator/stack/index.xml.njk
+++ b/demo/backend/navigation/navigator/stack/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/navigation/navigator/stack/index.xml"
-tags: navigator
+tags: "Navigation/Navigator"
 hv_title: "Stack Navigator"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/styling/button/index.xml.njk
+++ b/demo/backend/ui/styling/button/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/styling/button/index.xml"
-tags: "styling"
+tags: "UI/Styling"
 hv_title: "Button"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/styling/content.xml.njk
+++ b/demo/backend/ui/styling/content.xml.njk
@@ -1,2 +1,2 @@
-{% set hv_list_tag = "styling" %}
+{% set hv_list_tag = "UI/Styling" %}
 {% include "templates/list.xml.njk" %}

--- a/demo/backend/ui/styling/elevation/index.xml.njk
+++ b/demo/backend/ui/styling/elevation/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/styling/elevation/index.xml"
-tags: styling
+tags: "UI/Styling"
 hv_title: "Elevation"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/styling/flex/index.xml.njk
+++ b/demo/backend/ui/styling/flex/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/styling/flex/index.xml"
-tags: "styling"
+tags: "UI/Styling"
 hv_title: "Flex"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/styling/shadows/index.xml.njk
+++ b/demo/backend/ui/styling/shadows/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/styling/shadow/index.xml"
-tags: styling
+tags: "UI/Styling"
 hv_title: "Shadow"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/styling/text/index.xml.njk
+++ b/demo/backend/ui/styling/text/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/styling/text/index.xml"
-tags: "styling"
+tags: "UI/Styling"
 hv_title: "Text"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/content.xml.njk
+++ b/demo/backend/ui/ui-elements/content.xml.njk
@@ -1,2 +1,2 @@
-{% set hv_section_list_tag = "Text,View,Image,Forms,List,Section List,Web View" %}
+{% set hv_section_list_tag = "UI/UI Elements/Text,UI/UI Elements/View,UI/UI Elements/Image,UI/UI Elements/Forms,UI/UI Elements/List,UI/UI Elements/Section List,UI/UI Elements/Web View" %}
 {% include "templates/section-list.xml.njk" %}

--- a/demo/backend/ui/ui-elements/forms/date-field/index.xml.njk
+++ b/demo/backend/ui/ui-elements/forms/date-field/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/forms/date-field/index.xml"
-tags: "Forms"
+tags: "UI/UI Elements/Forms"
 hv_title: "Date Field"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/forms/picker/index.xml.njk
+++ b/demo/backend/ui/ui-elements/forms/picker/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/forms/picker/index.xml"
-tags: "Forms"
+tags: "UI/UI Elements/Forms"
 hv_title: "Picker"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/forms/select-multiple/index.xml.njk
+++ b/demo/backend/ui/ui-elements/forms/select-multiple/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/forms/select-multiple/index.xml"
-tags: "Forms"
+tags: "UI/UI Elements/Forms"
 hv_title: "Select Multiple"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/forms/select-single/index.xml.njk
+++ b/demo/backend/ui/ui-elements/forms/select-single/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/forms/select-single/index.xml"
-tags: "Forms"
+tags: "UI/UI Elements/Forms"
 hv_title: "Select Single"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/forms/switch/index.xml.njk
+++ b/demo/backend/ui/ui-elements/forms/switch/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/forms/switch/index.xml"
-tags: "Forms"
+tags: "UI/UI Elements/Forms"
 hv_title: "Switch"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/image/index.xml.njk
+++ b/demo/backend/ui/ui-elements/image/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/image/index.xml"
-tags: "Image"
+tags: "UI/UI Elements/Image"
 hv_title: "Image"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/list/basic/index.xml.njk
+++ b/demo/backend/ui/ui-elements/list/basic/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/list/basic/index.xml"
-tags: "List"
+tags: "UI/UI Elements/List"
 hv_title: "Basic List"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/list/hidden-scroll/index.xml.njk
+++ b/demo/backend/ui/ui-elements/list/hidden-scroll/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/list/hidden-scroll/index.xml"
-tags: "List"
+tags: "UI/UI Elements/List"
 hv_title: "Hidden Scrollbar"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/list/horizontal/index.xml.njk
+++ b/demo/backend/ui/ui-elements/list/horizontal/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/list/horizontal/index.xml"
-tags: "List"
+tags: "UI/UI Elements/List"
 hv_title: "Horizontal List"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/list/infinite/index.xml.njk
+++ b/demo/backend/ui/ui-elements/list/infinite/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/list/infinite/index.xml"
-tags: "List"
+tags: "UI/UI Elements/List"
 hv_title: "Infinite Scroll"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/list/keyboard-dismiss/index.xml.njk
+++ b/demo/backend/ui/ui-elements/list/keyboard-dismiss/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/list/keyboard-dismiss/index.xml"
-tags: "List"
+tags: "UI/UI Elements/List"
 hv_title: "Dismiss Keyboard on Drag"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/list/keyboard-persist-tap/index.xml.njk
+++ b/demo/backend/ui/ui-elements/list/keyboard-persist-tap/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/list/keyboard-persist-tap/index.xml"
-tags: "List"
+tags: "UI/UI Elements/List"
 hv_title: "Keyboard Persist Tap"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/list/refresh-infinite/index.xml.njk
+++ b/demo/backend/ui/ui-elements/list/refresh-infinite/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/list/refresh-infinite/index.xml"
-tags: "List"
+tags: "UI/UI Elements/List"
 hv_title: "Refresh and Infinite Scroll"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/list/refresh/index.xml.njk
+++ b/demo/backend/ui/ui-elements/list/refresh/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/list/refresh/index.xml"
-tags: "List"
+tags: "UI/UI Elements/List"
 hv_title: "List with Refresh"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/list/sticky/index.xml.njk
+++ b/demo/backend/ui/ui-elements/list/sticky/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/list/sticky/index.xml"
-tags: "List"
+tags: "UI/UI Elements/List"
 hv_title: "List with Sticky items"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/section-list/basic/index.xml.njk
+++ b/demo/backend/ui/ui-elements/section-list/basic/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/section-list/basic/index.xml"
-tags: "Section List"
+tags: "UI/UI Elements/Section List"
 hv_title: "Basic Section List"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/section-list/deprecated/index.xml.njk
+++ b/demo/backend/ui/ui-elements/section-list/deprecated/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/section-list/deprecated/index.xml"
-tags: "Section List"
+tags: "UI/UI Elements/Section List"
 hv_title: "Deprecated Section List"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/section-list/dismiss-keyboard/index.xml.njk
+++ b/demo/backend/ui/ui-elements/section-list/dismiss-keyboard/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/section-list/dismiss-keyboard/index.xml"
-tags: "Section List"
+tags: "UI/UI Elements/Section List"
 hv_title: "Dismiss Keyboard on Drag"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/section-list/infinite/index.xml.njk
+++ b/demo/backend/ui/ui-elements/section-list/infinite/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/section-list/infinite/index.xml"
-tags: "Section List"
+tags: "UI/UI Elements/Section List"
 hv_title: "Section List Infinite Scroll"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/section-list/keyboard-persist-tap/index.xml.njk
+++ b/demo/backend/ui/ui-elements/section-list/keyboard-persist-tap/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/section-list/keyboard-persist-tap/index.xml"
-tags: "Section List"
+tags: "UI/UI Elements/Section List"
 hv_title: "Keyboard Persist Tap"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/section-list/non-sticky/index.xml.njk
+++ b/demo/backend/ui/ui-elements/section-list/non-sticky/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/section-list/non-sticky/index.xml"
-tags: "Section List"
+tags: "UI/UI Elements/Section List"
 hv_title: "Non-sticky Titles"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/section-list/refresh/index.xml.njk
+++ b/demo/backend/ui/ui-elements/section-list/refresh/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/section-list/refresh/index.xml"
-tags: "Section List"
+tags: "UI/UI Elements/Section List"
 hv_title: "Section List with Refresh"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/text/adjustable/index.xml.njk
+++ b/demo/backend/ui/ui-elements/text/adjustable/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/text/adjustable/index.xml"
-tags: "Text"
+tags: "UI/UI Elements/Text"
 hv_title: "Adjustable Font Size"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/text/basic/index.xml.njk
+++ b/demo/backend/ui/ui-elements/text/basic/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/text/basic/index.xml"
-tags: "Text"
+tags: "UI/UI Elements/Text"
 hv_title: "Basic"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/text/escaped/index.xml.njk
+++ b/demo/backend/ui/ui-elements/text/escaped/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/text/escaped/index.xml"
-tags: "Text"
+tags: "UI/UI Elements/Text"
 hv_title: "Escaped"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/text/nested/index.xml.njk
+++ b/demo/backend/ui/ui-elements/text/nested/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/text/nested/index.xml"
-tags: "Text"
+tags: "UI/UI Elements/Text"
 hv_title: "Nested"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/text/number-of-lines/index.xml.njk
+++ b/demo/backend/ui/ui-elements/text/number-of-lines/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/text/number-of-lines/index.xml"
-tags: "Text"
+tags: "UI/UI Elements/Text"
 hv_title: "Number of Lines"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/text/preformatted/index.xml.njk
+++ b/demo/backend/ui/ui-elements/text/preformatted/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/text/preformatted/index.xml"
-tags: "Text"
+tags: "UI/UI Elements/Text"
 hv_title: "Preformatted"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/text/selectable/index.xml.njk
+++ b/demo/backend/ui/ui-elements/text/selectable/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/text/selectable/index.xml"
-tags: "Text"
+tags: "UI/UI Elements/Text"
 hv_title: "Selectable"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/view/keyboard-avoiding-view/index.xml.njk
+++ b/demo/backend/ui/ui-elements/view/keyboard-avoiding-view/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/view/keyboard-avoiding-view/index.xml"
-tags: "View"
+tags: "UI/UI Elements/View"
 hv_title: "Keyboard Avoiding View"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/view/scroll-view/index.xml.njk
+++ b/demo/backend/ui/ui-elements/view/scroll-view/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/list/scroll-view/index.xml"
-tags: "View"
+tags: "UI/UI Elements/View"
 hv_title: "Scroll View"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/view/view/index.xml.njk
+++ b/demo/backend/ui/ui-elements/view/view/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/view/view/index.xml"
-tags: "View"
+tags: "UI/UI Elements/View"
 hv_title: "View"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/web-view/dispatch-event/index.xml.njk
+++ b/demo/backend/ui/ui-elements/web-view/dispatch-event/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/web-view/dispatch-event/index.xml"
-tags: "Web View"
+tags: "UI/UI Elements/Web View"
 hv_title: "Event Dispatch"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/web-view/html/index.xml.njk
+++ b/demo/backend/ui/ui-elements/web-view/html/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/web-view/html/index.xml"
-tags: "Web View"
+tags: "UI/UI Elements/Web View"
 hv_title: "HTML"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/web-view/injected-js/index.xml.njk
+++ b/demo/backend/ui/ui-elements/web-view/injected-js/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/web-view/injected-js/index.xml"
-tags: "Web View"
+tags: "UI/UI Elements/Web View"
 hv_title: "Injected Javascript"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/web-view/loading/index.xml.njk
+++ b/demo/backend/ui/ui-elements/web-view/loading/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/web-view/loading/index.xml"
-tags: "Web View"
+tags: "UI/UI Elements/Web View"
 hv_title: "Show Loading Indicator"
 hv_button_behavior: "back"
 ---

--- a/demo/backend/ui/ui-elements/web-view/url/index.xml.njk
+++ b/demo/backend/ui/ui-elements/web-view/url/index.xml.njk
@@ -1,6 +1,6 @@
 ---
 permalink: "/ui/ui-elements/web-view/url/index.xml"
-tags: "Web View"
+tags: "UI/UI Elements/Web View"
 hv_title: "URL"
 hv_button_behavior: "back"
 ---

--- a/docs/guide_demo_app_contribution.md
+++ b/docs/guide_demo_app_contribution.md
@@ -17,15 +17,15 @@ All included files go under `_includes/` folder to contain reusable files across
 
 1. `templates/`
    1. `list.xml.njk`: Renders a list of items, each linking to a different screen.
-   1. `section-list.xml.njk`: Renders a section list of items with subtitles.
-   1. `tab.xml.njk`: Basic tab structure for tabs on home screen.
-   1. `styles.xml.njk`: Contains re-usable styles across the app.
-   1. `base.xml.njk`: Base template for all the screens. Can be extended by providing custom styles and content.
-   1. `scrollview.xml.njk`: Extends `base.xml.njk` to provide a scroll view for any screen that extends it.
-   1. `loading-screen.xml.njk`: Included as a loading screen in other templates.
-   1. `header.xml.njk`: Used to render the header button logic.
-1. `icons/` : All icons used across the app go into this folder.
-1. `macros/` : Folder that includes all reusable macros. Each macro should have a separate folder with `index.xml.njk` containing the definition along with `styles.xml.njk` containing the styles.
+   2. `section-list.xml.njk`: Renders a section list of items with subtitles.
+   3. `tab.xml.njk`: Basic tab structure for tabs on home screen.
+   4. `styles.xml.njk`: Contains re-usable styles across the app.
+   5. `base.xml.njk`: Base template for all the screens. Can be extended by providing custom styles and content.
+   6. `scrollview.xml.njk`: Extends `base.xml.njk` to provide a scroll view for any screen that extends it.
+   7. `loading-screen.xml.njk`: Included as a loading screen in other templates.
+   8. `header.xml.njk`: Used to render the header button logic.
+2. `icons/` : All icons used across the app go into this folder.
+3. `macros/` : Folder that includes all reusable macros. Each macro should have a separate folder with `index.xml.njk` containing the definition along with `styles.xml.njk` containing the styles.
 
 ### Examples with multiple demonstrations
 
@@ -74,7 +74,7 @@ Metadata used to define variables or settings that are used by eleventy while pr
 
 To render a list view as shown above:
 
-1. In `ui/index.xml.njk`, include `templates/list.xml.njk` and define `hv_list_tag`: "Styling" inside the metadata:
+1. In `ui/index.xml.njk`, include `templates/list.xml.njk` and define `hv_list_tag`: "UI/Styling" inside the metadata:
 
 ```xml
 ---
@@ -82,16 +82,16 @@ permalink: "/ui/styling/index.xml"
 hv_title: "Styling"
 hv_button_behavior: "back"
 ---
-{% set hv_list_tag = "styling" %}
+{% set hv_list_tag = "UI/Styling" %}
 {% include "templates/list.xml.njk" %}
 ```
 
-2. In `ui/styling/button/index.xml.njk`, define the tag which this item links to (in our case styling):
+2. In `ui/styling/button/index.xml.njk`, define the tag which this item links to (in our case UI/Styling):
 
 ```xml
 ---
 permalink: "/ui/styling/button/index.xml"
-tags: "styling"
+tags: "UI/Styling"
 hv_title: "Button"
 hv_button_behavior: "back"
 ---
@@ -115,7 +115,8 @@ All the href paths should start with `/hyperview/public/` . This ensures that re
 ### Case
 
 1. File names, style ids are to follow kebab case, i.e. custom-select, custom-select-bold
-1. style ids and element ids should not overlap. i.e., `<style id="container" />` and `<view id="container" />`
+2. style ids and element ids should not overlap. i.e., `<style id="container" />` and `<view id="container" />`
+3. Tags should be capitalized and named after the parent directory of the file they represent. i.e. `Advanced/Case Studies` for the items under `advanced/case-studies`.
 
 ### Files
 
@@ -124,7 +125,7 @@ All the href paths should start with `/hyperview/public/` . This ensures that re
 ### Front matter
 
 1. All custom front matter attributes start with prefix `hv_` . example: `hv_button_behavior`
-1. Built-in Properties come first followed by custom properties
+2. Built-in Properties come first followed by custom properties
 
 ### Styles
 
@@ -135,7 +136,7 @@ All the href paths should start with `/hyperview/public/` . This ensures that re
 We accept two formats to render attributes of an XML element:
 
 1. inline (provided that the total number of characters does not exceed 80)
-1. one attribute per line
+2. one attribute per line
 
 When rendering the attributes inline, the element closing delimiter and the element closing tag should be on the same line. If the element is a self closing tag, there should be a single space between the last attribute's value and the self closing tag. If the element is not a self closing tag, there should be no leading space before the element delimiter.
 When rendering one attribute per line, the element delimiter should be rendered on a new line, and the indentation level should match the element opening tag. Use alphabetical order for XML element attributes, exception made for id which should be first attribute of the element.


### PR DESCRIPTION
To prevent potential overlap between tags from different sections, apply the following formatting rules to every tags used:
- Capitalize all tags - since we use them sometimes for display, these should be consistent throughout
- Use the full path of the sections they live under

i.e. "Advanced/Case Studies" instead of "case_studies".

Following this change:
- update docs to reflect convention
- add new `sectionTitle` nunjuck filter to continue displaying section titles properly