### PR TITLE
fix(ci): sync Hyperview code into demo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,12 @@ jobs:
           command: yarn
       - run:
           working_directory: demo
+          name: Demo - Sync hyperview
+          command: |
+            rm -rf node_modules/hyperview/src
+            cp -r ../src node_modules/hyperview
+      - run:
+          working_directory: demo
           name: Demo - Check types
           command: yarn test:ts
       - run:
@@ -56,6 +62,12 @@ jobs:
           working_directory: demo
           name: Install
           command: yarn
+      - run:
+          working_directory: demo
+          name: Sync hyperview
+          command: |
+            rm -rf node_modules/hyperview/src
+            cp -r ../src node_modules/hyperview
       - run:
           working_directory: demo
           name: Deploy


### PR DESCRIPTION
This helps getting the latest Hyperview changes into CI, before cutting a release. It is also helpful to have the changes from master deployed before a release.