### PR TITLE
fix(ios): date picker max date bug

### DIFF
--- a/src/components/hv-date-field/picker/index.ios.tsx
+++ b/src/components/hv-date-field/picker/index.ios.tsx
@@ -29,7 +29,10 @@ export default (props: Props): JSX.Element | null => {
         // so that the picking experience is available immediately.
         display="spinner"
         locale={props.locale}
-        maximumDate={props.maxDate || undefined}
+        // Force a max date - this is a workaround for a bug in the DateTimePicker
+        // where selection is not possible after a picker was rendered with a max date
+        // unless the max date is actually set to a value.
+        maximumDate={props.maxDate || new Date('2100-01-01T00:00:00.000Z')}
         minimumDate={props.minDate || undefined}
         mode="date"
         onChange={(evt: unknown, date?: Date) => props.setPickerValue(date)}


### PR DESCRIPTION
Explicitly set an arbitrary maximum date to work around an iOS bug, where the date picker will not allow a selection after another date picker with a max date was rendered.

https://app.asana.com/0/1204008699308084/1209403666139698

| Before | After |
|--|--|
| ![before](https://github.com/user-attachments/assets/a93fa321-9a5c-4f16-84fa-c371a6b72294) | ![after](https://github.com/user-attachments/assets/458fb835-1f88-47e5-8d80-f17426131d25) |


