### PR TITLE
fix(demo): Advanced > Basic Forms styles

### DIFF
--- a/demo/backend/advanced/case-studies/basic-forms/index.xml.njk
+++ b/demo/backend/advanced/case-studies/basic-forms/index.xml.njk
@@ -6,7 +6,6 @@ hv_button_behavior: "back"
 ---
 {% extends 'templates/base.xml.njk' %}
 
-{# TBD rohanbayya: To fix this #}
 {% block styles %}
   {% include './_styles.xml.njk' %}
 {% endblock %}

--- a/demo/backend/advanced/case-studies/basic-forms/next.xml.njk
+++ b/demo/backend/advanced/case-studies/basic-forms/next.xml.njk
@@ -5,10 +5,12 @@ hv_button_behavior: "back"
 ---
 {% extends 'templates/base.xml.njk' %}
 
+{% from 'macros/description/index.xml.njk' import description %}
+
 {% block styles %}
   {% include './_styles.xml.njk' %}
 {% endblock %}
 
 {% block container %}
-  <text>Next page</text>
+  {{ description('Next page') }}
 {% endblock %}

--- a/demo/backend/advanced/case-studies/basic-forms/submit.xml
+++ b/demo/backend/advanced/case-studies/basic-forms/submit.xml
@@ -1,4 +1,4 @@
-<form id="myForm" xmlns="https://hyperview.org/hyperview">
+<form id="myForm"  scroll="true" xmlns="https://hyperview.org/hyperview">
   <view style="form-group">
     <text style="label">Label line</text>
     <text-field

--- a/demo/backend/advanced/case-studies/basic-forms/submit2.xml
+++ b/demo/backend/advanced/case-studies/basic-forms/submit2.xml
@@ -1,4 +1,4 @@
-<form id="myForm" xmlns="https://hyperview.org/hyperview">
+<form id="myForm" scroll="true" xmlns="https://hyperview.org/hyperview">
   <view style="form-group">
     <text style="label">Label line</text>
     <text-field


### PR DESCRIPTION
Add missing scroll attribute that causes layout to break.

https://app.asana.com/0/1205761271270033/1209017355656030/f

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/605032af-39e6-435b-9887-e70002a65ef8) | ![after](https://github.com/user-attachments/assets/e1fa79bf-b831-4f62-a48f-670772c76acd) |

