### PR TITLE
fix(hvscreen): display error for missing content

### DIFF
--- a/src/core/components/hv-screen/errors.ts
+++ b/src/core/components/hv-screen/errors.ts
@@ -1,0 +1,8 @@
+/* eslint-disable instawork/error-object */
+/* eslint-disable max-classes-per-file */
+
+import * as ErrorService from 'hyperview/src/services/error';
+
+export class HvScreenRenderError extends ErrorService.HvBaseError {
+  name = 'HvScreenRenderError';
+}


### PR DESCRIPTION
Resolving an issue where Hyperview renders a white screen in certain cases. Instead of showing blank screen, show an error screen with options.

| Before | After |
| -- | -- |
| ![before](https://github.com/user-attachments/assets/8358869e-4d10-4439-8e11-c9d412499845) | ![after](https://github.com/user-attachments/assets/f4bc91d9-f21c-4352-b325-566a8fee5b14) |
| ![before](https://github.com/user-attachments/assets/13df870c-4f95-4b6c-a9e0-029c08992dac) | ![after](https://github.com/user-attachments/assets/af57daf3-9a4f-4c01-9e9c-4201d1aecce6) |


> The cause of the empty content is under investigation. This change improves the user experience.

[Asana](https://app.asana.com/0/1204008699308084/1209252349679167/f)