### PR TITLE
feat(network-retry): add retry event to behavior

### DIFF
--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -149,6 +149,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
     formData: FormData | null | undefined,
     onUpdateCallbacks: OnUpdateCallbacks,
     networkRetryAction: XNetworkRetryAction | null | undefined,
+    networkRetryEvent: string | null | undefined,
   ): Promise<Element | null> => {
     if (!href) {
       Logging.error(new Error('No href passed to fetchElement'));
@@ -175,6 +176,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
         formData || null,
         httpMethod,
         networkRetryAction,
+        networkRetryEvent,
       );
       if (staleHeaderType) {
         // We are doing this to ensure that we keep the screen stale until a `reload` happens
@@ -344,6 +346,9 @@ export default class Hyperview extends PureComponent<Types.Props> {
     const networkRetryAction = behaviorElement?.getAttribute(
       'network-retry-action',
     ) as XNetworkRetryAction | null | undefined;
+    const networkRetryEvent = behaviorElement?.getAttribute(
+      'network-retry-event',
+    ) as string | null | undefined;
 
     const showIndicatorIdList = showIndicatorIds
       ? Xml.splitAttributeList(showIndicatorIds)
@@ -389,6 +394,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
           formData,
           onUpdateCallbacks,
           networkRetryAction,
+          networkRetryEvent,
         ).then(newElement => {
           // If a target is specified and exists, use it. Otherwise, the action target defaults
           // to the element triggering the action.

--- a/src/services/dom/parser.ts
+++ b/src/services/dom/parser.ts
@@ -60,6 +60,7 @@ export class Parser {
     httpMethod: HttpMethod | null | undefined = undefined,
     acceptContentType: string = CONTENT_TYPE.APPLICATION_VND_HYPERVIEW_XML,
     networkRetryAction: XNetworkRetryAction | null | undefined = undefined,
+    networkRetryEvent: string | null | undefined = undefined,
   ): Promise<{
     doc: Document;
     staleHeaderType: XResponseStaleReason | null | undefined;
@@ -85,6 +86,9 @@ export class Parser {
         [HTTP_HEADERS.X_HYPERVIEW_DIMENSIONS]: `${width}w ${height}h`,
         ...(networkRetryAction && {
           [HTTP_HEADERS.X_NETWORK_RETRY_ACTION]: networkRetryAction,
+        }),
+        ...(networkRetryEvent && {
+          [HTTP_HEADERS.X_NETWORK_RETRY_EVENT]: networkRetryEvent,
         }),
       },
       method,
@@ -169,6 +173,7 @@ export class Parser {
     data: FormData | null,
     method: HttpMethod | null = HTTP_METHODS.GET,
     networkRetryAction: XNetworkRetryAction | null | undefined,
+    networkRetryEvent: string | null | undefined,
   ): Promise<{
     doc: Document;
     staleHeaderType: XResponseStaleReason | null | undefined;
@@ -179,6 +184,7 @@ export class Parser {
       method,
       CONTENT_TYPE.APPLICATION_VND_HYPERVIEW_FRAGMENT_XML,
       networkRetryAction,
+      networkRetryEvent,
     );
     const docElement = getFirstTag(doc, LOCAL_NAME.DOC);
     if (docElement) {

--- a/src/services/dom/types.ts
+++ b/src/services/dom/types.ts
@@ -4,6 +4,7 @@ export const HTTP_HEADERS = {
   X_HYPERVIEW_DIMENSIONS: 'X-Hyperview-Dimensions',
   X_HYPERVIEW_VERSION: 'X-Hyperview-Version',
   X_NETWORK_RETRY_ACTION: 'X-Network-Retry-Action',
+  X_NETWORK_RETRY_EVENT: 'X-Network-Retry-Event',
   X_RESPONSE_STALE_REASON: 'X-Response-Stale-Reason',
 } as const;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -256,6 +256,7 @@ export const BEHAVIOR_ATTRIBUTES = {
   HREF_STYLE: 'href-style',
   IMMEDIATE: 'immediate',
   NetworkRetryAction: 'network-retry-action',
+  NetworkRetryEvent: 'network-retry-event',
   NEW_VALUE: 'new-value',
   ONCE: 'once',
   SHOW_DURING_LOAD: 'show-during-load',


### PR DESCRIPTION
Support `network-retry-event` on core behavior and pass it down via request headers. This will be used downstream to retry eligible requests.