### PR TITLE
chore(navigation): remove support for externally provided navigation

### DIFF
--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -26,7 +26,6 @@ import {
 } from 'hyperview/src/types';
 import React, { PureComponent } from 'react';
 import HvRoute from 'hyperview/src/core/components/hv-route';
-import HvScreen from 'hyperview/src/core/components/hv-screen';
 import { Linking } from 'react-native';
 import { XNetworkRetryAction } from 'hyperview/src/services/dom/types';
 
@@ -547,40 +546,6 @@ export default class Hyperview extends PureComponent<Types.Props> {
   };
 
   render() {
-    if (this.props.navigation) {
-      // Externally provided navigation will use the provided navigation and action callbacks
-      return (
-        <Contexts.RefreshControlComponentContext.Provider
-          value={this.props.refreshControl}
-        >
-          <HvScreen
-            back={this.props.back}
-            behaviors={this.props.behaviors}
-            closeModal={this.props.closeModal}
-            components={this.props.components}
-            elementErrorComponent={this.props.elementErrorComponent}
-            entrypointUrl={this.props.entrypointUrl}
-            errorScreen={this.props.errorScreen}
-            fetch={this.props.fetch}
-            formatDate={this.props.formatDate}
-            loadingScreen={this.props.loadingScreen}
-            navigate={this.props.navigate}
-            navigation={this.props.navigation}
-            onError={this.props.onError}
-            onParseAfter={this.props.onParseAfter}
-            onParseBefore={this.props.onParseBefore}
-            onUpdate={this.onUpdate}
-            openModal={this.props.openModal}
-            push={this.props.push}
-            refreshControl={this.props.refreshControl}
-            reload={this.reload}
-            route={this.props.route}
-          />
-        </Contexts.RefreshControlComponentContext.Provider>
-      );
-    }
-
-    // Without an external navigation, all navigation is handled internally
     return (
       <Contexts.DateFormatContext.Provider value={this.props.formatDate}>
         <Contexts.RefreshControlComponentContext.Provider

--- a/src/core/components/hv-root/types.ts
+++ b/src/core/components/hv-root/types.ts
@@ -1,11 +1,9 @@
 import * as Logging from 'hyperview/src/services/logging';
-import * as NavigatorService from 'hyperview/src/services/navigator';
 import { ComponentType, ReactNode } from 'react';
 import type {
   Fetch,
   HvBehavior,
   HvComponent,
-  NavigationRouteParams,
   Route,
 } from 'hyperview/src/types';
 import type { Props as ErrorProps } from 'hyperview/src/core/components/load-error';
@@ -23,9 +21,6 @@ export type Props = {
   ) => string | undefined;
   refreshControl?: ComponentType<RefreshControlProps>;
   navigationComponents?: NavigationComponents;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  navigation?: any;
-  route?: NavigatorService.Route<string, { url?: string }>;
   entrypointUrl: string;
   fetch: Fetch;
   onError?: (error: Error) => void;
@@ -33,18 +28,11 @@ export type Props = {
   onParseBefore?: (url: string) => void;
   onRouteBlur?: (route: Route) => void;
   onRouteFocus?: (route: Route) => void;
-  url?: string;
-  back?: (params: NavigationRouteParams | object | undefined) => void;
-  closeModal?: (params: NavigationRouteParams | object | undefined) => void;
-  navigate?: (params: NavigationRouteParams | object, key: string) => void;
-  openModal?: (params: NavigationRouteParams | object) => void;
-  push?: (params: object) => void;
   behaviors?: HvBehavior[];
   components?: HvComponent[];
   elementErrorComponent?: ComponentType<ErrorProps>;
   errorScreen?: ComponentType<ErrorProps>;
   loadingScreen?: ComponentType<LoadingProps>;
   handleBack?: ComponentType<{ children: ReactNode }>;
-  doc?: Document;
   logger?: Logging.Logger;
 };

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -32,4 +32,5 @@ export type Props = Omit<
   reload: Reload;
   removePreload?: (id: number) => void;
   route?: NavigatorService.Route<string, { url?: string }>;
+  url?: string;
 };

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -1,12 +1,26 @@
-import type { HvComponentOnUpdate, Reload } from 'hyperview/src/types';
+import * as NavigatorService from 'hyperview/src/services/navigator';
+import type {
+  HvComponentOnUpdate,
+  NavigationRouteParams,
+  Reload,
+} from 'hyperview/src/types';
 import { Props as HvRootProps } from 'hyperview/src/core/components/hv-root/types';
 
 /**
  * All of the props used by hv-screen
  */
 export type Props = HvRootProps & {
+  back?: (params: NavigationRouteParams | object | undefined) => void;
+  closeModal?: (params: NavigationRouteParams | object | undefined) => void;
+  doc?: Document;
+  navigate?: (params: NavigationRouteParams | object, key: string) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  navigation?: any;
   onUpdate: HvComponentOnUpdate;
+  openModal?: (params: NavigationRouteParams | object) => void;
+  push?: (params: object) => void;
   registerPreload?: (id: number, element: Element) => void;
   reload: Reload;
   removePreload?: (id: number) => void;
+  route?: NavigatorService.Route<string, { url?: string }>;
 };

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -9,7 +9,16 @@ import { Props as HvRootProps } from 'hyperview/src/core/components/hv-root/type
 /**
  * All of the props used by hv-screen
  */
-export type Props = HvRootProps & {
+export type Props = Omit<
+  HvRootProps,
+  | 'refreshControl'
+  | 'navigationComponents'
+  | 'onRouteBlur'
+  | 'onRouteFocus'
+  | 'loadingScreen'
+  | 'handleBack'
+  | 'logger'
+> & {
   back?: (params: NavigationRouteParams | object | undefined) => void;
   closeModal?: (params: NavigationRouteParams | object | undefined) => void;
   doc?: Document;


### PR DESCRIPTION
Removing legacy support for external navigation

Step 1: hv-root is updated to remove the multiple hierarchies.
- https://github.com/Instawork/hyperview/pull/1029/commits/f18fd436eba3a073549a8bfaaf1acb4a998e50ed

[Asana](https://app.asana.com/0/1204008699308084/1209086306165666/f)

Step 2: update the exposed props for `hv-root` (public Hyperview)
- [chore: remove unneeded external props, move to internal](https://github.com/Instawork/hyperview/pull/1029/commits/962c7947cc83ef3217126c8ef249508e6197e2ee)
- [chore: limit to only required props](https://github.com/Instawork/hyperview/pull/1029/commits/7336dfdd5395835b430a47f474d99542a72fe539)

[Asana](https://app.asana.com/0/1204008699308084/1209086306165667/f)