### PR TITLE
fix(docs): links to code

### DIFF
--- a/docs/example_advanced_form.md
+++ b/docs/example_advanced_form.md
@@ -12,7 +12,7 @@ The standard UI choice for `<option>` elements in a `<select-single>` is the rad
 ![form](/img/advanced_form/standard.gif)
 
 <div style="text-align:center;margin-bottom:1em;">
-  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/examples/case_studies/advanced_form">See the full code</a>
+  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/demo/backend/advanced/case-studies/advanced-forms">See the full code</a>
 </div>
 
 Looking at the anatomy of an option in the example above, we can break down the UI into 3 parts:

--- a/docs/example_basic_form.md
+++ b/docs/example_basic_form.md
@@ -8,7 +8,7 @@ Hyperview supports sending user input with requests through the [`<form>`](/docs
 ![main](/img/basic_form/main.png)
 
 <div style="text-align:center;margin-bottom:1em;">
-  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/examples/case_studies/basic_form">See the full code</a>
+  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/demo/backend/advanced/case-studies/basic-forms">See the full code</a>
 </div>
 
 ### Styling inputs

--- a/docs/example_delayed_navigation.md
+++ b/docs/example_delayed_navigation.md
@@ -62,7 +62,7 @@ Putting it all together, we get the desired delayed navigation behavior:
 ![delayed navigation](/img/example_delayed_navigation1.gif)
 
 <div style="text-align:center;margin-bottom:1em;">
-  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/examples/case_studies/delayed_navigation">See the full code</a>
+  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/demo/backend/advanced/case-studies/delayed-navigation">See the full code</a>
 </div>
 
 This technique is very powerful. In this example, we hard-coded the contents of `redirect.xml`. In a real app, the contents could be dynamically generated. For example, instead of always opening the second screen, server-side logic could've decided to open a modal instead. Or, the server could've sent back an error message instead of a behavior that triggers on load. It could also return a success message and a second link, requiring the user to perform a "double confirm" to proceed to the next screen.

--- a/docs/example_event_dispatch.md
+++ b/docs/example_event_dispatch.md
@@ -13,7 +13,7 @@ Every time a person is added, we want the list on the first screen to show the u
 ![final](/img/event_dispatch/final.gif)
 
 <div style="text-align:center;margin-bottom:1em;">
-  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/examples/advanced_behaviors/dispatch_events_multiple">See the full code</a>
+  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/demo/backend/behaviors/advanced/dispatch-multiple">See the full code</a>
 </div>
 
 Let's start with the markup for the list of people and the default status. Clicking on an item will open a new screen with the person's information.

--- a/docs/example_infinite_scroll.md
+++ b/docs/example_infinite_scroll.md
@@ -9,7 +9,7 @@ You can create an infinite-scroll experience by using [`<list>`](reference_list)
 ![infinite scroll](/img/example_infinite_scroll1.gif)
 
 <div style="text-align:center;margin-bottom:1em;">
-  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/examples/case_studies/infinite_scroll">See the full code</a>
+  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/demo/backend/advanced/case-studies/infinite-scroll">See the full code</a>
 </div>
 
 ```xml

--- a/docs/example_lazy_load.md
+++ b/docs/example_lazy_load.md
@@ -9,7 +9,7 @@ The [previous example](/docs/example_infinite_scroll) showed how to implement an
 ![lazy load](/img/example_lazy_load1.gif)
 
 <div style="text-align:center;margin-bottom:1em;">
-  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/examples/case_studies/lazy_load">See the full code</a>
+  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/demo/backend/advanced/case-studies/lazy-load">See the full code</a>
 </div>
 
 ```xml

--- a/docs/example_photo_sharing.md
+++ b/docs/example_photo_sharing.md
@@ -7,7 +7,7 @@ sidebar_label: Photo sharing app
 This case study replicates the functionality of a photo-sharing app. It consists of two screens: a feed of shared images, with comments and likes, and a user profile that shows a grid of images shared by a specific user. The feed supports sticky image headers, toggling likes, loading more comments, and tapping user names to load the profile screen.
 
 <div style="text-align:center">
-  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/examples/case_studies/photos">See the full code</a>
+  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/demo/backend/advanced/case-studies/photos">See the full code</a>
 </div>
 
 <div style="display:flex;justify-content:space-around">
@@ -350,4 +350,4 @@ Images require an explicit width and height, but different devices will have dif
 
 ### See the code
 
-For the full example, browse the full code in the [Hyperview Github repo](https://github.com/Instawork/hyperview/tree/master/examples/case_studies/photos).
+For the full example, browse the full code in the [Hyperview Github repo](https://github.com/Instawork/hyperview/tree/master/demo/backend/advanced/case-studies/photos).

--- a/docs/example_pull_to_refresh.md
+++ b/docs/example_pull_to_refresh.md
@@ -9,7 +9,7 @@ Hyperview has built-in support for the pull-to-refresh gesture on [`<list>`](ref
 ![pull to refresh](/img/example_pull_to_refresh1.gif)
 
 <div style="text-align:center;margin-bottom:1em;">
-  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/examples/case_studies/pull_to_refresh">See the full code</a>
+  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/demo/backend/advanced/case-studies/pull-to-refresh">See the full code</a>
 </div>
 
 ```xml

--- a/docs/example_tabs.md
+++ b/docs/example_tabs.md
@@ -8,7 +8,7 @@ By using [`<select-single>`](/docs/reference_selectsingle) with selection styles
 ![example_tabs1](/img/example_tabs4.gif)
 
 <div style="text-align:center;margin-bottom:1em;">
-  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/examples/case_studies/tabs">See the full code</a>
+  <a class="button" href="https://github.com/Instawork/hyperview/tree/master/demo/backend/advanced/case-studies/tabs">See the full code</a>
 </div>
 
 Let's start with the markup for the tabs. Since only one tab can be selected at a time, we can use `<select-single>` to capture this state:


### PR DESCRIPTION
When we migrated the backend code to a new directory, we forgot to update direct links to examples in docs.

Solves #998