### PR TITLE
chore(navigation): remove unused route key

### DIFF
--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -172,9 +172,6 @@ export default class HvScreen extends React.Component {
     if (behaviorElementId) {
       this.props.removePreload?.(behaviorElementId);
     }
-    if (this.state.url) {
-      this.navigation.removeRouteKey(this.state.url);
-    }
   }
 
   /**
@@ -191,7 +188,7 @@ export default class HvScreen extends React.Component {
    * Performs a full load of the screen.
    */
   load = async () => {
-    const { params, key: routeKey } = this.getRoute(this.props);
+    const { params } = this.getRoute(this.props);
 
     try {
       // If an initial document was passed, use it once and then remove
@@ -214,7 +211,6 @@ export default class HvScreen extends React.Component {
         staleHeaderType = loadedType;
       }
       const stylesheets = Stylesheets.createStylesheets(doc);
-      this.navigation.setRouteKey(this.state.url, routeKey);
       this.setState({
         doc,
         elementError: null,

--- a/src/services/navigation/index.ts
+++ b/src/services/navigation/index.ts
@@ -10,13 +10,6 @@ import type {
 import { NAV_ACTIONS } from 'hyperview/src/types';
 
 export const ANCHOR_ID_SEPARATOR = '#';
-const QUERY_SEPARATOR = '?';
-
-const getHrefKey = (href: string): string => href.split(QUERY_SEPARATOR)[0];
-
-const routeKeys: {
-  [key: string]: string;
-} = {};
 
 export default class Navigation {
   url: string;
@@ -36,17 +29,6 @@ export default class Navigation {
 
   setDocument = (document: Document) => {
     this.document = document;
-  };
-
-  getRouteKey = (href: string): string | null | undefined =>
-    routeKeys[getHrefKey(href)];
-
-  setRouteKey = (href: string, key: string): void => {
-    routeKeys[getHrefKey(href)] = key;
-  };
-
-  removeRouteKey = (href: string): void => {
-    delete routeKeys[getHrefKey(href)];
   };
 
   navigate = (
@@ -125,12 +107,7 @@ export default class Navigation {
         this.navigation.push(routeParams);
         break;
       case NAV_ACTIONS.NAVIGATE: {
-        const key = this.getRouteKey(url);
-        if (key) {
-          this.navigation.navigate(routeParams, this.getRouteKey(url));
-        } else {
-          this.navigation.push(routeParams);
-        }
+        this.navigation.navigate(routeParams);
         break;
       }
       case NAV_ACTIONS.NEW:

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -269,8 +269,6 @@ export const getNavigatorById = (
 
 /**
  * Determine the action to perform based on the route params
- * Correct for a push action being introduced in
- * `this.getRouteKey(url);` in `hyperview/src/services/navigation`
  * Url fragments are treated as a navigate action
  */
 export const getNavAction = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -380,10 +380,7 @@ export type NavigationRouteParams = {
 export type NavigationProps = {
   back: (routeParams?: NavigationRouteParams | undefined) => void;
   closeModal: (routeParams?: NavigationRouteParams | undefined) => void;
-  navigate: (
-    routeParams: NavigationRouteParams,
-    key?: string | null | undefined,
-  ) => void;
+  navigate: (routeParams: NavigationRouteParams) => void;
   openModal: (routeParams: NavigationRouteParams) => void;
   push: (routeParams: NavigationRouteParams) => void;
 };


### PR DESCRIPTION
The route key and associated cache were a relic of external navigation and are not required for HV navigation.

[Asana](https://app.asana.com/0/1204008699308084/1209189437518181/f)