### PR TITLE
feat(demo): add delay for localhost fetch

### DIFF
--- a/demo/src/Helpers/misc.ts
+++ b/demo/src/Helpers/misc.ts
@@ -1,3 +1,4 @@
+import Constants from 'expo-constants';
 import moment from 'moment';
 
 export const formatDate = (
@@ -9,7 +10,7 @@ export const fetchWrapper = (
   input: RequestInfo | URL,
   init: RequestInit | undefined = { headers: {} },
 ): Promise<Response> => {
-  return fetch(input, {
+  const response = fetch(input, {
     ...init,
     headers: {
       // Don't cache requests for the demo
@@ -19,5 +20,14 @@ export const fetchWrapper = (
       ...init.headers,
     },
     mode: 'cors',
+  });
+
+  const baseUrl = Constants.expoConfig?.extra?.baseUrl;
+  const delayTime = baseUrl && input.toString().startsWith(baseUrl) ? 750 : 0;
+
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve(response);
+    }, delayTime);
   });
 };


### PR DESCRIPTION
After [fixing a bug in Hyperview](https://github.com/Instawork/hyperview/pull/1014), the demo application no longer shows loading indicators in localhost because it loads immediately.

This update introduces an artificial delay when running in localhost

[Asana](https://app.asana.com/0/1205761271270033/1209189437518211/f)