### PR TITLE
chore(schema): update for `autoCapitalize` feature

### DIFF
--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -1148,6 +1148,16 @@
       <xs:attribute name="type" type="xs:string" />
       <xs:attributeGroup ref="hv:behaviorAttributes" />
       <xs:attribute name="text-content-type" type="hv:text-content-type" />
+      <xs:attribute name="autoCapitalize">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="none" />
+            <xs:enumeration value="sentences" />
+            <xs:enumeration value="words" />
+            <xs:enumeration value="characters" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
 


### PR DESCRIPTION
Adding an `autoCapitalize` attribute into `text-field`.

Tested locally against changes made in https://github.com/Instawork/instawork/pull/36726

Required for https://github.com/Instawork/instawork/pull/36726