### PR TITLE
chore(loading screen): remove duplicate screen cache

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -372,6 +372,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
             errorScreen={this.props.errorScreen}
             fetch={this.props.fetch}
             formatDate={formatter}
+            getPreload={this.props.getPreload}
             navigate={this.navLogic.navigate}
             navigation={this.props.navigation}
             onError={this.props.onError}

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -93,7 +93,7 @@ export default class HvScreen extends React.Component {
     const url = params.url || this.props.entrypointUrl || null;
 
     const preloadScreen = params.preloadScreen
-      ? this.navigation.getPreloadScreen(params.preloadScreen)
+      ? this.props.getPreload(params.preloadScreen)
       : null;
     const preloadStyles = preloadScreen
       ? Stylesheets.createStylesheets(preloadScreen)
@@ -146,7 +146,7 @@ export default class HvScreen extends React.Component {
       this.needsLoad = true;
 
       const preloadScreen = newPreloadScreen
-        ? this.navigation.getPreloadScreen(newPreloadScreen)
+        ? this.props.getPreload(newPreloadScreen)
         : null;
 
       const doc = preloadScreen || this.doc;

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -22,6 +22,7 @@ export type Props = Omit<
   back?: (params: NavigationRouteParams | object | undefined) => void;
   closeModal?: (params: NavigationRouteParams | object | undefined) => void;
   doc?: Document;
+  getPreload?: (id: number) => Element | undefined;
   navigate?: (params: NavigationRouteParams | object, key: string) => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   navigation?: any;

--- a/src/services/navigation/index.ts
+++ b/src/services/navigation/index.ts
@@ -17,9 +17,6 @@ const getHrefKey = (href: string): string => href.split(QUERY_SEPARATOR)[0];
 const routeKeys: {
   [key: string]: string;
 } = {};
-const preloadScreens: {
-  [key: number]: Element;
-} = {};
 
 export default class Navigation {
   url: string;
@@ -39,17 +36,6 @@ export default class Navigation {
 
   setDocument = (document: Document) => {
     this.document = document;
-  };
-
-  getPreloadScreen = (id: number): Element | null | undefined =>
-    preloadScreens[id];
-
-  setPreloadScreen = (id: number, element: Element): void => {
-    preloadScreens[id] = element;
-  };
-
-  removePreloadScreen = (id: number): void => {
-    delete preloadScreens[id];
   };
 
   getRouteKey = (href: string): string | null | undefined =>
@@ -97,7 +83,6 @@ export default class Navigation {
       ).find(s => s && s.getAttribute('id') === showIndicatorId);
       if (loadingScreen) {
         preloadScreen = Date.now(); // Not truly unique but sufficient for our use-case
-        this.setPreloadScreen(preloadScreen, loadingScreen);
         if (registerPreload) {
           registerPreload(preloadScreen, loadingScreen);
         }
@@ -107,7 +92,6 @@ export default class Navigation {
     if (!preloadScreen && opts.behaviorElement) {
       // Pass the behavior element to the loading screen
       behaviorElementId = Date.now();
-      this.setPreloadScreen(behaviorElementId, opts.behaviorElement);
       if (registerPreload) {
         registerPreload(behaviorElementId, opts.behaviorElement);
       }


### PR DESCRIPTION
The preload screen cache in `services/navigation` was redundant with the external context-provided cache. The service cache is removed and `hv-screen` is updated to receive the function from props.

`<screen>` based loading functionality tested in demo app.

[Asana](https://app.asana.com/0/1204008699308084/1209086306165670/f)