### PR TITLE
fix(navigation): action reload is not reading href

### DIFF
--- a/demo/backend/_includes/templates/base.xml.njk
+++ b/demo/backend/_includes/templates/base.xml.njk
@@ -1,17 +1,22 @@
 {# Base template that should be used for all screens. Shows the Header + back button #}
-<doc xmlns="https://hyperview.org/hyperview" {% block custom_ns %}{% endblock %}>
-  <screen>
-    <styles>
-      {% include 'templates/styles.xml.njk' %}
-      {% block styles %}
-      {% endblock %}
-    </styles>
-    <body style="body" safe-area="true">
-      {% include 'templates/header.xml.njk' %}
-      {% block container %}{% endblock %}
-    </body>
-  </screen>
-  {% block custom_screen %}
-  {% endblock %}
-  {% include 'templates/loading-screen.xml.njk' %}
-</doc>
+
+{% extends 'templates/root.xml.njk' %}
+
+{% block root %}
+  <doc xmlns="https://hyperview.org/hyperview" {% block custom_ns %}{% endblock %}>
+    <screen>
+      <styles>
+        {% include 'templates/styles.xml.njk' %}
+        {% block styles %}
+        {% endblock %}
+      </styles>
+      <body style="body" safe-area="true">
+        {% include 'templates/header.xml.njk' %}
+        {% block container %}{% endblock %}
+      </body>
+    </screen>
+    {% block custom_screen %}
+    {% endblock %}
+    {% include 'templates/loading-screen.xml.njk' %}
+  </doc>
+{% endblock %}

--- a/demo/backend/_includes/templates/root.xml.njk
+++ b/demo/backend/_includes/templates/root.xml.njk
@@ -1,3 +1,3 @@
-{# Base template that should be used for all screens. Shows the Header + back button #}
+{# Base template that should be used for all templates #}
 
 {% block root %}{% endblock %}

--- a/demo/backend/_includes/templates/root.xml.njk
+++ b/demo/backend/_includes/templates/root.xml.njk
@@ -1,0 +1,3 @@
+{# Base template that should be used for all screens. Shows the Header + back button #}
+
+{% block root %}{% endblock %}

--- a/demo/backend/index-reloaded.xml.njk
+++ b/demo/backend/index-reloaded.xml.njk
@@ -4,7 +4,6 @@ hv_button_behavior: "none"
 hv_title: "Hyperview"
 hv_list_tag: "root"
 ---
-
 {% extends './index.xml.njk' %}
 
 {% block advanced_attributes %}selected="true"{% endblock %}

--- a/demo/backend/index-reloaded.xml.njk
+++ b/demo/backend/index-reloaded.xml.njk
@@ -1,5 +1,5 @@
 ---
-permalink: "index.xml"
+permalink: "index-reloaded.xml"
 hv_button_behavior: "none"
 hv_title: "Hyperview"
 hv_list_tag: "root"
@@ -14,13 +14,12 @@ hv_list_tag: "root"
       action="reload"
       href="/hyperview/public/index-reloaded.xml"
     />
-
     <nav-route id="tabs">
       <navigator id="tabs-navigator" type="tab">
         <nav-route id="tab-ui" href="/hyperview/public/ui/index.xml"/>
         <nav-route id="tab-navigation" href="/hyperview/public/navigation/index.xml"/>
         <nav-route id="tab-behaviors" href="/hyperview/public/behaviors/index.xml"/>
-        <nav-route id="tab-advanced" href="/hyperview/public/advanced/index.xml"/>
+        <nav-route id="tab-advanced" href="/hyperview/public/advanced/index.xml" selected="true"/>
       </navigator>
     </nav-route>
   </navigator>

--- a/demo/backend/index-reloaded.xml.njk
+++ b/demo/backend/index-reloaded.xml.njk
@@ -5,22 +5,6 @@ hv_title: "Hyperview"
 hv_list_tag: "root"
 ---
 
-<doc xmlns="https://hyperview.org/hyperview">
-  <navigator id="stack-navigator" type="stack">
-    {# invoked from /navigation/behaviors/actions/reload/index.xml #}
-    <behavior
-      trigger="on-event"
-      event-name="reload-root-navigation"
-      action="reload"
-      href="/hyperview/public/index-reloaded.xml"
-    />
-    <nav-route id="tabs">
-      <navigator id="tabs-navigator" type="tab">
-        <nav-route id="tab-ui" href="/hyperview/public/ui/index.xml"/>
-        <nav-route id="tab-navigation" href="/hyperview/public/navigation/index.xml"/>
-        <nav-route id="tab-behaviors" href="/hyperview/public/behaviors/index.xml"/>
-        <nav-route id="tab-advanced" href="/hyperview/public/advanced/index.xml" selected="true"/>
-      </navigator>
-    </nav-route>
-  </navigator>
-</doc>
+{% extends './index.xml.njk' %}
+
+{% block advanced_attributes %}selected="true"{% endblock %}

--- a/demo/backend/index.xml.njk
+++ b/demo/backend/index.xml.njk
@@ -4,24 +4,27 @@ hv_button_behavior: "none"
 hv_title: "Hyperview"
 hv_list_tag: "root"
 ---
+{% extends 'templates/root.xml.njk' %}
 
-<doc xmlns="https://hyperview.org/hyperview">
-  <navigator id="stack-navigator" type="stack">
-    {# invoked from /navigation/behaviors/actions/reload/index.xml #}
-    <behavior
-      trigger="on-event"
-      event-name="reload-root-navigation"
-      action="reload"
-      href="/hyperview/public/index-reloaded.xml"
-    />
+{% block root %}
+  <doc xmlns="https://hyperview.org/hyperview">
+    <navigator id="stack-navigator" type="stack">
+      {# invoked from /navigation/behaviors/actions/reload/index.xml #}
+      <behavior
+        trigger="on-event"
+        event-name="reload-root-navigation"
+        action="reload"
+        href="/hyperview/public/index-reloaded.xml"
+      />
 
-    <nav-route id="tabs">
-      <navigator id="tabs-navigator" type="tab">
-        <nav-route id="tab-ui" href="/hyperview/public/ui/index.xml" {% block ui_attributes %}{% endblock %} />
-        <nav-route id="tab-navigation" href="/hyperview/public/navigation/index.xml" {% block navigation_attributes %}{% endblock %} />
-        <nav-route id="tab-behaviors" href="/hyperview/public/behaviors/index.xml" {% block behavior_attributes %}{% endblock %} />
-        <nav-route id="tab-advanced" href="/hyperview/public/advanced/index.xml" {% block advanced_attributes %}{% endblock %} />
-      </navigator>
-    </nav-route>
-  </navigator>
-</doc>
+      <nav-route id="tabs">
+        <navigator id="tabs-navigator" type="tab">
+          <nav-route id="tab-ui" href="/hyperview/public/ui/index.xml" {% block ui_attributes %}{% endblock %} />
+          <nav-route id="tab-navigation" href="/hyperview/public/navigation/index.xml" {% block navigation_attributes %}{% endblock %} />
+          <nav-route id="tab-behaviors" href="/hyperview/public/behaviors/index.xml" {% block behavior_attributes %}{% endblock %} />
+          <nav-route id="tab-advanced" href="/hyperview/public/advanced/index.xml" {% block advanced_attributes %}{% endblock %} />
+        </navigator>
+      </nav-route>
+    </navigator>
+  </doc>
+{% endblock %}

--- a/demo/backend/index.xml.njk
+++ b/demo/backend/index.xml.njk
@@ -17,10 +17,10 @@ hv_list_tag: "root"
 
     <nav-route id="tabs">
       <navigator id="tabs-navigator" type="tab">
-        <nav-route id="tab-ui" href="/hyperview/public/ui/index.xml"/>
-        <nav-route id="tab-navigation" href="/hyperview/public/navigation/index.xml"/>
-        <nav-route id="tab-behaviors" href="/hyperview/public/behaviors/index.xml"/>
-        <nav-route id="tab-advanced" href="/hyperview/public/advanced/index.xml"/>
+        <nav-route id="tab-ui" href="/hyperview/public/ui/index.xml" {% block ui_attributes %}{% endblock %} />
+        <nav-route id="tab-navigation" href="/hyperview/public/navigation/index.xml" {% block navigation_attributes %}{% endblock %} />
+        <nav-route id="tab-behaviors" href="/hyperview/public/behaviors/index.xml" {% block behavior_attributes %}{% endblock %} />
+        <nav-route id="tab-advanced" href="/hyperview/public/advanced/index.xml" {% block advanced_attributes %}{% endblock %} />
       </navigator>
     </nav-route>
   </navigator>

--- a/demo/backend/navigation/behaviors/actions/reload/index.xml.njk
+++ b/demo/backend/navigation/behaviors/actions/reload/index.xml.njk
@@ -22,4 +22,16 @@ hv_button_behavior: "back"
   {% call button('Reload different screen') -%}
     <behavior action="reload" href="/hyperview/public/navigation/index.xml" show-during-load="loading-screen" />
   {%- endcall %}
+
+  {{ description('Tapping the button below will reload the root navigation hierarchy with the "Advanced" tab selected') }}
+  {% call button('Reload hierarchy') -%}
+    {# close this view #}
+    <behavior action="back" href="#" />
+
+    {# invoke the behavior defined on /backend/index.xml #}
+    <behavior
+      action="dispatch-event"
+      event-name="reload-root-navigation"
+    />
+  {%- endcall %}
 {% endblock %}

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -96,8 +96,8 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
   componentDidUpdate(prevProps: Types.InnerRouteProps) {
     if (prevProps.url !== this.props.url || this.needsLoad) {
       this.load();
+      this.needsLoad = false;
     }
-    this.needsLoad = false;
   }
 
   /**

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -114,7 +114,9 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
 
   getUrl = (): string => {
     return UrlService.getUrlFromHref(
-      this.state.url || this.props.url || this.props.entrypointUrl,
+      (this.needsLoad ? this.state.url : undefined) ||
+        this.props.url ||
+        this.props.entrypointUrl,
       this.props.entrypointUrl,
     );
   };

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -114,7 +114,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
 
   getUrl = (): string => {
     return UrlService.getUrlFromHref(
-      this.props.url || this.props.entrypointUrl,
+      this.state.url || this.props.url || this.props.entrypointUrl,
       this.props.entrypointUrl,
     );
   };


### PR DESCRIPTION
Resolving issue with `on-event` behaviors embedded in `<navigator>` elements no properly performing `reload` action.

- [fix: only reset flag when loading](https://github.com/Instawork/hyperview/pull/1005/commits/b665f2d721a58cf5df0b97066470231defaa009f): copied over from [`hv-screen` implementation](https://github.com/Instawork/hyperview/blob/42e1534c371b32fff97efaaf122f79165c06d7aa/src/core/components/hv-screen/index.js#L176-L180). The issue with having it outside the if/then is that it could be cleared when a parent component causes an update before this component has updated its own state.
- [fix: include state in url logic](https://github.com/Instawork/hyperview/pull/1005/commits/dac168c5e69e0de7e414f623cab4328848c4e71d): as with `hv-screen`, the update mechanism needs to inject data that may have been passed into the `state`. See [hv-screen](https://github.com/Instawork/hyperview/blob/42e1534c371b32fff97efaaf122f79165c06d7aa/src/core/components/hv-screen/index.js#L205)
- Added a demo to illustrate the feature.
  - created an `index-reloaded` file to represent the content to load into the hv-route
  - the templates [have to inherit](https://github.com/Instawork/hyperview/pull/1005/commits/486bb1af5ce781e0878e22d258f6bd741a3cff8c) from an included template to ensure the headers didn't get copied into the generated xml templates

[Asana](https://app.asana.com/0/1204008699308084/1208942355610921/f)

| iOS | Android |
| -- | -- |
| ![iOS](https://github.com/user-attachments/assets/8556531d-43db-4071-877d-bb980b87cd70) | ![Android](https://github.com/user-attachments/assets/9ab9a736-b4fb-441f-a33d-bd3666cf3151) |


QA Plan:
- ensure navigation works as normal including
  - deep links
  - modals
  - pushed screens
