### PR TITLE
chore(render): add support for rendering a filtered list of children

### DIFF
--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -39,6 +39,8 @@ export default class Hyperview extends PureComponent<Types.Props> {
 
   static renderChildren = Render.renderChildren;
 
+  static renderChildNodes = Render.renderChildNodes;
+
   static renderElement = Render.renderElement;
 
   behaviorRegistry: BehaviorRegistry;

--- a/src/services/render/index.tsx
+++ b/src/services/render/index.tsx
@@ -147,22 +147,12 @@ export const renderChildren = (
   onUpdate: HvComponentOnUpdate,
   options: HvComponentOptions,
 ) => {
-  const children = [];
-  if (element.childNodes) {
-    const { childNodes } = element;
-    for (let i = 0; i < childNodes.length; i += 1) {
-      const e = renderElement(
-        element.childNodes.item(i) as Element,
-        stylesheets,
-        onUpdate,
-        { ...options, skipHref: false },
-      );
-      if (e) {
-        children.push(e);
-      }
-    }
-  }
-  return children;
+  return renderChildNodes(
+    Array.from(element.childNodes),
+    stylesheets,
+    onUpdate,
+    options,
+  );
 };
 
 /**

--- a/src/services/render/index.tsx
+++ b/src/services/render/index.tsx
@@ -164,3 +164,26 @@ export const renderChildren = (
   }
   return children;
 };
+
+/**
+ * This alternate renderChildren function allows for passing an external
+ * childNodes array, which can be useful when filtering out specific nodes.
+ */
+export const renderChildNodes = (
+  childNodes: ChildNode[],
+  stylesheets: StyleSheets,
+  onUpdate: HvComponentOnUpdate,
+  options: HvComponentOptions,
+) => {
+  const children = [];
+  for (let i = 0; i < childNodes.length; i += 1) {
+    const e = renderElement(childNodes[i] as Element, stylesheets, onUpdate, {
+      ...options,
+      skipHref: false,
+    });
+    if (e) {
+      children.push(e);
+    }
+  }
+  return children;
+};

--- a/src/services/render/index.tsx
+++ b/src/services/render/index.tsx
@@ -147,12 +147,15 @@ export const renderChildren = (
   onUpdate: HvComponentOnUpdate,
   options: HvComponentOptions,
 ) => {
-  return renderChildNodes(
-    Array.from(element.childNodes),
-    stylesheets,
-    onUpdate,
-    options,
-  );
+  if (element.childNodes) {
+    return renderChildNodes(
+      Array.from(element.childNodes),
+      stylesheets,
+      onUpdate,
+      options,
+    );
+  }
+  return [];
 };
 
 /**


### PR DESCRIPTION
As we move to create more community components within Hyperview, we will start running into issues with XML structures and rendering. As an example, the updated `bottom-sheet` schema is going to require non-rendering child elements to pass multiple values. The current functionality only supports two ways of ignoring rendering a child:
1. Use of the [`hide` attribute](https://github.com/Instawork/hyperview/blob/d1e0364a95f61bb378b7c4e830817a2a75fa7ba4/src/services/render/index.tsx#L23-L28)
2. Hard coding a set of known local names which [should be ignored](https://github.com/Instawork/hyperview/blob/d1e0364a95f61bb378b7c4e830817a2a75fa7ba4/src/services/render/index.tsx#L37-L43)

The new `renderChildNodes` method allows passing in a `ChildNode[]` where the caller has control over which children to render.

`renderChildren` [has been modified](https://github.com/Instawork/hyperview/pull/985/commits/98153a0139a72ad103ef303b73fb160868d26b5a) to pass its children into `renderChildNodes`.


[Asana](https://app.asana.com/0/1204008699308084/1208652837553615/f)