### PR TITLE
fix(docs): `<header>` reference

### DIFF
--- a/docs/reference_header.md
+++ b/docs/reference_header.md
@@ -6,26 +6,24 @@ sidebar_label: <header>
 
 The `<header>` element represents the header of a screen in the app. Typically, the header shows a title and navigation elements
 
-An example header on a screen with a scrolling body.
+An example header on a screen with a scrolling view.
 
 ```xml
 <screen>
-  <header style="MyHeader">
-    <text href="#">Back</text>
-    <text>My App</text>
-  </header>
-  <body style="Flex" scroll="true">
-    <view style="FlexHorizontal">
-      <text>Basic view</text>
-      <text>With Horizontal Layout</text>
+  <body style="Flex">
+    <header style="MyHeader">
+      <text href="#">Back</text>
+      <text>My App</text>
+    </header>
+    <view scroll="true" style="Flex">
+      <view style="FlexHorizontal">
+        <text>Basic view</text>
+        <text>With Horizontal Layout</text>
+      </view>
     </view>
   </body>
 </screen>
 ```
-
-## Structure
-
-A `<header>` element can only appear as a direct child of a `<screen>` element.
 
 ## Attributes
 


### PR DESCRIPTION
`<header>` element might have been at some point a special element that could render as a sibling of `<body>`, but that is no longer the case: it is now just an alias of `<view>`. We might want to restore this original intent though in a future iteration.