### PR TITLE
fix(demo): `BottomTabBar` tab content reload

### DIFF
--- a/demo/backend/_includes/macros/tabbar-bottom-tab/index.xml.njk
+++ b/demo/backend/_includes/macros/tabbar-bottom-tab/index.xml.njk
@@ -1,12 +1,9 @@
 {% macro tabbar_bottom_tab(id, label, selected) %}
-  <option
-    {% if selected %}
-      selected="true"
-    {% endif %}
+  <navigation:bottom-tab-bar-item
+    key="{{ id }}"
+    navigation:route="tab-{{ id }}"
     style="tabbar-bottom-tab"
-    value="tab-{{ id }}"
   >
-    <behavior trigger="select" action="navigate" target="tab-{{ id }}" />
     <view style="tabbar-bottom-tab-icon-selected">
       {% include 'icons/' +  id + '-selected.svg' %}
     </view>
@@ -14,5 +11,5 @@
       {% include 'icons/' + id + '.svg' %}
     </view>
     <text style="tabbar-bottom-tabbar-top-label">{{ label }}</text>
-  </option>
+  </navigation:bottom-tab-bar-item>
 {% endmacro %}

--- a/demo/backend/_includes/macros/tabbar-bottom/index.xml.njk
+++ b/demo/backend/_includes/macros/tabbar-bottom/index.xml.njk
@@ -1,12 +1,12 @@
-{% macro tabbar_bottom(target) %}
+{% macro tabbar_bottom(navigator) %}
   <navigation:bottom-tab-bar
     xmlns:navigation="https://hyperview.org/navigation"
-    navigation:navigator="{{ target }}"
+    navigation:navigator="{{ navigator }}"
   >
-    <select-single style="tabbar-bottom" name="tabbar-bottom" key="tabbar-bottom">
+    <view style="tabbar-bottom" key="tabbar-bottom">
       {% if caller %}
         {{ caller() }}
       {% endif %}
-    </select-single>
+    </view>
   </navigation:bottom-tab-bar>
 {% endmacro %}

--- a/demo/backend/advanced/community/elements/bottom-tabbar/tab-1-reloaded.xml.njk
+++ b/demo/backend/advanced/community/elements/bottom-tabbar/tab-1-reloaded.xml.njk
@@ -1,0 +1,11 @@
+---
+permalink: "/advanced/community/elements/bottom-tabbar/tab-1-reloaded.xml"
+hv_title: "Tab Navigator - Tab 1"
+hv_button_behavior: "back"
+---
+{% from 'macros/description/index.xml.njk' import description %}
+{% extends './tab-1.xml.njk' %}
+
+{% block content %}
+  {{ description('This is the content for tab 1 after reload.') }}
+{% endblock %}

--- a/demo/backend/advanced/community/elements/bottom-tabbar/tab-1.xml.njk
+++ b/demo/backend/advanced/community/elements/bottom-tabbar/tab-1.xml.njk
@@ -8,7 +8,15 @@ hv_button_behavior: "back"
 
 {% block container %}
   <view scroll="true">
-    {{ description('This is the content for tab 2.') }}
+    {% block content %}
+      {{ description('This is the content for tab 1.') }}
+    {% endblock %}
+    <behavior
+      trigger="on-event"
+      event-name="advanced/community/elements/bottom-tabbar/tab-1/reload"
+      action="reload"
+      href="/hyperview/public/advanced/community/elements/bottom-tabbar/tab-1-reloaded.xml"
+    />
   </view>
   {% set selected_tab = 1 %}
   {% include "./tab-bar.xml.njk" %}

--- a/demo/backend/advanced/community/elements/bottom-tabbar/tab-1.xml.njk
+++ b/demo/backend/advanced/community/elements/bottom-tabbar/tab-1.xml.njk
@@ -18,6 +18,5 @@ hv_button_behavior: "back"
       href="/hyperview/public/advanced/community/elements/bottom-tabbar/tab-1-reloaded.xml"
     />
   </view>
-  {% set selected_tab = 1 %}
   {% include "./tab-bar.xml.njk" %}
 {% endblock %}

--- a/demo/backend/advanced/community/elements/bottom-tabbar/tab-2.xml.njk
+++ b/demo/backend/advanced/community/elements/bottom-tabbar/tab-2.xml.njk
@@ -10,13 +10,19 @@ hv_button_behavior: "back"
 {% block container %}
   <view scroll="true">
     {{ description('This is the content for tab 2.') }}
-    {% call button("Add notification to tab 2", attributes={id:"add-notification"}) -%}
+    {% call button("Notify tab 2", attributes={id:"notify-tab-2"}) -%}
       <behavior action="hide" target="add-notification" />
       <behavior action="show" target="remove-notification" />
       <behavior action="replace" target="bottom-tab-bar" href="/hyperview/public/advanced/community/elements/bottom-tabbar/tab-bar-notify-tab-2.xml" />
     {%- endcall %}
-    {% call button("Remove notification from tab 2", attributes={id:"remove-notification", hide:"true"}) -%}
+    {% call button("Unnotify tab 2", attributes={id:"unnotify-tab-2", hide:"true"}) -%}
       <behavior action="reload" href="#" />
+    {%- endcall %}
+    {% call button("Reload tab 1", attributes={id:"reload-tab-1"}) -%}
+      <behavior
+        action="dispatch-event"
+        event-name="advanced/community/elements/bottom-tabbar/tab-1/reload"
+      />
     {%- endcall %}
   </view>
   {% set selected_tab = 2 %}

--- a/demo/backend/advanced/community/elements/bottom-tabbar/tab-2.xml.njk
+++ b/demo/backend/advanced/community/elements/bottom-tabbar/tab-2.xml.njk
@@ -25,6 +25,5 @@ hv_button_behavior: "back"
       />
     {%- endcall %}
   </view>
-  {% set selected_tab = 2 %}
   {% include "./tab-bar.xml.njk" %}
 {% endblock %}

--- a/demo/backend/advanced/community/elements/bottom-tabbar/tab-bar-notify-tab-2.xml.njk
+++ b/demo/backend/advanced/community/elements/bottom-tabbar/tab-bar-notify-tab-2.xml.njk
@@ -2,6 +2,5 @@
 permalink: "/advanced/community/elements/bottom-tabbar/tab-bar-notify-tab-2.xml"
 
 ---
-{% set selected_tab = 2 %}
 {% set notify_tab = 2 %}
 {% include "./tab-bar.xml.njk" %}

--- a/demo/backend/advanced/community/elements/bottom-tabbar/tab-bar.xml.njk
+++ b/demo/backend/advanced/community/elements/bottom-tabbar/tab-bar.xml.njk
@@ -4,15 +4,11 @@
   navigation:navigator="custom-bottom-tabs-navigator"
   id="bottom-tab-bar"
 >
-  <select-single style="tabbar-bottom" name="custom-tab-bar" key="custom-tab-bar">
-    <option
-      {% if selected_tab == 1 %}
-        selected="true"
-      {% endif %}
+  <view style="tabbar-bottom" key="tabbar-bottom">
+    <navigation:bottom-tab-bar-item
+      navigation:route="custom-bottom-tabs-tab-1"
       style="tabbar-bottom-tab"
-      value="custom-tab-1"
     >
-      <behavior trigger="select" action="navigate" href="#custom-bottom-tabs-tab-1" />
       <view style="tabbar-bottom-tab-content">
         <view style="tabbar-bottom-tab-icon-selected">
           {% include 'icons/behaviors-selected.svg' %}
@@ -25,15 +21,11 @@
           <view style="tabbar-bottom-tab-notify" />
         {% endif %}
       </view>
-    </option>
-    <option
-      {% if selected_tab == 2 %}
-        selected="true"
-      {% endif %}
+    </navigation:bottom-tab-bar-item>
+    <navigation:bottom-tab-bar-item
+      navigation:route="custom-bottom-tabs-tab-2"
       style="tabbar-bottom-tab"
-      value="custom-tab-2"
     >
-      <behavior trigger="select" action="navigate" href="#custom-bottom-tabs-tab-2" />
       <view style="tabbar-bottom-tab-content">
         <view style="tabbar-bottom-tab-icon-selected">
           {% include 'icons/advanced-selected.svg' %}
@@ -46,6 +38,6 @@
           <view style="tabbar-bottom-tab-notify" />
         {% endif %}
       </view>
-    </option>
-  </select-single>
+    </navigation:bottom-tab-bar-item>
+  </view>
 </navigation:bottom-tab-bar>

--- a/demo/src/Components/BottomTabBar/BottomTabBar.tsx
+++ b/demo/src/Components/BottomTabBar/BottomTabBar.tsx
@@ -1,8 +1,7 @@
 import type { HvComponentProps, LocalName } from 'hyperview';
+import { namespaceURI } from './constants';
 import { useBottomTabBarContext } from '../../Contexts';
 import { useEffect } from 'react';
-
-const namespaceURI = 'https://hyperview.org/navigation';
 
 /**
  * This component's only job is to associate its own props with a

--- a/demo/src/Components/BottomTabBar/BottomTabBarItem.tsx
+++ b/demo/src/Components/BottomTabBar/BottomTabBarItem.tsx
@@ -1,0 +1,60 @@
+import * as Render from 'hyperview/src/services/render';
+import type {
+  HvComponentOnUpdate,
+  HvComponentProps,
+  LocalName,
+} from 'hyperview';
+import { TouchableWithoutFeedback, View } from 'react-native';
+import { createElement, useState } from 'react';
+import { createEventHandler } from 'hyperview/src/core/hyper-ref';
+import { createProps } from 'hyperview/src/services';
+import { namespaceURI } from './constants';
+
+const BottomTabBarItem = (props: HvComponentProps) => {
+  const route = props.element.getAttributeNS(namespaceURI, 'route');
+  const selected = route === props.options?.targetId;
+  const [pressed, setPressed] = useState(false);
+
+  // Updates options with pressed/selected state, so that child element can render
+  // using the appropriate modifier styles.
+  const newOptions = {
+    ...props.options,
+    pressed,
+    pressedSelected: pressed && selected,
+    selected,
+  } as const;
+  const p = createProps(props.element, props.stylesheets, newOptions);
+
+  // Option renders as an outer TouchableWithoutFeedback view and inner view.
+  // The outer view handles presses, the inner view handles styling.
+  const outerProps = {
+    onPress: createEventHandler(() => {
+      props.options?.onSelect?.(route);
+    }, true),
+    onPressIn: createEventHandler(() => setPressed(true)),
+    onPressOut: createEventHandler(() => setPressed(false)),
+    style: {},
+  };
+  if (p.style && p.style.flex) {
+    // Flex is a style that needs to be lifted from the inner component to the outer
+    // component to ensure proper layout.
+    outerProps.style = { flex: p.style.flex };
+  }
+  const component = createElement(
+    View,
+    p,
+    ...Render.renderChildren(
+      props.element,
+      props.stylesheets,
+      props.onUpdate as HvComponentOnUpdate,
+      newOptions,
+    ),
+  );
+  return createElement(TouchableWithoutFeedback, outerProps, component);
+};
+
+BottomTabBarItem.namespaceURI = namespaceURI;
+BottomTabBarItem.localName = 'bottom-tab-bar-item' as LocalName;
+BottomTabBarItem.localNameAliases = [] as LocalName[];
+
+export { BottomTabBarItem };

--- a/demo/src/Components/BottomTabBar/constants.ts
+++ b/demo/src/Components/BottomTabBar/constants.ts
@@ -1,0 +1,1 @@
+export const namespaceURI = 'https://hyperview.org/navigation';

--- a/demo/src/Components/BottomTabBar/index.ts
+++ b/demo/src/Components/BottomTabBar/index.ts
@@ -1,1 +1,2 @@
 export { BottomTabBar } from './BottomTabBar';
+export { BottomTabBarItem } from './BottomTabBarItem';

--- a/demo/src/Components/index.ts
+++ b/demo/src/Components/index.ts
@@ -1,6 +1,6 @@
+import { BottomTabBar, BottomTabBarItem } from './BottomTabBar';
 import { BottomSheet } from './BottomSheet';
-import { BottomTabBar } from './BottomTabBar';
 import { Filter } from './Filter';
 import { Svg } from './Svg';
 
-export default [BottomSheet, BottomTabBar, Filter, Svg];
+export default [BottomSheet, BottomTabBar, BottomTabBarItem, Filter, Svg];

--- a/demo/src/Core/BottomTabBar/index.tsx
+++ b/demo/src/Core/BottomTabBar/index.tsx
@@ -9,7 +9,8 @@ import { useCallback } from 'react';
  * from BottomTabBarContext. This works in tandem with the custom Hyperview
  * element <navigation:bottom-tab-bar>
  */
-export const BottomTabBar = ({ id }: Props): JSX.Element | null => {
+export const BottomTabBar = (navProps: Props): JSX.Element | null => {
+  const { id, state, navigation } = navProps;
   // id is provided by Hyperview, and represents a tab navigator id
   const { getElementProps, setElement } = useBottomTabBarContext();
 
@@ -42,6 +43,14 @@ export const BottomTabBar = ({ id }: Props): JSX.Element | null => {
     props.element,
     props.stylesheets,
     onUpdateCustom,
-    props.options,
+    {
+      ...props.options,
+      onSelect: (route: string | null | undefined) => {
+        if (route) {
+          navigation.navigate(route);
+        }
+      },
+      targetId: state.routes[state.index].name,
+    },
   ) as unknown) as JSX.Element;
 };


### PR DESCRIPTION
Refactor `BottomTabBar` to use custom markup for items, that keeps track of selection state and performs navigation.
 This fixes an issue with the previous implementation that relied on a `<select-single>` / `<option>` combo to allow client side state + navigation with default Hyperview action, which would cause navigation to be performed when the tab bar was reloaded by a tab not currently focused.

See commits breakdown for details

| Before | After |
|--------|------|
| ![before](https://github.com/user-attachments/assets/b221e669-d76d-45f0-9ace-4bd7deb1c436) | ![after](https://github.com/user-attachments/assets/cbe3944e-af45-4245-8848-225d1f72c4d7) |

