### PR TITLE
chore(demo): reload example improvements

### DIFF
--- a/demo/backend/navigation/behaviors/actions/reload/index.xml.njk
+++ b/demo/backend/navigation/behaviors/actions/reload/index.xml.njk
@@ -22,16 +22,4 @@ hv_button_behavior: "back"
   {% call button('Reload different screen') -%}
     <behavior action="reload" href="/hyperview/public/navigation/behaviors/actions/reload/reloaded.xml" show-during-load="loadingElement" />
   {%- endcall %}
-
-  {{ description('Tapping the button below will reload the root navigation hierarchy with the "Advanced" tab selected') }}
-  {% call button('Reload hierarchy') -%}
-    {# close this view #}
-    <behavior action="back" href="#" />
-
-    {# invoke the behavior defined on /backend/index.xml #}
-    <behavior
-      action="dispatch-event"
-      event-name="reload-root-navigation"
-    />
-  {%- endcall %}
 {% endblock %}

--- a/demo/backend/navigation/behaviors/actions/reload/index.xml.njk
+++ b/demo/backend/navigation/behaviors/actions/reload/index.xml.njk
@@ -20,7 +20,7 @@ hv_button_behavior: "back"
 
   {{ description('Tapping the button below will reload this screen with a new URL') }}
   {% call button('Reload different screen') -%}
-    <behavior action="reload" href="/hyperview/public/navigation/index.xml" show-during-load="loading-screen" />
+    <behavior action="reload" href="/hyperview/public/navigation/behaviors/actions/reload/reloaded.xml" show-during-load="loadingElement" />
   {%- endcall %}
 
   {{ description('Tapping the button below will reload the root navigation hierarchy with the "Advanced" tab selected') }}

--- a/demo/backend/navigation/behaviors/actions/reload/reloaded.xml.njk
+++ b/demo/backend/navigation/behaviors/actions/reload/reloaded.xml.njk
@@ -1,0 +1,12 @@
+---
+permalink: "/navigation/behaviors/actions/reload/reloaded.xml"
+hv_title: "Reload - Updated"
+hv_button_behavior: "back"
+---
+{% extends 'templates/scrollview.xml.njk' %}
+{% from 'macros/description/index.xml.njk' import description %}
+{% from 'macros/button/index.xml.njk' import button %}
+
+{% block content %}
+  {{ description('Changed Screen') }}
+{% endblock %}


### PR DESCRIPTION
Resolving issues in Navigation > Behaviors > Reload
1. "Reload different screen" had an invalid loading value and caused the whole app to reload without navigation. Resolved to show loading a new screen in place.
2. The "Reload hierarchy" was not directly related to "reload" functionality and will be moved to a more appropriate location in the future.

| Before | After |
| -- | -- |
| ![before](https://github.com/user-attachments/assets/bb8099b9-5d98-4d8d-b66e-6894f9f464c1) | ![after](https://github.com/user-attachments/assets/4f50b0e5-f846-444b-9e6f-b42e6fc3f2e0) |


[Asana](https://app.asana.com/0/1204008699308084/1209182447962509)