### PR TITLE
chore(text-field): add support for `auto-capitalize`

### DIFF
--- a/src/components/hv-text-field/index.tsx
+++ b/src/components/hv-text-field/index.tsx
@@ -41,6 +41,15 @@ const HvTextField = (props: HvComponentProps) => {
   const textContentType =
     (props.element.getAttribute('text-content-type') as TextContextType) ||
     'none';
+  // Force email addresses to have no auto-capitalization, others use default
+  const defaultCapitalization =
+    keyboardType === 'email-address' ? 'none' : undefined;
+  const autoCapitalize =
+    (props.element.getAttribute('auto-capitalize') as
+      | 'none'
+      | 'sentences'
+      | 'words'
+      | 'characters') || defaultCapitalization;
 
   // Handlers
   const setFocus = (focused: boolean) => {
@@ -104,6 +113,7 @@ const HvTextField = (props: HvComponentProps) => {
           props.options.registerInputHandler(ref);
         }
       }}
+      autoCapitalize={autoCapitalize}
       autoFocus={autoFocus}
       defaultValue={defaultValue}
       editable={editable}


### PR DESCRIPTION
Bug fix: Disable auto capitalization on email fields to fix iOS display bug.

Adding a new `auto-capitalize` attribute to the `text-field` component.

Android is unaffected as it was already using lowercase for the email field.

| Before | After |
| -- | -- |
| ![before](https://github.com/user-attachments/assets/8ff96ff3-d482-4aaf-b1fa-9dbb95a18133) | ![after](https://github.com/user-attachments/assets/baf0645e-bdc0-4e77-bbf9-13b6157752b8) |

[Asana](https://app.asana.com/0/1204008699308084/1209284165533416)