### PR TITLE
chore(error): improve error message and context for DocumentGetElementByIdError

### DIFF
--- a/src/services/dom/errors.ts
+++ b/src/services/dom/errors.ts
@@ -71,13 +71,11 @@ export class DocumentGetElementByIdError extends ErrorService.HvBaseError {
   name = 'DocumentGetElementByIdError';
 
   constructor(id: string, doc: Document, error: Error) {
-    super(
-      `Document.getElementById failed for id: ${id} on doc: ${docToString(
-        doc,
-      )} and error: ${error.message}`,
-    );
+    super(`Document.getElementById failed for id: ${id}`);
     this.stack = error.stack;
     this.setExtraContext('error', error);
+    this.setExtraContext('doc', docToString(doc));
+    this.setExtraContext('id', id);
   }
 }
 


### PR DESCRIPTION
Reducing the amount of data in the message string. Improving context with `id` and `doc`.

Relates to https://github.com/Instawork/mobile/pull/7084

[Asana](https://app.asana.com/0/1204008699308084/1209425378622147)