### PR TITLE
fix(demo): back behavior triggers multiple times

### DIFF
--- a/demo/backend/behaviors/basic/triggers/back/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/back/index.xml.njk
@@ -24,7 +24,8 @@ hv_button_behavior: "back"
     >
       <alert:option alert:label="OK">
         <behavior action="hide" target="back_behaviors" />
-        <behavior action="back" />
+        <!-- the "delay" attribute is used to ensure the hide completes before 'back' is performed -->
+        <behavior action="back" delay="1"/>
       </alert:option>
       <alert:option alert:label="Cancel" />
     </behavior>


### PR DESCRIPTION
The demo at `Behaviors > Triggers > Back` frequently re-triggers.

This same demo appears also at `Navigation > Behaviors > Triggers > Back`. This version includes a delay on the `back` action to ensure the `hide` has completed. This delay was ported to fix the issue.

| Before | After |
| -- | -- |
| ![before](https://github.com/user-attachments/assets/80781a5f-0986-459d-9395-d9a72ae5acfa) | ![after](https://github.com/user-attachments/assets/7eeaafac-f452-4890-b76a-473924a726df) |

[Asana](https://app.asana.com/0/1204008699308084/1209227756307892)