### PR TITLE
chore(navigation): remove unused doc cache

### DIFF
--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -222,7 +222,6 @@ export default class Hyperview extends PureComponent<Types.Props> {
           targetId,
         } = options;
         const delayVal: number = +(delay || '');
-        navigation.setDocument(doc);
         navigation.navigate(
           href || Navigation.ANCHOR_ID_SEPARATOR,
           navAction,
@@ -236,6 +235,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
             targetId: targetId || undefined,
           },
           state.url,
+          doc,
           options.onUpdateCallbacks.setElement,
         );
       }

--- a/src/services/navigation/index.ts
+++ b/src/services/navigation/index.ts
@@ -14,18 +14,12 @@ export const ANCHOR_ID_SEPARATOR = '#';
 export default class Navigation {
   entrypointUrl: string;
 
-  document: Document | null | undefined = null;
-
   navigation: NavigationProps;
 
   constructor(url: string, navigation: NavigationProps) {
     this.entrypointUrl = url;
     this.navigation = navigation;
   }
-
-  setDocument = (document: Document) => {
-    this.document = document;
-  };
 
   navigate = (
     href: string,
@@ -34,6 +28,7 @@ export default class Navigation {
     componentRegistry: Components.Registry,
     opts: BehaviorOptions,
     stateUrl?: string | null,
+    doc?: Document | null,
     setElement?: (id: number, e: Element) => void,
   ): void => {
     const { showIndicatorId, delay, targetId } = opts;
@@ -55,8 +50,8 @@ export default class Navigation {
 
     let preloadScreen: number | null = null;
     let behaviorElementId: number | null = null;
-    if (indicatorId && this.document) {
-      const screens: HTMLCollectionOf<Element> = this.document.getElementsByTagNameNS(
+    if (indicatorId && doc) {
+      const screens: HTMLCollectionOf<Element> = doc.getElementsByTagNameNS(
         Namespaces.HYPERVIEW,
         'screen',
       );


### PR DESCRIPTION
The doc is available at the point the navigation method is called and doesn't need to be cached.

[Asana](https://app.asana.com/0/1204008699308084/1209189437518187/f)