### PR TITLE
fix(demo): `set-value` examples issues 

### DIFF
--- a/demo/backend/behaviors/advanced/set-value/_clear-delay/index.xml.njk
+++ b/demo/backend/behaviors/advanced/set-value/_clear-delay/index.xml.njk
@@ -2,7 +2,6 @@
 
 {% call link("Clear all with delay") -%}
   <behavior action="set-value" new-value="" target="id_tf" delay="500"/>
-  <behavior action="set-value" new-value="" target="id_ta" delay="1000"/>
   <behavior action="set-value" new-value="" target="id_ss" delay="1500"/>
   <behavior action="set-value" new-value="" target="id_pf" delay="2000"/>
   <behavior action="set-value" new-value="" target="id_df" delay="2500"/>

--- a/demo/backend/behaviors/advanced/set-value/_clear-indicator/index.xml.njk
+++ b/demo/backend/behaviors/advanced/set-value/_clear-indicator/index.xml.njk
@@ -2,7 +2,6 @@
 
 {% call link("Clear all with indicator") -%}
   <behavior action="set-value" new-value="" target="id_tf" delay="500" show-during-load="id_tf_loading"/>
-  <behavior action="set-value" new-value="" target="id_ta" delay="1000" show-during-load="id_ta_loading"/>
   <behavior action="set-value" new-value="" target="id_ss" delay="1500" show-during-load="id_ss_loading"/>
   <behavior action="set-value" new-value="" target="id_pf" delay="2000" show-during-load="id_pf_loading"/>
   <behavior action="set-value" new-value="" target="id_df" delay="2500" show-during-load="id_df_loading"/>

--- a/demo/backend/behaviors/advanced/set-value/_clear/index.xml.njk
+++ b/demo/backend/behaviors/advanced/set-value/_clear/index.xml.njk
@@ -2,7 +2,6 @@
 
 {% call link('Clear all') -%}
   <behavior action="set-value" new-value="" target="id_tf"/>
-  <behavior action="set-value" new-value="" target="id_ta"/>
   <behavior action="set-value" new-value="" target="id_pf"/>
   <behavior action="set-value" new-value="" target="id_ss"/>
   <behavior action="set-value" new-value="" target="id_df"/>

--- a/demo/backend/behaviors/advanced/set-value/_set-delay/index.xml.njk
+++ b/demo/backend/behaviors/advanced/set-value/_set-delay/index.xml.njk
@@ -2,7 +2,6 @@
 
 {% call link("Set all with delay") -%}
   <behavior action="set-value" new-value="Multi" target="id_tf" delay="500"/>
-  <behavior action="set-value" new-value="Multi" target="id_ta" delay="1000"/>
   <behavior action="set-value" new-value="Ramen" target="id_ss" delay="1500"/>
   <behavior action="set-value" new-value="2" target="id_pf" delay="2000"/>
   <behavior action="set-value" new-value="2019-04-02" target="id_df" delay="2500"/>

--- a/demo/backend/behaviors/advanced/set-value/_set-indicator/index.xml.njk
+++ b/demo/backend/behaviors/advanced/set-value/_set-indicator/index.xml.njk
@@ -2,7 +2,6 @@
 
 {% call link("Set all with indicator") -%}
   <behavior action="set-value" new-value="Multi" target="id_tf" delay="500" show-during-load="id_tf_loading"/>
-  <behavior action="set-value" new-value="Multi" target="id_ta" delay="1000" show-during-load="id_ta_loading"/>
   <behavior action="set-value" new-value="Ramen" target="id_ss" delay="1500" show-during-load="id_ss_loading"/>
   <behavior action="set-value" new-value="2" target="id_pf" delay="2000" show-during-load="id_pf_loading"/>
   <behavior action="set-value" new-value="2019-04-02" target="id_df" delay="2500" show-during-load="id_df_loading"/>

--- a/demo/backend/behaviors/advanced/set-value/_set/index.xml.njk
+++ b/demo/backend/behaviors/advanced/set-value/_set/index.xml.njk
@@ -2,7 +2,6 @@
 
 {% call link("Set all") -%}
   <behavior action="set-value" new-value="Multi" target="id_tf"/>
-  <behavior action="set-value" new-value="Multi" target="id_ta"/>
   <behavior action="set-value" new-value="Ramen" target="id_ss"/>
   <behavior action="set-value" new-value="2" target="id_pf"/>
   <behavior action="set-value" new-value="2019-04-02" target="id_df"/>


### PR DESCRIPTION
The cleanup of "text area" missed removing the behaviors.

Relates to https://github.com/Instawork/hyperview/pull/1034

[Asana](https://app.asana.com/0/1205761271270033/1209017355656026/f)