### PR TITLE
bug(behavior): example cause of white screen issue

### DIFF
--- a/demo/backend/ui/ui-elements/text/bug/index.xml.njk
+++ b/demo/backend/ui/ui-elements/text/bug/index.xml.njk
@@ -1,0 +1,39 @@
+---
+permalink: "/ui/ui-elements/text/bug/index.xml"
+tags: "UI/UI Elements/Text"
+hv_title: "Bug"
+hv_button_behavior: "back"
+---
+{% extends 'templates/scrollview.xml.njk' %}
+
+{% from 'macros/button/index.xml.njk' import button %}
+{% from 'macros/description/index.xml.njk' import description %}
+
+{% block content %}
+  {{ description("The following will fail in 1 second.") }}
+
+  <view id="broken-replace">
+    <text>
+      The parent view should be replaced by 'replace' behavior below.
+    </text>
+
+    {# This behavior will fail because the target will have been orphaned by the second behavior. #}
+    {# If it had a 'target' attribute, or if it didn't have a 'delay', it would work. #}
+    <behavior
+      action="replace"
+      trigger="load"
+      href="/hyperview/public/ui/ui-elements/text/bug/replacement.xml"
+      delay="1000"
+      once="true"
+    />
+
+    {# This behavior will orphan the target of the first behavior. #}
+    <behavior
+      action="show"
+      trigger="load"
+      target="broken-replace"
+      once="true"
+    />
+
+  </view>
+{% endblock %}

--- a/demo/backend/ui/ui-elements/text/bug/replacement.xml.njk
+++ b/demo/backend/ui/ui-elements/text/bug/replacement.xml.njk
@@ -1,0 +1,11 @@
+---
+permalink: "/ui/ui-elements/text/bug/replacement.xml"
+hv_title: "Bug"
+hv_button_behavior: "back"
+---
+
+<view xmlns="https://hyperview.org/hyperview">
+  <text>
+    This is the new content.
+  </text>
+</view>


### PR DESCRIPTION
This example reproduces the "behavior target" bug in the following way:
- All behaviors are direct dependents of the same `<view>` element
- The first behavior uses a `replace` action with no target specified
  - When this behavior is assigned, the `element` is cached - this is the view which contains the behaviors
  - This behavior has a delay so its action will not be immediately performed. This reproduces the case of any delay, whether that is assigned in the behavior or is the result of a fetch request
- The second behavior immediately performs a `show` action
  - The action mutates the `<view>` and clones it to a new doc which is used for further renders
- After the delay, the first behavior is performed
  - the content is fetched
  - since no `target` was defined, [the hv-root code will use the original `element`](https://github.com/Instawork/hyperview/blob/097deab3257089e884084f0cac71388e83720953/src/core/components/hv-root/index.tsx#L399-L404) (the view)
  - this view has since been orphaned by the `show` action
    - The [attempt to performUpdate](https://github.com/Instawork/hyperview/blob/947bf03c70398066e50620ff9750ff69b4838ea2/src/core/components/hv-root/index.tsx#L407-L411) with action `replace` fails because the element has no parentNode
    - The [doc which is assigned to state](https://github.com/Instawork/hyperview/blob/947bf03c70398066e50620ff9750ff69b4838ea2/src/core/components/hv-root/index.tsx#L424-L426) is also corrupt and has no parentNode
    - When the screen tries to render its new document, [it can't find a `body`](https://github.com/Instawork/hyperview/blob/947bf03c70398066e50620ff9750ff69b4838ea2/src/core/components/hv-screen/index.js#L273-L277) and so does not render the element

Log of the `element` passed in to hv-root/onUpdateFragment:
```xml
<view id="broken-replace" _hv-timeout-id="59359" hide="false" xmlns="https://hyperview.org/hyperview">
    <text>
      The parent view should be replaced by 'replace' behavior below.
    </text>
    <behavior action="replace" trigger="load" href="/hyperview/public/ui/ui-elements/text/bug/replacement.xml" delay="1000" once="true" ran-once="true"/>
    <behavior action="show" trigger="load" target="broken-replace" once="true" ran-once="true"/>
  </view>
```

log of `targetElement` immediately before [calling performUpdate](https://github.com/Instawork/hyperview/blob/947bf03c70398066e50620ff9750ff69b4838ea2/src/core/components/hv-root/index.tsx#L406-L411)
```xml
<view id="broken-replace" _hv-timeout-id="59359" hide="false" xmlns="https://hyperview.org/hyperview"/>
```


https://github.com/user-attachments/assets/4b1de4bc-cdf6-484e-8b39-4b73b7f49fca




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209310667884736