### PR TITLE
chore(navigation): simplify preload screen cache

### DIFF
--- a/src/contexts/navigator-map.tsx
+++ b/src/contexts/navigator-map.tsx
@@ -19,19 +19,27 @@ export const NavigatorMapContext = createContext<NavigatorMapContextProps>({
 
 type Props = { children: React.ReactNode };
 
+type PreloadScreen = {
+  element: Element;
+  id: number;
+};
 /**
  * Encapsulated context provider. The maps are intentionally not updating state; their purpose is to
  * store runtime information about the navigator and urls.
  */
 export function NavigatorMapProvider(props: Props) {
-  const [preloadMap] = useState<Map<number, Element>>(new Map());
+  const [preloadScreen, setPreloadScreen] = useState<PreloadScreen | null>(
+    null,
+  );
 
   const setPreload = (key: number, element: Element) => {
-    preloadMap.set(key, element);
+    setPreloadScreen({ element, id: key });
   };
 
   const getPreload = (key: number): Element | undefined => {
-    return preloadMap.get(key);
+    return preloadScreen && preloadScreen.id === key
+      ? preloadScreen.element
+      : undefined;
   };
 
   return (

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -162,7 +162,7 @@ export default class HvScreen extends React.Component {
   componentWillUnmount() {
     const { params } = this.getRoute(this.props);
     const { preloadScreen } = params;
-    if (preloadScreen && this.navigation.getPreloadScreen(preloadScreen)) {
+    if (preloadScreen) {
       this.navigation.removePreloadScreen(preloadScreen);
     }
     if (this.state.url) {

--- a/src/services/navigation/index.ts
+++ b/src/services/navigation/index.ts
@@ -17,9 +17,7 @@ const getHrefKey = (href: string): string => href.split(QUERY_SEPARATOR)[0];
 const routeKeys: {
   [key: string]: string;
 } = {};
-const preloadScreens: {
-  [key: number]: Element;
-} = {};
+let cachedPreloadScreen: { element: Element; id: number } | null = null;
 
 export default class Navigation {
   url: string;
@@ -41,15 +39,21 @@ export default class Navigation {
     this.document = document;
   };
 
-  getPreloadScreen = (id: number): Element | null | undefined =>
-    preloadScreens[id];
+  getPreloadScreen = (id: number): Element | null | undefined => {
+    if (cachedPreloadScreen && cachedPreloadScreen.id === id) {
+      return cachedPreloadScreen.element;
+    }
+    return null;
+  };
 
   setPreloadScreen = (id: number, element: Element): void => {
-    preloadScreens[id] = element;
+    cachedPreloadScreen = { element, id };
   };
 
   removePreloadScreen = (id: number): void => {
-    delete preloadScreens[id];
+    if (cachedPreloadScreen && cachedPreloadScreen.id === id) {
+      cachedPreloadScreen = null;
+    }
   };
 
   getRouteKey = (href: string): string | null | undefined =>


### PR DESCRIPTION
The existing cache behavior creates a unique id for each navigation action's `show-during-load` element and may cause an accumulation of cached items, particularly in base screens which don't get unmounted. There is a cache at each level of the navigation hierarchy.

This change simplifies each cache by only keeping a single preload screen per cache. Every time a `set` is called, the previous element is replaced in the cache.

[Asana](https://app.asana.com/0/1204008699308084/1209017355656018/f)

