### PR TITLE
refactor(demo/scroll-opacity): use ranges to map position with opacity

### DIFF
--- a/demo/backend/advanced/community/elements/scroll-opacity/_styles.xml.njk
+++ b/demo/backend/advanced/community/elements/scroll-opacity/_styles.xml.njk
@@ -3,3 +3,9 @@
   marginHorizontal="24"
   marginBottom="16"
 />
+
+<style
+  id="instructions-text"
+  flex="1"
+  alignItems="flex-end"
+/>

--- a/demo/backend/advanced/community/elements/scroll-opacity/index.xml.njk
+++ b/demo/backend/advanced/community/elements/scroll-opacity/index.xml.njk
@@ -18,10 +18,19 @@ hv_title: "Scroll Opacity"
     <scroll-opacity:scroll-opacity
       xmlns:scroll-opacity="https://hyperview.org/scroll-opacity"
       scroll-opacity:context-key="scroll-view"
-      scroll-opacity:distance="20"
-      scroll-opacity:initial-opacity="0"
+      scroll-opacity:scroll-range="[30, 100]"
+      scroll-opacity:opacity-range="[0, 1]"
     >
       <text style="header-title" key="title">{{ hv_title }}</text>
+    </scroll-opacity:scroll-opacity>
+    <scroll-opacity:scroll-opacity
+      xmlns:scroll-opacity="https://hyperview.org/scroll-opacity"
+      style="instructions-text"
+      scroll-opacity:context-key="scroll-view"
+      scroll-opacity:scroll-range="[0, 20]"
+      scroll-opacity:opacity-range="[1, 0]"
+    >
+      <text key="instructions-text">Scroll down…</text>
     </scroll-opacity:scroll-opacity>
   </header>
   <view

--- a/demo/schema/scroll-opacity.xsd
+++ b/demo/schema/scroll-opacity.xsd
@@ -3,17 +3,24 @@
   attributeFormDefault="qualified"
   elementFormDefault="qualified"
   targetNamespace="https://hyperview.org/scroll-opacity"
+  xmlns:scroll-opacity="https://hyperview.org/scroll-opacity"
   xmlns:hv="https://hyperview.org/hyperview"
 >
   <xs:import
     namespace="https://hyperview.org/hyperview"
     schemaLocation="hyperview.xsd"
   />
+  <xs:simpleType name="range">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\[-?[0-9]+,\s?-?[0-9]+\]" />
+    </xs:restriction>
+  </xs:simpleType>
   <xs:element name="scroll-opacity">
     <xs:complexType>
       <xs:sequence>
         <xs:any minOccurs="0" maxOccurs="unbounded" />
       </xs:sequence>
+      <xs:attribute name="style" type="hv:styleList" form="unqualified" />
       <xs:attribute name="context-key" type="xs:token" />
       <xs:attribute name="axis">
         <xs:simpleType>
@@ -23,9 +30,9 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>
-      <xs:attribute name="distance" type="xs:nonNegativeInteger" />
       <xs:attribute name="duration" type="xs:nonNegativeInteger" />
-      <xs:attribute name="initial-opacity" type="xs:nonNegativeInteger" />
+      <xs:attribute name="scroll-range" type="scroll-opacity:range" />
+      <xs:attribute name="opacity-range" type="scroll-opacity:range" />
     </xs:complexType>
   </xs:element>
 </xs:schema>

--- a/demo/schema/scroll-opacity.xsd
+++ b/demo/schema/scroll-opacity.xsd
@@ -10,9 +10,14 @@
     namespace="https://hyperview.org/hyperview"
     schemaLocation="hyperview.xsd"
   />
-  <xs:simpleType name="range">
+  <xs:simpleType name="scroll-range">
     <xs:restriction base="xs:string">
       <xs:pattern value="\[-?[0-9]+,\s?-?[0-9]+\]" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="opacity-range">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\[[0-9]\.?[0-9]*,\s?[0-9]\.?[0-9]*\]" />
     </xs:restriction>
   </xs:simpleType>
   <xs:element name="scroll-opacity">
@@ -31,8 +36,8 @@
         </xs:simpleType>
       </xs:attribute>
       <xs:attribute name="duration" type="xs:nonNegativeInteger" />
-      <xs:attribute name="scroll-range" type="scroll-opacity:range" />
-      <xs:attribute name="opacity-range" type="scroll-opacity:range" />
+      <xs:attribute name="scroll-range" type="scroll-opacity:scroll-range" />
+      <xs:attribute name="opacity-range" type="scroll-opacity:opacity-range" />
     </xs:complexType>
   </xs:element>
 </xs:schema>

--- a/demo/src/Components/ScrollOpacity/utils.ts
+++ b/demo/src/Components/ScrollOpacity/utils.ts
@@ -3,11 +3,48 @@ export const namespaceURI = 'https://hyperview.org/scroll-opacity';
 export const getNumberAttr = (
   element: Element,
   attrName: string,
-  defaultValue: number | null = null,
+  defaultValue: number,
 ): number => {
   const value: string | null = element.getAttributeNS(namespaceURI, attrName);
   if (!value) {
-    return defaultValue || 0;
+    return defaultValue;
   }
   return parseInt(value, 10);
+};
+
+export const getRangeAttr = (
+  element: Element,
+  attrName: string,
+  defaultValue: [number, number],
+): [number, number] => {
+  const value: string | null = element.getAttributeNS(namespaceURI, attrName);
+  if (!value) {
+    return defaultValue;
+  }
+  try {
+    return JSON.parse(value);
+  } catch (e) {
+    throw new Error(`Invalid range attribute: ${value}`);
+  }
+};
+
+export const calculateOpacity = (
+  position: number,
+  inputRange: [number, number],
+  outputRange: [number, number],
+) => {
+  const [a, b] = inputRange;
+  const [c, d] = outputRange;
+
+  // Calculate the slope
+  const slope = (d - c) / (b - a);
+
+  // Calculate the opacity based on the position
+  if (position < a) {
+    return c;
+  }
+  if (position > b) {
+    return d;
+  }
+  return c + slope * (position - a);
 };

--- a/demo/src/Components/ScrollOpacity/utils.ts
+++ b/demo/src/Components/ScrollOpacity/utils.ts
@@ -36,6 +36,13 @@ export const calculateOpacity = (
   const [a, b] = inputRange;
   const [c, d] = outputRange;
 
+  // Check if the input range has the same start and end values
+  if (a === b) {
+    // If the position is exactly at a (or b), return the start of the output range
+    // Otherwise, return the end of the output range
+    return position <= a ? c : d;
+  }
+
   // Calculate the slope
   const slope = (d - c) / (b - a);
 


### PR DESCRIPTION
To increase flexibiility of the component, read position (input) and opacity (output) ranges from XML attribute, and use these to calculate the expected opacity. Update the example to show-case two different use.
Also add the ability to pass styles to the wrapping view.


https://github.com/user-attachments/assets/11c12a96-55a9-46f9-bc2e-1e0968298d69

