### PR TITLE
fix(behavior): set fallback target

### DIFF
--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -406,11 +406,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
               onUpdateCallbacks.getDoc(),
               behaviorElement,
             );
-          }
-
-          if (!targetElement && element?.parentNode) {
-            // Fall back to the original element if it is not orphaned
-            targetElement = element;
+            // Warn developers if a provided target was not found
             if (targetId) {
               Logging.error(
                 'Target element not found. Falling back to current element.',

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -408,6 +408,11 @@ export default class Hyperview extends PureComponent<Types.Props> {
             );
           }
 
+          if (!targetElement && element?.parentNode) {
+            // Fall back to the original element if it is not orphaned
+            targetElement = element;
+          }
+
           if (newElement && targetElement) {
             newRoot = Behaviors.performUpdate(
               action,

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -411,6 +411,12 @@ export default class Hyperview extends PureComponent<Types.Props> {
           if (!targetElement && element?.parentNode) {
             // Fall back to the original element if it is not orphaned
             targetElement = element;
+            if (targetId) {
+              Logging.error(
+                'Target element not found. Falling back to current element.',
+                { id: targetId },
+              );
+            }
           }
 
           if (newElement && targetElement) {

--- a/src/services/dom/helpers.ts
+++ b/src/services/dom/helpers.ts
@@ -131,12 +131,9 @@ export const processDocument = (doc: Document): Document => {
     const action = behavior.getAttribute('action');
     const updateAction: UpdateAction = action as UpdateAction;
     if (updateAction && Object.values(UPDATE_ACTIONS).includes(updateAction)) {
-      const target = behavior.getAttribute('target');
-      if (!target) {
-        const behaviorId = behavior.getAttribute('id');
-        if (!behaviorId) {
-          behavior.setAttribute('id', uuid());
-        }
+      const behaviorId = behavior.getAttribute('id');
+      if (!behaviorId) {
+        behavior.setAttribute('id', uuid());
       }
     }
   });


### PR DESCRIPTION
In the original implementation, the original `element` was the fallback target. In cases where a `targetId` is specified but unfound, we can still fall back to the original element.

Relates to https://github.com/Instawork/hyperview/pull/1068

| Before | After |
| -- | -- |
| ![before](https://github.com/user-attachments/assets/7310c5e1-ed69-46ed-a5f3-23dd5aace305) | ![after](https://github.com/user-attachments/assets/511d6155-7fdb-4f52-97c3-97cf44db580a) |

An error is being logged to notify developers

| | |
| -- | -- |
| ![error-closed](https://github.com/user-attachments/assets/35578e01-d656-4fa1-83be-9e227fdb340c) | ![error-open](https://github.com/user-attachments/assets/d7850c85-9ac8-4b9a-a38b-0daf5655925a) |



[Asana](https://app.asana.com/0/1204008699308084/1209438247623833)