### PR TITLE
fix(hv-screen): delay should only be applied when loading document

### DIFF
--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -187,10 +187,6 @@ export default class HvScreen extends React.Component {
     const { params, key: routeKey } = this.getRoute(this.props);
 
     try {
-      if (params.delay) {
-        await later(parseInt(params.delay, 10));
-      }
-
       // If an initial document was passed, use it once and then remove
       let doc;
       let staleHeaderType;
@@ -198,6 +194,10 @@ export default class HvScreen extends React.Component {
         doc = this.initialDoc;
         this.initialDoc = null;
       } else {
+        if (params.delay) {
+          await later(parseInt(params.delay, 10));
+        }
+
         // eslint-disable-next-line react/no-access-state-in-setstate
         const {
           doc: loadedDoc,


### PR DESCRIPTION
Resolving a bug where a delay in the behavior is applied to both the triggering of the behavior and the subsequent document injection.

Example:
```
<behavior action="new" delay="1000" href="/hyperview/public/navigation/behaviors/actions/modal/index.xml" show-during-load="loading-screen" />
```

| Before | After |
| -- | -- |
| ![before](https://github.com/user-attachments/assets/2788818b-78d6-4c94-991e-b7aa7ec2b82e) | ![after](https://github.com/user-attachments/assets/574ae86b-c4a7-451c-b87c-c7a5a8219ddf)


[Asana](https://app.asana.com/0/1204008699308084/1209072402643062/f)