### PR TITLE
feat(loading): add support for named loading screens

### DIFF
--- a/docs/reference_behavior_attributes.md
+++ b/docs/reference_behavior_attributes.md
@@ -685,9 +685,9 @@ A space-separated list of element ids. The elements with the given ids will be s
 
 Navigation actions immediately show a new screen or modal before requesting the new content. Since the request can take a while, using `show-during-load` will copy the referenced element into the new screen. Once the request completes, the requested content will replace the loading state on the new screen. There are a few nuances when using this attribute with navigation actions:
 
-- `show-during-load` should only contain a single element id for a `<screen>` element. This screen must be part of the current doc.
+- `show-during-load` should only contain a single id. This id can be either the id of a `<screen>` element in the current doc, or it can be the id of a `loadingScreen` which was passed into the `<Hyperview>` component's optional `loadingScreens` property. See [Loading Screens](/docs/reference_loading_screens).
 - If `show-during-load` contains multiple space-separated element ids, only the first element will be used.
-- If the element id from `show-during-load` references an element other than a `<screen>`, that element will not be used as the new screen's loading state.
+- If no `<screen>` is found with the id, Hyperview will look for a named loading screen, and will fall back to the default loading screen. See [Loading Screens](/docs/reference_loading_screens).
 
 > Only the first `<screen>` element in `<doc>` will be displayed on a screen. Therefore, be sure to include indicator `<screen>` elements at the end of the `<doc>`.
 

--- a/docs/reference_loading_screens.md
+++ b/docs/reference_loading_screens.md
@@ -1,0 +1,64 @@
+---
+id: reference_loading_screens
+title: Loading Screens
+sidebar_label: Loading Screens
+---
+
+The Hyperview client supports displaying loading screens during fetch requests. Examples of these loading screen options are available in the included demo application.
+
+## default component
+
+If no custom component is provided, a default internal component will be used. This component is a simple white screen with a centered gray spinning graphic.
+
+## loadingScreen
+
+The `<Hyperview>` component provides an optional `loadingScreen` property. When a component is provided to this property, the custom component will always be used instead of the default component.
+
+```es6
+import { ActivityIndicator, View } from 'react-native';
+import React from 'react';
+
+const DefaultLoadingScreen = () => {
+  return (
+    <View
+      style={{
+        alignItems: 'center',
+        flex: 1,
+        justifyContent: 'center',
+      }}
+    >
+      <ActivityIndicator color={'#8d9494'} size="large" />
+    </View>
+  );
+};
+```
+
+```es6
+<Hyperview
+  ...
+  loadingScreen={DefaultLoadingScreen}
+/>
+```
+
+## loadingScreens
+
+In addition to supporting a single custom loading screen, Hyperview provides support for passing named loadingScreen components. These named screens can be invoked by id in the codebase.
+
+```es6
+<Hyperview
+  ...
+  loadingScreens={{
+    'green-loader': GreenLoadingScreen,
+  }}
+/>
+```
+
+Once these have been passed in, they can be referenced via the `show-during-load` attribute of navigation behaviors.
+
+```es6
+<behavior
+  action="new"
+  href="/hyperview/public/navigation/behaviors/actions/modal/index.xml"
+  show-during-load="green-loader"
+/>
+```

--- a/src/contexts/loading-screen.tsx
+++ b/src/contexts/loading-screen.tsx
@@ -10,6 +10,8 @@ type Props = {
  * Centralizes implementation of default loading screen:
  * - If a loading screen is passed in props, it will be used as the default screen
  * - If no loading screen is passed, the default screen will be the local `Loading` component
+ * Provides a registry of externally provided loadingScreen components by id
+ * - If no id is provided, the default screen will be used
  */
 export const LoadingScreenContext = createContext<Props>({
   get: () => Loading,
@@ -18,8 +20,11 @@ export const LoadingScreenContext = createContext<Props>({
 export function LoadingScreenProvider(props: {
   children: ReactNode;
   loadingScreen?: ComponentType<LoadingProps>;
+  loadingScreens?: { [key: string]: ComponentType<LoadingProps> };
 }) {
-  const registry = useRef<{ [key: string]: ComponentType<LoadingProps> }>({});
+  const registry = useRef<{ [key: string]: ComponentType<LoadingProps> }>(
+    props.loadingScreens || {},
+  );
 
   if (props.loadingScreen) {
     // Inject the props.loadingScreen as the default screen
@@ -34,8 +39,13 @@ export function LoadingScreenProvider(props: {
    * @param id - The id of the loading screen component to retrieve
    * @returns The loading screen component by id or the default screen if no id is provided
    */
-  const get = (id?: string): ComponentType<LoadingProps> =>
-    registry.current[id || 'default'];
+  const get = (id?: string): ComponentType<LoadingProps> => {
+    if (id) {
+      const screen = registry.current[id];
+      return screen || registry.current.default;
+    }
+    return registry.current.default;
+  };
 
   return (
     <LoadingScreenContext.Provider
@@ -50,4 +60,5 @@ export function LoadingScreenProvider(props: {
 
 LoadingScreenProvider.defaultProps = {
   loadingScreen: undefined,
+  loadingScreens: {},
 };

--- a/src/contexts/loading-screen.tsx
+++ b/src/contexts/loading-screen.tsx
@@ -1,0 +1,53 @@
+import React, { ComponentType, ReactNode, createContext, useRef } from 'react';
+import Loading from 'hyperview/src/core/components/loading';
+import type { Props as LoadingProps } from 'hyperview/src/core/components/loading';
+
+type Props = {
+  get: (id?: string) => ComponentType<LoadingProps>;
+};
+
+/*
+ * Centralizes implementation of default loading screen:
+ * - If a loading screen is passed in props, it will be used as the default screen
+ * - If no loading screen is passed, the default screen will be the local `Loading` component
+ */
+export const LoadingScreenContext = createContext<Props>({
+  get: () => Loading,
+});
+
+export function LoadingScreenProvider(props: {
+  children: ReactNode;
+  loadingScreen?: ComponentType<LoadingProps>;
+}) {
+  const registry = useRef<{ [key: string]: ComponentType<LoadingProps> }>({});
+
+  if (props.loadingScreen) {
+    // Inject the props.loadingScreen as the default screen
+    registry.current.default = props.loadingScreen;
+  } else {
+    // Fallback to the local component
+    registry.current.default = Loading;
+  }
+
+  /**
+   * Get a loading screen component by id
+   * @param id - The id of the loading screen component to retrieve
+   * @returns The loading screen component by id or the default screen if no id is provided
+   */
+  const get = (id?: string): ComponentType<LoadingProps> =>
+    registry.current[id || 'default'];
+
+  return (
+    <LoadingScreenContext.Provider
+      value={{
+        get,
+      }}
+    >
+      {props.children}
+    </LoadingScreenContext.Provider>
+  );
+}
+
+LoadingScreenProvider.defaultProps = {
+  loadingScreen: undefined,
+};

--- a/src/contexts/navigation.ts
+++ b/src/contexts/navigation.ts
@@ -8,7 +8,6 @@ import type {
 } from 'hyperview/src/types';
 import React, { ComponentType, ReactNode } from 'react';
 import type { Props as ErrorProps } from 'hyperview/src/core/components/load-error';
-import type { Props as LoadingProps } from 'hyperview/src/core/components/loading';
 import type { NavigationComponents } from 'hyperview/src/services/navigator';
 
 export type NavigationContextProps = {
@@ -26,7 +25,6 @@ export type NavigationContextProps = {
   components?: HvComponent[];
   elementErrorComponent?: ComponentType<ErrorProps>;
   errorScreen?: ComponentType<ErrorProps>;
-  loadingScreen?: ComponentType<LoadingProps>;
   handleBack?: ComponentType<{ children: ReactNode }>;
   navigationComponents?: NavigationComponents;
 };

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -23,11 +23,14 @@ import {
   UPDATE_ACTIONS,
   UpdateAction,
 } from 'hyperview/src/types';
+import {
+  LoadingScreenContext,
+  LoadingScreenProvider,
+} from 'hyperview/src/contexts/loading-screen';
 import React, { PureComponent } from 'react';
 import HvRoute from 'hyperview/src/core/components/hv-route';
 import HvScreen from 'hyperview/src/core/components/hv-screen';
 import { Linking } from 'react-native';
-import { LoadingScreenProvider } from 'hyperview/src/contexts/loading-screen';
 import { XNetworkRetryAction } from 'hyperview/src/services/dom/types';
 
 /**
@@ -548,28 +551,33 @@ export default class Hyperview extends PureComponent<Types.Props> {
           value={this.props.refreshControl}
         >
           <LoadingScreenProvider loadingScreen={this.props.loadingScreen}>
-            <HvScreen
-              back={this.props.back}
-              behaviors={this.props.behaviors}
-              closeModal={this.props.closeModal}
-              components={this.props.components}
-              elementErrorComponent={this.props.elementErrorComponent}
-              entrypointUrl={this.props.entrypointUrl}
-              errorScreen={this.props.errorScreen}
-              fetch={this.props.fetch}
-              formatDate={this.props.formatDate}
-              navigate={this.props.navigate}
-              navigation={this.props.navigation}
-              onError={this.props.onError}
-              onParseAfter={this.props.onParseAfter}
-              onParseBefore={this.props.onParseBefore}
-              onUpdate={this.onUpdate}
-              openModal={this.props.openModal}
-              push={this.props.push}
-              refreshControl={this.props.refreshControl}
-              reload={this.reload}
-              route={this.props.route}
-            />
+            <LoadingScreenContext.Consumer>
+              {loadingConsumer => (
+                <HvScreen
+                  back={this.props.back}
+                  behaviors={this.props.behaviors}
+                  closeModal={this.props.closeModal}
+                  components={this.props.components}
+                  elementErrorComponent={this.props.elementErrorComponent}
+                  entrypointUrl={this.props.entrypointUrl}
+                  errorScreen={this.props.errorScreen}
+                  fetch={this.props.fetch}
+                  formatDate={this.props.formatDate}
+                  getLoadingScreen={loadingConsumer.get}
+                  navigate={this.props.navigate}
+                  navigation={this.props.navigation}
+                  onError={this.props.onError}
+                  onParseAfter={this.props.onParseAfter}
+                  onParseBefore={this.props.onParseBefore}
+                  onUpdate={this.onUpdate}
+                  openModal={this.props.openModal}
+                  push={this.props.push}
+                  refreshControl={this.props.refreshControl}
+                  reload={this.reload}
+                  route={this.props.route}
+                />
+              )}
+            </LoadingScreenContext.Consumer>
           </LoadingScreenProvider>
         </Contexts.RefreshControlComponentContext.Provider>
       );

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -27,6 +27,7 @@ import React, { PureComponent } from 'react';
 import HvRoute from 'hyperview/src/core/components/hv-route';
 import HvScreen from 'hyperview/src/core/components/hv-screen';
 import { Linking } from 'react-native';
+import { LoadingScreenProvider } from 'hyperview/src/contexts/loading-screen';
 import { XNetworkRetryAction } from 'hyperview/src/services/dom/types';
 
 /**
@@ -546,29 +547,31 @@ export default class Hyperview extends PureComponent<Types.Props> {
         <Contexts.RefreshControlComponentContext.Provider
           value={this.props.refreshControl}
         >
-          <HvScreen
-            back={this.props.back}
-            behaviors={this.props.behaviors}
-            closeModal={this.props.closeModal}
-            components={this.props.components}
-            elementErrorComponent={this.props.elementErrorComponent}
-            entrypointUrl={this.props.entrypointUrl}
-            errorScreen={this.props.errorScreen}
-            fetch={this.props.fetch}
-            formatDate={this.props.formatDate}
-            loadingScreen={this.props.loadingScreen}
-            navigate={this.props.navigate}
-            navigation={this.props.navigation}
-            onError={this.props.onError}
-            onParseAfter={this.props.onParseAfter}
-            onParseBefore={this.props.onParseBefore}
-            onUpdate={this.onUpdate}
-            openModal={this.props.openModal}
-            push={this.props.push}
-            refreshControl={this.props.refreshControl}
-            reload={this.reload}
-            route={this.props.route}
-          />
+          <LoadingScreenProvider loadingScreen={this.props.loadingScreen}>
+            <HvScreen
+              back={this.props.back}
+              behaviors={this.props.behaviors}
+              closeModal={this.props.closeModal}
+              components={this.props.components}
+              elementErrorComponent={this.props.elementErrorComponent}
+              entrypointUrl={this.props.entrypointUrl}
+              errorScreen={this.props.errorScreen}
+              fetch={this.props.fetch}
+              formatDate={this.props.formatDate}
+              loadingScreen={this.props.loadingScreen}
+              navigate={this.props.navigate}
+              navigation={this.props.navigation}
+              onError={this.props.onError}
+              onParseAfter={this.props.onParseAfter}
+              onParseBefore={this.props.onParseBefore}
+              onUpdate={this.onUpdate}
+              openModal={this.props.openModal}
+              push={this.props.push}
+              refreshControl={this.props.refreshControl}
+              reload={this.reload}
+              route={this.props.route}
+            />
+          </LoadingScreenProvider>
         </Contexts.RefreshControlComponentContext.Provider>
       );
     }
@@ -599,7 +602,9 @@ export default class Hyperview extends PureComponent<Types.Props> {
               reload: this.reload,
             }}
           >
-            <HvRoute />
+            <LoadingScreenProvider loadingScreen={this.props.loadingScreen}>
+              <HvRoute />
+            </LoadingScreenProvider>
           </NavContexts.Context.Provider>
         </Contexts.RefreshControlComponentContext.Provider>
       </Contexts.DateFormatContext.Provider>

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -550,7 +550,10 @@ export default class Hyperview extends PureComponent<Types.Props> {
         <Contexts.RefreshControlComponentContext.Provider
           value={this.props.refreshControl}
         >
-          <LoadingScreenProvider loadingScreen={this.props.loadingScreen}>
+          <LoadingScreenProvider
+            loadingScreen={this.props.loadingScreen}
+            loadingScreens={this.props.loadingScreens}
+          >
             <LoadingScreenContext.Consumer>
               {loadingConsumer => (
                 <HvScreen
@@ -608,7 +611,10 @@ export default class Hyperview extends PureComponent<Types.Props> {
               reload: this.reload,
             }}
           >
-            <LoadingScreenProvider loadingScreen={this.props.loadingScreen}>
+            <LoadingScreenProvider
+              loadingScreen={this.props.loadingScreen}
+              loadingScreens={this.props.loadingScreens}
+            >
               <HvRoute />
             </LoadingScreenProvider>
           </NavContexts.Context.Provider>

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -558,7 +558,6 @@ export default class Hyperview extends PureComponent<Types.Props> {
               errorScreen={this.props.errorScreen}
               fetch={this.props.fetch}
               formatDate={this.props.formatDate}
-              loadingScreen={this.props.loadingScreen}
               navigate={this.props.navigate}
               navigation={this.props.navigation}
               onError={this.props.onError}
@@ -591,7 +590,6 @@ export default class Hyperview extends PureComponent<Types.Props> {
               errorScreen: this.props.errorScreen,
               fetch: this.props.fetch,
               handleBack: this.props.handleBack,
-              loadingScreen: this.props.loadingScreen,
               navigationComponents: this.props.navigationComponents,
               onError: this.props.onError,
               onParseAfter: this.props.onParseAfter,

--- a/src/core/components/hv-root/types.ts
+++ b/src/core/components/hv-root/types.ts
@@ -44,6 +44,7 @@ export type Props = {
   elementErrorComponent?: ComponentType<ErrorProps>;
   errorScreen?: ComponentType<ErrorProps>;
   loadingScreen?: ComponentType<LoadingProps>;
+  loadingScreens?: { [key: string]: ComponentType<LoadingProps> };
   handleBack?: ComponentType<{ children: ReactNode }>;
   doc?: Document;
   logger?: Logging.Logger;

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -26,6 +26,7 @@ import HvScreen from 'hyperview/src/core/components/hv-screen';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import LoadError from 'hyperview/src/core/components/load-error';
 import Loading from 'hyperview/src/core/components/loading';
+import { LoadingScreenContext } from 'hyperview/src/contexts/loading-screen';
 // eslint-disable-next-line instawork/import-services
 import Navigation from 'hyperview/src/services/navigation';
 import { NavigationContainerRefContext } from '@react-navigation/native';
@@ -353,6 +354,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
             errorScreen={this.props.errorScreen}
             fetch={this.props.fetch}
             formatDate={formatter}
+            getLoadingScreen={this.props.getLoadingScreen}
             navigate={this.navLogic.navigate}
             navigation={this.props.navigation}
             onError={this.props.onError}
@@ -550,7 +552,9 @@ function HvRouteFC(props: Types.Props) {
   const navigatorMapContext: Types.NavigatorMapContextProps | null = useContext(
     NavigatorMapContext.NavigatorMapContext,
   );
-  if (!navigationContext || !navigatorMapContext) {
+  const loadingScreenContext = useContext(LoadingScreenContext);
+
+  if (!navigationContext || !navigatorMapContext || !loadingScreenContext) {
     throw new NavigatorService.HvRouteError('No context found');
   }
   const backContext = useContext(BackBehaviorContext);
@@ -656,6 +660,7 @@ function HvRouteFC(props: Types.Props) {
       entrypointUrl={navigationContext.entrypointUrl}
       errorScreen={navigationContext.errorScreen}
       fetch={navigationContext.fetch}
+      getLoadingScreen={loadingScreenContext.get}
       getPreload={navigatorMapContext.getPreload}
       handleBack={navigationContext.handleBack}
       navigation={nav}

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -25,7 +25,6 @@ import HvNavigator from 'hyperview/src/core/components/hv-navigator';
 import HvScreen from 'hyperview/src/core/components/hv-screen';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import LoadError from 'hyperview/src/core/components/load-error';
-import Loading from 'hyperview/src/core/components/loading';
 import { LoadingScreenContext } from 'hyperview/src/contexts/loading-screen';
 // eslint-disable-next-line instawork/import-services
 import Navigation from 'hyperview/src/services/navigation';
@@ -301,7 +300,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
         }
       }
     }
-    const LoadingScreen = this.props.loadingScreen || Loading;
+    const LoadingScreen = this.props.getLoadingScreen();
     return <LoadingScreen />;
   };
 

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -353,7 +353,6 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
             errorScreen={this.props.errorScreen}
             fetch={this.props.fetch}
             formatDate={formatter}
-            loadingScreen={this.props.loadingScreen}
             navigate={this.navLogic.navigate}
             navigation={this.props.navigation}
             onError={this.props.onError}
@@ -659,7 +658,6 @@ function HvRouteFC(props: Types.Props) {
       fetch={navigationContext.fetch}
       getPreload={navigatorMapContext.getPreload}
       handleBack={navigationContext.handleBack}
-      loadingScreen={navigationContext.loadingScreen}
       navigation={nav}
       onError={navigationContext.onError}
       onParseAfter={navigationContext.onParseAfter}

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -300,7 +300,11 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
         }
       }
     }
-    const LoadingScreen = this.props.getLoadingScreen();
+
+    // Load either the loadingScreen by id or the default loading screen
+    const LoadingScreen = this.props.getLoadingScreen(
+      this.props.route?.params?.loadingScreen,
+    );
     return <LoadingScreen />;
   };
 

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -62,6 +62,7 @@ export type InnerRouteProps = {
   getPreload: (key: number) => Element | undefined;
   element?: Element;
   reload: Reload;
+  getLoadingScreen: (id?: string) => ComponentType<LoadingProps>;
 };
 
 /**

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -26,7 +26,6 @@ export type NavigationContextProps = {
   components?: HvComponent[];
   elementErrorComponent?: ComponentType<ErrorProps>;
   errorScreen?: ComponentType<ErrorProps>;
-  loadingScreen?: ComponentType<LoadingProps>;
   handleBack?: ComponentType<{ children: ReactNode }>;
   reload: Reload;
 };
@@ -58,7 +57,6 @@ export type InnerRouteProps = {
   components?: HvComponent[];
   elementErrorComponent?: ComponentType<ErrorProps>;
   errorScreen?: ComponentType<ErrorProps>;
-  loadingScreen?: ComponentType<LoadingProps>;
   handleBack?: ComponentType<{ children: ReactNode }>;
   setPreload: (key: number, element: Element) => void;
   getPreload: (key: number) => Element | undefined;

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -10,7 +10,6 @@ import * as Stylesheets from 'hyperview/src/services/stylesheets';
 import { createProps, createStyleProp, later } from 'hyperview/src/services';
 import LoadElementError from '../load-element-error';
 import LoadError from 'hyperview/src/core/components/load-error';
-import Loading from 'hyperview/src/core/components/loading';
 // eslint-disable-next-line instawork/import-services
 import Navigation from 'hyperview/src/services/navigation';
 import React from 'react';
@@ -251,7 +250,7 @@ export default class HvScreen extends React.Component {
       });
     }
     if (!this.state.doc) {
-      const loadingScreen = this.props.loadingScreen || Loading;
+      const loadingScreen = this.props.getLoadingScreen();
       return React.createElement(loadingScreen);
     }
     const elementErrorComponent = this.state.elementError

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -41,6 +41,7 @@ export default class HvScreen extends React.Component {
       doc: null,
       elementError: null,
       error: null,
+      loadingScreen: null,
       staleHeaderType: null,
       styles: null,
       url: null,
@@ -104,6 +105,7 @@ export default class HvScreen extends React.Component {
         doc: preloadScreen,
         elementError: null,
         error: null,
+        loadingScreen: params.loadingScreen,
         styles: preloadStyles,
         url,
       });
@@ -111,6 +113,7 @@ export default class HvScreen extends React.Component {
       this.setState({
         elementError: null,
         error: null,
+        loadingScreen: params.loadingScreen,
         url,
       });
     }
@@ -151,7 +154,12 @@ export default class HvScreen extends React.Component {
         : // eslint-disable-next-line react/no-access-state-in-setstate
           this.state.styles;
 
-      this.setState({ doc, styles, url: newUrl });
+      this.setState({
+        doc,
+        loadingScreen: newNavigationState.params.loadingScreen,
+        styles,
+        url: newUrl,
+      });
     }
   };
 
@@ -211,6 +219,7 @@ export default class HvScreen extends React.Component {
         doc,
         elementError: null,
         error: null,
+        loadingScreen: null,
         staleHeaderType,
         styles: stylesheets,
       });
@@ -222,6 +231,7 @@ export default class HvScreen extends React.Component {
         doc: null,
         elementError: null,
         error: err,
+        loadingScreen: null,
         styles: null,
       });
     }
@@ -250,7 +260,9 @@ export default class HvScreen extends React.Component {
       });
     }
     if (!this.state.doc) {
-      const loadingScreen = this.props.getLoadingScreen();
+      const loadingScreen = this.props.getLoadingScreen(
+        this.state.loadingScreen,
+      );
       return React.createElement(loadingScreen);
     }
     const elementErrorComponent = this.state.elementError

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -6,7 +6,7 @@ import { Props as LoadingProps } from 'hyperview/src/core/components/loading';
 /**
  * All of the props used by hv-screen
  */
-export type Props = Omit<HvRootProps, 'loadingScreen'> & {
+export type Props = Omit<HvRootProps, 'loadingScreen' | 'loadingScreens'> & {
   getLoadingScreen: (id?: string) => ComponentType<LoadingProps>;
   onUpdate: HvComponentOnUpdate;
   registerPreload?: (id: number, element: Element) => void;

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -1,10 +1,13 @@
 import type { HvComponentOnUpdate, Reload } from 'hyperview/src/types';
+import { ComponentType } from 'react';
 import { Props as HvRootProps } from 'hyperview/src/core/components/hv-root/types';
+import { Props as LoadingProps } from 'hyperview/src/core/components/loading';
 
 /**
  * All of the props used by hv-screen
  */
 export type Props = Omit<HvRootProps, 'loadingScreen'> & {
+  getLoadingScreen: (id?: string) => ComponentType<LoadingProps>;
   onUpdate: HvComponentOnUpdate;
   registerPreload?: (id: number, element: Element) => void;
   reload: Reload;

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -4,7 +4,7 @@ import { Props as HvRootProps } from 'hyperview/src/core/components/hv-root/type
 /**
  * All of the props used by hv-screen
  */
-export type Props = HvRootProps & {
+export type Props = Omit<HvRootProps, 'loadingScreen'> & {
   onUpdate: HvComponentOnUpdate;
   registerPreload?: (id: number, element: Element) => void;
   reload: Reload;

--- a/src/services/navigation/index.ts
+++ b/src/services/navigation/index.ts
@@ -85,6 +85,7 @@ export default class Navigation {
 
     let preloadScreen = null;
     let preloadElement: Element | null | undefined = null;
+    let loadingScreen;
     if (showIndicatorId && this.document) {
       const screens: HTMLCollectionOf<Element> = this.document.getElementsByTagNameNS(
         Namespaces.HYPERVIEW,
@@ -101,8 +102,18 @@ export default class Navigation {
         }
       }
     }
+    if (!preloadElement && showIndicatorId) {
+      loadingScreen = showIndicatorId;
+    }
 
-    const routeParams = { delay, preloadScreen, targetId, url } as const;
+    const routeParams = {
+      delay,
+      loadingScreen,
+      preloadScreen,
+      targetId,
+      url,
+    } as const;
+
     if (delay) {
       setTimeout(() => {
         this.executeNavigate(action, routeParams, url, href);

--- a/src/services/navigation/index.ts
+++ b/src/services/navigation/index.ts
@@ -95,7 +95,7 @@ export default class Navigation {
         s => s && s.getAttribute('id') === showIndicatorId,
       );
       if (preloadElement) {
-        preloadScreen = Date.now(); // Not trully unique but sufficient for our use-case
+        preloadScreen = Date.now(); // Not truly unique but sufficient for our use-case
         this.setPreloadScreen(preloadScreen, preloadElement);
         if (registerPreload) {
           registerPreload(preloadScreen, preloadElement);

--- a/src/services/navigation/index.ts
+++ b/src/services/navigation/index.ts
@@ -75,6 +75,7 @@ export default class Navigation {
     const formData: FormData | null | undefined = componentRegistry.getFormData(
       element,
     );
+    const indicatorId = showIndicatorId?.split(' ')[0] || null;
 
     let url = href;
     if (!href.startsWith(ANCHOR_ID_SEPARATOR)) {
@@ -86,13 +87,13 @@ export default class Navigation {
     let preloadScreen = null;
     let preloadElement: Element | null | undefined = null;
     let loadingScreen;
-    if (showIndicatorId && this.document) {
+    if (indicatorId && this.document) {
       const screens: HTMLCollectionOf<Element> = this.document.getElementsByTagNameNS(
         Namespaces.HYPERVIEW,
         'screen',
       );
       preloadElement = Array.from(screens).find(
-        s => s && s.getAttribute('id') === showIndicatorId,
+        s => s && s.getAttribute('id') === indicatorId,
       );
       if (preloadElement) {
         preloadScreen = Date.now(); // Not truly unique but sufficient for our use-case
@@ -102,8 +103,8 @@ export default class Navigation {
         }
       }
     }
-    if (!preloadElement && showIndicatorId) {
-      loadingScreen = showIndicatorId;
+    if (!preloadElement && indicatorId) {
+      loadingScreen = indicatorId;
     }
 
     const routeParams = {

--- a/src/services/navigation/index.ts
+++ b/src/services/navigation/index.ts
@@ -84,19 +84,20 @@ export default class Navigation {
     }
 
     let preloadScreen = null;
+    let preloadElement: Element | null | undefined = null;
     if (showIndicatorId && this.document) {
       const screens: HTMLCollectionOf<Element> = this.document.getElementsByTagNameNS(
         Namespaces.HYPERVIEW,
         'screen',
       );
-      const loadingScreen: Element | null | undefined = Array.from(
-        screens,
-      ).find(s => s && s.getAttribute('id') === showIndicatorId);
-      if (loadingScreen) {
+      preloadElement = Array.from(screens).find(
+        s => s && s.getAttribute('id') === showIndicatorId,
+      );
+      if (preloadElement) {
         preloadScreen = Date.now(); // Not trully unique but sufficient for our use-case
-        this.setPreloadScreen(preloadScreen, loadingScreen);
+        this.setPreloadScreen(preloadScreen, preloadElement);
         if (registerPreload) {
-          registerPreload(preloadScreen, loadingScreen);
+          registerPreload(preloadScreen, preloadElement);
         }
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -392,6 +392,7 @@ export type Route = NavigatorRoute<string, RouteParams>;
 export type RouteParams = {
   id?: string;
   url: string;
+  loadingScreen?: string;
   preloadScreen?: number;
   isModal?: boolean;
 };

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -78,7 +78,8 @@
     "Hyperview Client": [
       "reference_hyperview_component",
       "reference_custom_elements",
-      "reference_custom_behaviors"
+      "reference_custom_behaviors",
+      "reference_loading_screens"
     ],
     "Hyperview Navigation":[
       "reference_navigator",


### PR DESCRIPTION
Adding a new feature to Hyperview to allow passing in named loading screen components.

Example:
```es6
<Hyperview
  ...
  loadingScreens={{
    'green-loader': GreenLoadingScreen,
  }}
/>
```

```es6
<behavior
  action="new"
  href="/hyperview/public/navigation/behaviors/actions/modal/index.xml"
  show-during-load="green-loader"
/>
```

https://github.com/user-attachments/assets/8a3d3bd1-510b-42e5-95e4-b9a4f8505ddd


See commits for breakdown.

[Asana](https://app.asana.com/0/1204008699308084/1208750137800484/f)