### PR TITLE
chore(hv-screen): migrate `registerPreload` to screen props

### DIFF
--- a/src/core/components/hv-root/types.ts
+++ b/src/core/components/hv-root/types.ts
@@ -46,6 +46,5 @@ export type Props = {
   loadingScreen?: ComponentType<LoadingProps>;
   handleBack?: ComponentType<{ children: ReactNode }>;
   doc?: Document;
-  registerPreload?: (id: number, element: Element) => void;
   logger?: Logging.Logger;
 };

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -6,5 +6,6 @@ import { Props as HvRootProps } from 'hyperview/src/core/components/hv-root/type
  */
 export type Props = HvRootProps & {
   onUpdate: HvComponentOnUpdate;
+  registerPreload?: (id: number, element: Element) => void;
   reload: Reload;
 };


### PR DESCRIPTION
Props were updated in https://github.com/Instawork/hyperview/pull/791 to allow separating the props from `hv-root` and `hv-screen`. The `registerPreload` function ended up being exposed at the root level but provides no mapping and was unnecessary.