### PR TITLE
chore(navigation): demo for supporting alternate loading screens for behaviors and nav-routes

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -10,6 +10,7 @@ import { BottomTabBarContextProvider } from './src/Contexts';
 import Components from './src/Components';
 import Constants from 'expo-constants';
 import Hyperview from 'hyperview';
+import LoadingScreen from './src/loading-screen';
 import { NavigationContainer } from '@react-navigation/native';
 import React from 'react';
 import { View } from 'react-native';
@@ -36,6 +37,7 @@ export default () => (
                 entrypointUrl={`${Constants.expoConfig?.extra?.baseUrl}/hyperview/public/index.xml`}
                 fetch={fetchWrapper}
                 formatDate={formatDate}
+                loadingScreen={LoadingScreen}
                 logger={new Logger(Logger.Level.log)}
                 navigationComponents={{
                   BottomTabBar,

--- a/demo/backend/navigation/navigator/stack/index.xml.njk
+++ b/demo/backend/navigation/navigator/stack/index.xml.njk
@@ -9,6 +9,6 @@ hv_button_behavior: "back"
 <doc xmlns="https://hyperview.org/hyperview">
   <navigator id="simple-stack-navigator" type="stack">
     <nav-route id="simple-screen-route" href="/hyperview/public/navigation/navigator/stack/screen.xml"/>
-    <nav-route id="modal-blue-loader" href="/hyperview/public/navigation/navigator/stack/modal-1.xml" modal="true" />
+    <nav-route id="modal-route" href="/hyperview/public/navigation/navigator/stack/modal-1.xml" modal="true" />
   </navigator>
 </doc>

--- a/demo/backend/navigation/navigator/stack/index.xml.njk
+++ b/demo/backend/navigation/navigator/stack/index.xml.njk
@@ -9,5 +9,6 @@ hv_button_behavior: "back"
 <doc xmlns="https://hyperview.org/hyperview">
   <navigator id="simple-stack-navigator" type="stack">
     <nav-route id="simple-screen-route" href="/hyperview/public/navigation/navigator/stack/screen.xml"/>
+    <nav-route id="modal-blue-loader" href="/hyperview/public/navigation/navigator/stack/modal-1.xml" modal="true" />
   </navigator>
 </doc>

--- a/demo/backend/ui/ui-elements/content.xml.njk
+++ b/demo/backend/ui/ui-elements/content.xml.njk
@@ -1,3 +1,3 @@
-{% set hv_section_list_tag = "UI/UI Elements/Text,UI/UI Elements/View,UI/UI Elements/Image,UI/UI Elements/Forms,UI/UI Elements/List,UI/UI Elements/Section List,UI/UI Elements/Web View" %}
+{% set hv_section_list_tag = "UI/UI Elements/Text,UI/UI Elements/View,UI/UI Elements/Image,UI/UI Elements/Forms,UI/UI Elements/List,UI/UI Elements/Section List,UI/UI Elements/Loading Screen,UI/UI Elements/Web View" %}
 {% set list_href = "/hyperview/public/ui/ui-elements/index.xml" %}
 {% include 'templates/section-list.xml.njk' %}

--- a/demo/backend/ui/ui-elements/loading-screen/index.xml.njk
+++ b/demo/backend/ui/ui-elements/loading-screen/index.xml.njk
@@ -1,0 +1,42 @@
+---
+permalink: "/ui/ui-elements/loading-screen/index.xml"
+tags: "UI/UI Elements/Loading Screen"
+hv_title: "Loading Screen"
+hv_button_behavior: "back"
+---
+{% extends 'templates/scrollview.xml.njk' %}
+{% from 'macros/description/index.xml.njk' import description %}
+{% from 'macros/button/index.xml.njk' import button %}
+
+{% block content %}
+  {{ description('Clicking each button will open a modal and show a loader until the content is ready.') }}
+  {{ description('Note: the fetch may be too fast on localhost to see the loader.') }}
+
+  {# The behavior element is passed into the `loadingScreen` component passed in App.tsx #}
+  {% call button('New with behavior loader') -%}
+    <behavior action="new" href="/hyperview/public/ui/ui-elements/loading-screen/modal.xml" />
+  {%- endcall %}
+
+  {# `custom-loader` screen is provided below #}
+  {% call button('New with doc loader') -%}
+    <behavior action="new" href="/hyperview/public/navigation/behaviors/actions/modal/index.xml" show-during-load="custom-loader" />
+  {%- endcall %}
+
+  {% call button('New with default loader') -%}
+    <behavior action="new" href="/hyperview/public/navigation/behaviors/actions/modal/index.xml" />
+  {%- endcall %}
+{% endblock %}
+
+{% block custom_screen %}
+  <screen id="custom-loader">
+    <styles>
+      {% include 'templates/styles.xml.njk' %}
+    </styles>
+    <body style="body" safe-area="true">
+      <view style="loading">
+        <text style="loading-text">This may take a while…</text>
+        <spinner/>
+      </view>
+    </body>
+  </screen>
+{% endblock %}

--- a/demo/backend/ui/ui-elements/loading-screen/modal.xml.njk
+++ b/demo/backend/ui/ui-elements/loading-screen/modal.xml.njk
@@ -1,0 +1,13 @@
+---
+permalink: "/ui/ui-elements/loading-screen/modal.xml"
+hv_title: "Modal"
+hv_button_behavior: "close"
+hv_open_modal: "true"
+---
+{% extends 'templates/scrollview.xml.njk' %}
+{% from 'macros/description/index.xml.njk' import description %}
+{% from 'macros/button/index.xml.njk' import button %}
+
+{% block content %}
+  {{ description('This modal showed a specific loader based on its url') }}
+{% endblock %}

--- a/demo/src/loading-screen/behavior-loading-screen.tsx
+++ b/demo/src/loading-screen/behavior-loading-screen.tsx
@@ -1,0 +1,23 @@
+import { ActivityIndicator, Text, View } from 'react-native';
+import React from 'react';
+
+/**
+ * Example loadingScreen used in stack navigation
+ */
+const BehaviorLoadingScreen = () => {
+  return (
+    <View
+      style={{
+        alignItems: 'center',
+        flex: 1,
+        gap: 10,
+        justifyContent: 'center',
+      }}
+    >
+      <Text>Loading a modal from a behavior ...</Text>
+      <ActivityIndicator />
+    </View>
+  );
+};
+
+export default BehaviorLoadingScreen;

--- a/demo/src/loading-screen/index.tsx
+++ b/demo/src/loading-screen/index.tsx
@@ -1,0 +1,37 @@
+import { ActivityIndicator, View } from 'react-native';
+import BehaviorLoadingScreen from './behavior-loading-screen';
+import type { Props } from './types';
+import React from 'react';
+import StackLoadingScreen from './stack-loading-screen';
+
+/**
+ * Example loadingScreen passed into Hyperview in App.tsx
+ * This component shows how to use the `element` prop to determine affect the loading screen
+ */
+const LoadingScreen = (props: Props) => {
+  const href = props.element?.getAttribute('href');
+
+  // Show a specific loading screen for this href
+  if (href === '/hyperview/public/ui/ui-elements/loading-screen/modal.xml') {
+    return <BehaviorLoadingScreen />;
+  }
+
+  // Show a specific loading screen for this href
+  if (href === '/hyperview/public/navigation/navigator/stack/modal-1.xml') {
+    return <StackLoadingScreen />;
+  }
+  return (
+    <View
+      style={{
+        alignItems: 'center',
+        flex: 1,
+        gap: 10,
+        justifyContent: 'center',
+      }}
+    >
+      <ActivityIndicator />
+    </View>
+  );
+};
+
+export default LoadingScreen;

--- a/demo/src/loading-screen/stack-loading-screen.tsx
+++ b/demo/src/loading-screen/stack-loading-screen.tsx
@@ -1,0 +1,23 @@
+import { ActivityIndicator, Text, View } from 'react-native';
+import React from 'react';
+
+/**
+ * Example loadingScreen used in stack navigation
+ */
+const StackLoadingScreen = () => {
+  return (
+    <View
+      style={{
+        alignItems: 'center',
+        flex: 1,
+        gap: 10,
+        justifyContent: 'center',
+      }}
+    >
+      <Text>Loading a modal from navigation hierarchy ...</Text>
+      <ActivityIndicator />
+    </View>
+  );
+};
+
+export default StackLoadingScreen;

--- a/demo/src/loading-screen/types.ts
+++ b/demo/src/loading-screen/types.ts
@@ -1,0 +1,1 @@
+export type Props = { element?: Element };

--- a/docs/reference_loading_screen.md
+++ b/docs/reference_loading_screen.md
@@ -37,11 +37,11 @@ The optional element which is passed into the loading screen provides a way to m
 
 ### Example
 
-The following example shows how to use the `id` attribute of the `<behavior>` element to colorize the load indicator.
+The following example shows how to use the `href` attribute of the `<behavior>` element to colorize the load indicator.
 
 ```xml
 <view>
-  <behavior id="green-loader" action="new" href="/example.xml">
+  <behavior action="new" href="/example.xml">
 </view>
 ```
 
@@ -49,8 +49,8 @@ The following example shows how to use the `id` attribute of the `<behavior>` el
 import { ActivityIndicator, View } from 'react-native';
 
 const LoadingScreen = (props: Props) => {
-  const id = props.element?.getAttribute('id');
-  const color = id === 'green-loader' ? 'green' : defaultColor;
+  const href = props.element?.getAttribute('href');
+  const color = href === '/example.xml' ? 'green' : defaultColor;
   return (
     <View
       style={{


### PR DESCRIPTION
Relates to https://github.com/Instawork/hyperview/pull/1007

The demo updates must wait until the [loading screen feature](https://github.com/Instawork/hyperview/pull/1016) is released as demo points to the release version of Hyperview.

# Loading screen examples
A new "Loading Screen" subsection has been added to UI/UI Elements:
<img width="30%" src="https://github.com/user-attachments/assets/836a7d2b-ba53-4e0c-bf92-5eaf345b2e16" />

This section provides examples of
- using a custom loading screen which uses the `id` of the behavior to colorize the loader
- using a `<screen>` element from the document
- using the default loading screen

https://github.com/user-attachments/assets/2a893ed0-a71e-464d-89c8-67b3402bc469

# Nav-route example
The Navigation/Stack example has been updated to show how to customize the loading screen color based on the `id` of a `<nav-route>` element.

https://github.com/user-attachments/assets/7fcff03d-a747-4042-95c2-fcd3f431c1c6

[Asana](https://app.asana.com/0/1205761271270033/1209189434962929/f)