### PR TITLE
chore(navigation): resolve performance issue

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -57,6 +57,7 @@ export default () => (
                 behaviors={Behaviors}
                 components={Components}
                 entrypointUrl={`${Constants.expoConfig?.extra?.baseUrl}/hyperview/public/index.xml`}
+                experimentalFeatures={{ navStateMutationsDelay: 10 }}
                 fetch={fetchWrapper}
                 formatDate={formatDate}
                 loadingScreen={LoadingScreen}


### PR DESCRIPTION
Resolving the navigation glitch seen in the demo app after updating `expo` and `react-native`.

Values below 2 showed the glitch always. Values between 2-5 showed the glitch often. So far a value of 10 has not exhibited the glitch.

| Before | After |
| -- | -- |
| ![before](https://github.com/user-attachments/assets/a20b7aa0-785f-4874-8d7d-d5157de26cfc) | ![after](https://github.com/user-attachments/assets/b97e2b30-e150-4c59-b5f0-09c42543d38c) |


Relates to
- https://github.com/Instawork/hyperview/pull/1092
- https://github.com/Instawork/hyperview/pull/1096

[Asana](https://app.asana.com/0/1204008699308084/1209518863613015)