### PR TITLE
feat(loading): update demo

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -9,6 +9,8 @@ import { BottomTabBar } from './src/Core';
 import { BottomTabBarContextProvider } from './src/Contexts';
 import Components from './src/Components';
 import Constants from 'expo-constants';
+import DefaultLoadingScreen from './src/Components/Loaders/DefaultLoader';
+import GreenLoadingScreen from './src/Components/Loaders/GreenLoader';
 import Hyperview from 'hyperview';
 import { NavigationContainer } from '@react-navigation/native';
 import React from 'react';
@@ -36,6 +38,11 @@ export default () => (
                 entrypointUrl={`${Constants.expoConfig?.extra?.baseUrl}/hyperview/public/index.xml`}
                 fetch={fetchWrapper}
                 formatDate={formatDate}
+                loadingScreen={DefaultLoadingScreen}
+                // Provide custom named loading screen(s)
+                loadingScreens={{
+                  'green-loader': GreenLoadingScreen,
+                }}
                 navigationComponents={{
                   BottomTabBar,
                 }}

--- a/demo/backend/ui/ui-elements/content.xml.njk
+++ b/demo/backend/ui/ui-elements/content.xml.njk
@@ -1,2 +1,2 @@
-{% set hv_section_list_tag = "UI/UI Elements/Text,UI/UI Elements/View,UI/UI Elements/Image,UI/UI Elements/Forms,UI/UI Elements/List,UI/UI Elements/Section List,UI/UI Elements/Web View" %}
+{% set hv_section_list_tag = "UI/UI Elements/Text,UI/UI Elements/View,UI/UI Elements/Image,UI/UI Elements/Forms,UI/UI Elements/List,UI/UI Elements/Loading Screen,UI/UI Elements/Section List,UI/UI Elements/Web View" %}
 {% include 'templates/section-list.xml.njk' %}

--- a/demo/backend/ui/ui-elements/loading-screen/index.xml.njk
+++ b/demo/backend/ui/ui-elements/loading-screen/index.xml.njk
@@ -1,0 +1,42 @@
+---
+permalink: "/ui/ui-elements/loading-screen/index.xml"
+tags: "UI/UI Elements/Loading Screen"
+hv_title: "Loading Screen"
+hv_button_behavior: "back"
+---
+{% extends 'templates/scrollview.xml.njk' %}
+{% from 'macros/description/index.xml.njk' import description %}
+{% from 'macros/button/index.xml.njk' import button %}
+
+{% block content %}
+  {{ description('Clicking each button will open a modal and show a loader until the content is ready.')}}
+
+  {# `green-loader` is passed in via the <Hyperview loadingScreens /> property in App.tsx #}
+  {% call button('New with green loader') -%}
+    <behavior action="new" delay="1000" href="/hyperview/public/navigation/behaviors/actions/modal/index.xml" show-during-load="green-loader" />
+  {%- endcall %}
+
+  {# `custom-loader` is provided below #}
+  {% call button('New with doc loader') -%}
+    <behavior action="new" delay="1000" href="/hyperview/public/navigation/behaviors/actions/modal/index.xml" show-during-load="custom-loader" />
+  {%- endcall %}
+
+  {# When no `show-during-load` attribute is included, the default loader component is used #}
+  {% call button('New with default loader') -%}
+    <behavior action="new" delay="1000" href="/hyperview/public/navigation/behaviors/actions/modal/index.xml" />
+  {%- endcall %}
+{% endblock %}
+
+{% block custom_screen %}
+  <screen id="custom-loader">
+    <styles>
+      {% include 'templates/styles.xml.njk' %}
+    </styles>
+    <body style="body" safe-area="true">
+      <view style="loading">
+        <text style="loading-text">This may take a while…</text>
+        <spinner/>
+      </view>
+    </body>
+  </screen>
+{% endblock %}

--- a/demo/src/Components/Loaders/DefaultLoader.tsx
+++ b/demo/src/Components/Loaders/DefaultLoader.tsx
@@ -1,0 +1,25 @@
+import { ActivityIndicator, View } from 'react-native';
+import type { Props as LoadingProps } from 'hyperview/src/core/components/loading';
+import React from 'react';
+
+/**
+ * DefaultLoadingScreen passed into the Hyperview component as the loadingScreen prop.
+ * This component will be used when a screen is loading and no other loading screen is specified.
+ */
+const DefaultLoadingScreen = (props: LoadingProps) => {
+  const color = props.color || '#8d9494';
+  return (
+    <View
+      style={{
+        alignItems: 'center',
+        flex: 1,
+        gap: 10,
+        justifyContent: 'center',
+      }}
+    >
+      <ActivityIndicator color={color} size="large" />
+    </View>
+  );
+};
+
+export default DefaultLoadingScreen;

--- a/demo/src/Components/Loaders/GreenLoader.tsx
+++ b/demo/src/Components/Loaders/GreenLoader.tsx
@@ -1,0 +1,23 @@
+import { ActivityIndicator, View } from 'react-native';
+import type { Props as LoadingProps } from 'hyperview/src/core/components/loading';
+import React from 'react';
+
+/**
+ * Custom loading screen that displays a green ActivityIndicator.
+ */
+const GreenLoadingScreen = (props: LoadingProps) => {
+  const color = props.color || '#63CB76';
+  return (
+    <View
+      style={{
+        alignItems: 'center',
+        flex: 1,
+        justifyContent: 'center',
+      }}
+    >
+      <ActivityIndicator color={color} size="large" />
+    </View>
+  );
+};
+
+export default GreenLoadingScreen;


### PR DESCRIPTION
Update the demo with a "Loading Screen" section with examples of using loading screens.

>NOTE: This PR will fail tests until HV is published as the demo relies on the released version and `loadingScreens` will not be available until that is released.

Relates to: https://github.com/Instawork/hyperview/pull/995