### PR TITLE
fix: date picker style

### DIFF
--- a/demo/backend/_includes/templates/styles.xml.njk
+++ b/demo/backend/_includes/templates/styles.xml.njk
@@ -119,3 +119,26 @@
 />
 <style id="list-header-text" fontSize="18" fontWeight="bold"/>
 <style id="links-container" flexDirection="row" flexWrap="wrap" marginLeft="24" marginBottom="24" />
+<style
+  id="picker-modal"
+  backgroundColor="white"
+  borderTopColor="#E1E1E1"
+  borderTopWidth="1"
+  shadowOffsetX="0"
+  shadowOffsetY="-5"
+  shadowOpacity="0.2"
+  shadowRadius="5"
+/>
+<style id="picker-modal-overlay" backgroundColor="#1f1f1fa0" />
+<style
+  id="picker-modal-text"
+  color="blue"
+  fontSize="16"
+  fontWeight="600"
+  marginBottom="16"
+  padding="24"
+>
+  <modifier pressed="true">
+  <style opacity="0.5" />
+  </modifier>
+</style>

--- a/demo/backend/behaviors/advanced/set-value/index.xml.njk
+++ b/demo/backend/behaviors/advanced/set-value/index.xml.njk
@@ -54,30 +54,6 @@ hv_button_behavior: "back"
   <style id="input-text" fontSize="16" fontWeight="normal"></style>
   <style id="section" marginLeft="24" fontSize="18" fontWeight="bold" marginTop="8"/>
   <style
-    id="picker-modal"
-    backgroundColor="white"
-    borderTopColor="#E1E1E1"
-    borderTopWidth="1"
-    shadowOffsetX="0"
-    shadowOffsetY="-5"
-    shadowOpacity="0.2"
-    shadowRadius="5"/>
-  <style
-    id="picker-modal-overlay"
-    backgroundColor="#1f1f1fa0"
-  />
-  <style
-    id="picker-modal-text"
-    color="blue"
-    fontSize="16"
-    fontWeight="600"
-    marginBottom="16"
-    padding="24">
-    <modifier pressed="true">
-    <style opacity="0.5"/>
-    </modifier>
-  </style>
-  <style
     id="tags"
     flex="1"
     flexDirection="row"

--- a/demo/backend/behaviors/basic/triggers/blur/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/blur/index.xml.njk
@@ -43,29 +43,6 @@ hv_button_behavior: "back"
   </style>
   <style id="tip" color="#FF4847" fontSize="16" />
   <style id="input-text" fontSize="16" fontWeight="normal" />
-  <style
-    id="picker-modal"
-    backgroundColor="white"
-    borderTopColor="#E1E1E1"
-    borderTopWidth="1"
-    shadowOffsetX="0"
-    shadowOffsetY="-5"
-    shadowOpacity="0.2"
-    shadowRadius="5"
-  />
-  <style id="picker-modal-overlay" backgroundColor="#1f1f1fa0" />
-  <style
-    id="picker-modal-text"
-    color="blue"
-    fontSize="16"
-    fontWeight="600"
-    marginBottom="16"
-    padding="24"
-  >
-    <modifier pressed="true">
-    <style opacity="0.5" />
-    </modifier>
-  </style>
 {% endblock %}
 
 {% block content %}

--- a/demo/backend/behaviors/basic/triggers/change/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/change/index.xml.njk
@@ -43,29 +43,6 @@ hv_button_behavior: "back"
   </style>
   <style id="tip" color="#FF4847" fontSize="16" />
   <style id="input-text" fontSize="16" fontWeight="normal" />
-  <style
-    id="picker-modal"
-    backgroundColor="white"
-    borderTopColor="#E1E1E1"
-    borderTopWidth="1"
-    shadowOffsetX="0"
-    shadowOffsetY="-5"
-    shadowOpacity="0.2"
-    shadowRadius="5"
-  />
-  <style id="picker-modal-overlay" backgroundColor="#1f1f1fa0" />
-  <style
-    id="picker-modal-text"
-    color="blue"
-    fontSize="16"
-    fontWeight="600"
-    marginBottom="16"
-    padding="24"
-  >
-    <modifier pressed="true">
-    <style opacity="0.5" />
-    </modifier>
-  </style>
 {% endblock %}
 
 {% block content %}

--- a/demo/backend/behaviors/basic/triggers/focus/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/focus/index.xml.njk
@@ -42,29 +42,6 @@ hv_button_behavior: "back"
   </style>
   <style id="tip" color="#FF4847" fontSize="16" />
   <style id="input-text" fontSize="16" fontWeight="normal" />
-  <style
-    id="picker-modal"
-    backgroundColor="white"
-    borderTopColor="#E1E1E1"
-    borderTopWidth="1"
-    shadowOffsetX="0"
-    shadowOffsetY="-5"
-    shadowOpacity="0.2"
-    shadowRadius="5"
-  />
-  <style id="picker-modal-overlay" backgroundColor="#1f1f1fa0" />
-  <style
-    id="picker-modal-text"
-    color="blue"
-    fontSize="16"
-    fontWeight="600"
-    marginBottom="16"
-    padding="24"
-  >
-    <modifier pressed="true">
-    <style opacity="0.5" />
-    </modifier>
-  </style>
 {% endblock %}
 
 {% block content %}

--- a/demo/backend/ui/ui-elements/forms/date-field/index.xml.njk
+++ b/demo/backend/ui/ui-elements/forms/date-field/index.xml.njk
@@ -22,18 +22,6 @@ hv_button_behavior: "back"
   />
   <style id="input-text-error" color="#FF4847"/>
   <style
-    id="picker-modal-text"
-    color="blue"
-    fontSize="16"
-    fontWeight="600"
-    marginBottom="16"
-    padding="24"
-  >
-    <modifier pressed="true">
-    <style opacity="0.5"/>
-    </modifier>
-  </style>
-  <style
     id="InputCustom"
     borderColor="#4E4D4D"
     borderRadius="4"
@@ -52,19 +40,6 @@ hv_button_behavior: "back"
     <style borderColor="#4778FF"/>
     </modifier>
   </style>
-  <style
-    id="picker-modal"
-    backgroundColor="white"
-    borderTopColor="#E1E1E1"
-    borderTopWidth="1"
-    shadowOffsetX="0"
-    shadowOffsetY="-5"
-    shadowOpacity="0.2"
-    shadowRadius="5"/>
-  <style
-    id="picker-modal-overlay"
-    backgroundColor="#1f1f1fa0"
-  />
   <style id="help-error" color="#FF4847"/>
   <style
     id="input"

--- a/demo/backend/ui/ui-elements/forms/picker/index.xml.njk
+++ b/demo/backend/ui/ui-elements/forms/picker/index.xml.njk
@@ -10,15 +10,6 @@ hv_button_behavior: "back"
 {% block styles %}
   <style id="label" borderColor="#4E4D4D" fontSize="16" fontWeight="bold" lineHeight="24" marginBottom="8"/>
   <style id="input-modal-text" color="purple" fontSize="18" fontWeight="600"/>
-  <style
-    id="picker-modal"
-    backgroundColor="white"
-    borderTopColor="#E1E1E1"
-    borderTopWidth="1"
-    shadowOffsetX="0"
-    shadowOffsetY="-5"
-    shadowOpacity="0.2"
-    shadowRadius="5"/>
   <style id="picker-modal-custom" backgroundColor="purple" borderTopColor="#E1E1E1" borderTopWidth="1"/>
   <style
     id="input"
@@ -50,15 +41,6 @@ hv_button_behavior: "back"
     marginTop="48"
     padding="24"
   />
-  <style
-    id="picker-modal-overlay"
-    backgroundColor="#1f1f1fa0"
-  />
-  <style id="picker-modal-text" color="blue" fontSize="16" fontWeight="600" marginBottom="16" padding="24">
-    <modifier pressed="true">
-    <style opacity="0.5"/>
-    </modifier>
-  </style>
   <style id="input-text" fontSize="16" fontWeight="normal"/>
   <style id="input-error" borderBottomColor="#FF4847">
     <modifier focused="true">

--- a/src/components/hv-date-field/picker/index.ios.tsx
+++ b/src/components/hv-date-field/picker/index.ios.tsx
@@ -2,6 +2,7 @@ import DateTimePicker from 'hyperview/src/core/components/date-time-picker';
 import Modal from 'hyperview/src/core/components/modal';
 import type { Props } from './types';
 import React from 'react';
+import styles from './styles';
 
 /**
  * On iOS this component is rendered inline, and on Android it's rendered as a modal.
@@ -32,6 +33,7 @@ export default (props: Props): JSX.Element | null => {
         minimumDate={props.minDate || undefined}
         mode="date"
         onChange={(evt: unknown, date?: Date) => props.setPickerValue(date)}
+        style={styles.container}
         value={props.value}
       />
     </Modal>

--- a/src/components/hv-date-field/picker/styles.ts
+++ b/src/components/hv-date-field/picker/styles.ts
@@ -1,0 +1,7 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    alignSelf: 'center',
+  },
+});


### PR DESCRIPTION
New version of datepicker no longer auto center - this fix forces it back in the center of the picker modal. This PR also cleans up duplication on the demo styles for the picker modal.

| Before | After |
|--|--|
| ![Simulator Screenshot - iPhone 16 Pro - 2025-02-14 at 16 52 40](https://github.com/user-attachments/assets/31ee777f-47ef-47c8-92fa-db21e23d7745) | ![Simulator Screenshot - iPhone 16 Pro - 2025-02-14 at 16 41 59](https://github.com/user-attachments/assets/d1e0b053-559a-4a00-bc9c-7ac494ab1977) |
