### PR TITLE
chore(docs/schema): text-field's `selectionHandleColor` attribute (Android only)

### DIFF
--- a/demo/backend/ui/ui-elements/forms/text-field/_basic/index.xml.njk
+++ b/demo/backend/ui/ui-elements/forms/text-field/_basic/index.xml.njk
@@ -6,6 +6,7 @@
     placeholder="Placeholder"
     placeholderTextColor="#8D9494"
     selectionColor="#4778FF"
+    selectionHandleColor="#4778FF"
     cursorColor="#4778FF"
     value=""
   />

--- a/demo/backend/ui/ui-elements/forms/text-field/_multiline/index.xml.njk
+++ b/demo/backend/ui/ui-elements/forms/text-field/_multiline/index.xml.njk
@@ -7,6 +7,7 @@
     placeholder="Placeholder"
     placeholderTextColor="#8D9494"
     selectionColor="#4778FF"
+    selectionHandleColor="#4778FF"
     cursorColor="#4778FF"
     value=""
   />

--- a/docs/reference_textfield.md
+++ b/docs/reference_textfield.md
@@ -87,6 +87,14 @@ The text color of the placeholder string.
 
 The highlight, selection handle and cursor color of the text input.
 
+#### `selectionHandleColor` (Android)
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
+
+Sets the color of the selection handle. Unlike `selectionColor`, it allows the selection handle color to be customized independently of the selection's color.
+
 #### `cursorColor` (Android)
 
 | Type   | Required |

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -1105,6 +1105,7 @@
       <xs:attribute name="placeholder" type="xs:string" />
       <xs:attribute name="placeholderTextColor" type="hv:color" />
       <xs:attribute name="selectionColor" type="hv:color" />
+      <xs:attribute name="selectionHandleColor" type="hv:color" />
       <xs:attribute name="cursorColor" type="hv:color" />
       <xs:attribute name="keyboard-type">
         <xs:simpleType>


### PR DESCRIPTION
Add `selectionHandleColor` attribute of text-field to documentation and schema.

Note: this attribute will only have effect with React Native 0.74+