### PR TITLE
fix(demo): correct loading screen id

### DIFF
--- a/demo/backend/navigation/behaviors/actions/new/index.xml.njk
+++ b/demo/backend/navigation/behaviors/actions/new/index.xml.njk
@@ -38,7 +38,7 @@ hv_button_behavior: "back"
   {%- endcall %}
 
   {% call button('New with indicator') -%}
-    <behavior action="new" delay="1000" href="/hyperview/public/navigation/behaviors/actions/modal/index.xml" show-during-load="loadingScreen" />
+    <behavior action="new" delay="1000" href="/hyperview/public/navigation/behaviors/actions/modal/index.xml" show-during-load="loading-screen" />
   {%- endcall %}
 
   <form>


### PR DESCRIPTION
Using the correct `loading-screen` id