### PR TITLE
fix(loadingscreen): always pass behavior element

### DIFF
--- a/src/services/navigation/index.ts
+++ b/src/services/navigation/index.ts
@@ -101,13 +101,15 @@ export default class Navigation {
         if (registerPreload) {
           registerPreload(preloadScreen, loadingScreen);
         }
-      } else if (opts.behaviorElement) {
-        // Pass the behavior element to the loading screen
-        behaviorElementId = Date.now();
-        this.setPreloadScreen(behaviorElementId, opts.behaviorElement);
-        if (registerPreload) {
-          registerPreload(behaviorElementId, opts.behaviorElement);
-        }
+      }
+    }
+
+    if (!preloadScreen && opts.behaviorElement) {
+      // Pass the behavior element to the loading screen
+      behaviorElementId = Date.now();
+      this.setPreloadScreen(behaviorElementId, opts.behaviorElement);
+      if (registerPreload) {
+        registerPreload(behaviorElementId, opts.behaviorElement);
       }
     }
 


### PR DESCRIPTION
Passing behavior element to loading screen should not be conditional on the presence of a `show-during-load` attribute.