### PR TITLE
chore(hv-doc): lift fetch

### DIFF
--- a/src/core/components/hv-doc/context.ts
+++ b/src/core/components/hv-doc/context.ts
@@ -4,6 +4,7 @@ import { createContext } from 'react';
 export const StateContext = createContext<StateContextProps>({
   getLocalDoc: () => null,
   getScreenState: () => ({}),
+  loadUrl: () => ({}),
   setLocalDoc: () => ({}),
   setScreenState: () => ({}),
 });

--- a/src/core/components/hv-doc/errors.ts
+++ b/src/core/components/hv-doc/errors.ts
@@ -1,0 +1,7 @@
+/* eslint-disable max-classes-per-file */
+
+import * as ErrorService from 'hyperview/src/services/error';
+
+export class HvDocError extends ErrorService.HvBaseError {
+  name = 'HvDocError';
+}

--- a/src/core/components/hv-doc/index.tsx
+++ b/src/core/components/hv-doc/index.tsx
@@ -1,7 +1,21 @@
-import React, { useRef, useState } from 'react';
+import * as DomService from 'hyperview/src/services/dom';
+import * as Helpers from 'hyperview/src/services/dom/helpers';
+import * as NavigationContext from 'hyperview/src/contexts/navigation';
+import * as NavigatorService from 'hyperview/src/services/navigator';
+import * as Stylesheets from 'hyperview/src/services/stylesheets';
+import * as UrlService from 'hyperview/src/services/url';
+import { LOCAL_NAME, ScreenState } from 'hyperview/src/types';
+import React, {
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { HvDocError } from './errors';
 import { Props } from './types';
-import { ScreenState } from 'hyperview/src/types';
 import { StateContext } from './context';
+import { later } from 'hyperview/src/services';
 
 const HvDoc = (props: Props) => {
   // <HACK>
@@ -12,32 +26,140 @@ const HvDoc = (props: Props) => {
   // available (see details here: https://reactjs.org/docs/react-component.html#setstate)
   // Whenever we need to access the document for reasons other than rendering, we should use
   // `localDoc`. When rendering, we should use `document`.
-  const localDoc = useRef<Document | null>(null);
-  const [state, setState] = useState<ScreenState>({
-    doc: undefined,
-    error: undefined,
+  const localDoc = useRef<Document | null | undefined>(null);
+  // </HACK>
+
+  const [state, setState] = useState<ScreenState>(() => {
+    // Initial state may receive a doc from the props
+    if (props.doc) {
+      localDoc.current = props.doc;
+      return {
+        doc: props.doc,
+        error: undefined,
+        staleHeaderType: undefined,
+        styles: props.doc
+          ? Stylesheets.createStylesheets(props.doc)
+          : undefined,
+      };
+    }
+    return {
+      doc: undefined,
+      error: undefined,
+    };
   });
 
+  const navigationContext: NavigationContext.NavigationContextProps | null = useContext(
+    NavigationContext.Context,
+  );
+
+  if (!navigationContext) {
+    throw new HvDocError('No context found');
+  }
+
+  const parser: DomService.Parser = useMemo(
+    () =>
+      new DomService.Parser(
+        navigationContext.fetch,
+        navigationContext.onParseBefore ?? null,
+        navigationContext.onParseAfter ?? null,
+      ),
+    [
+      navigationContext.fetch,
+      navigationContext.onParseBefore,
+      navigationContext.onParseAfter,
+    ],
+  );
+
+  const loadUrl = useCallback(
+    async (url?: string) => {
+      // Updates the state and calls the error handler
+      const raiseError = (err: Error) => {
+        if (navigationContext.onError) {
+          navigationContext.onError(err);
+        }
+        setState(prev => ({
+          ...prev,
+          error: err,
+        }));
+      };
+
+      const targetUrl = url ?? state.url;
+      if (!targetUrl) {
+        raiseError(new HvDocError('No URL provided'));
+        return;
+      }
+
+      try {
+        if (props.route?.params.delay) {
+          const delay =
+            typeof props.route.params.delay === 'number'
+              ? props.route.params.delay
+              : parseInt(props.route.params.delay, 10);
+          await later(delay);
+        }
+
+        const { doc, staleHeaderType } = await parser.loadDocument(
+          UrlService.getUrlFromHref(targetUrl, navigationContext.entrypointUrl),
+        );
+
+        const root = Helpers.getFirstChildTag(doc, LOCAL_NAME.DOC);
+        if (root) {
+          const navigatorElement: Element | null = Helpers.getFirstChildTag(
+            root,
+            LOCAL_NAME.NAVIGATOR,
+          );
+
+          // Navigator elements can be merged to allow for partial updates; screens do not
+          const document = navigatorElement
+            ? NavigatorService.mergeDocument(doc, localDoc.current ?? undefined)
+            : doc;
+
+          localDoc.current = document;
+          const stylesheets = Stylesheets.createStylesheets(doc);
+          setState(prev => ({
+            ...prev,
+            doc: document,
+            error: undefined,
+            staleHeaderType,
+            styles: stylesheets,
+            url: targetUrl,
+          }));
+        } else {
+          // Invalid document
+          localDoc.current = undefined;
+          raiseError(new HvDocError('No root element found'));
+        }
+      } catch (err: unknown) {
+        // Error
+        localDoc.current = undefined;
+        raiseError(err as Error);
+      }
+    },
+    [navigationContext, parser, props.route?.params.delay, state.url],
+  );
+
+  const contextValue = useMemo(
+    () => ({
+      getLocalDoc: () => localDoc.current ?? null,
+      getScreenState: () => state,
+      loadUrl,
+      setLocalDoc: (doc: Document | null) => {
+        if (doc !== undefined) {
+          localDoc.current = doc;
+        }
+      },
+      setScreenState: (newState: ScreenState) =>
+        setState(prev => ({
+          ...prev,
+          ...newState,
+          doc: props.element ? null : newState.doc ?? prev.doc,
+        })),
+    }),
+    [loadUrl, props.element, state],
+  );
+
   return (
-    <StateContext.Provider
-      value={{
-        getLocalDoc: () => localDoc.current,
-        getScreenState: () => state,
-        setLocalDoc: (doc: Document | null) => {
-          if (doc !== undefined) {
-            localDoc.current = doc;
-          }
-        },
-        // * Override the state to clear the doc when an element is passed
-        setScreenState: (newState: ScreenState) => {
-          setState({
-            ...state,
-            ...newState,
-            doc: props.element ? null : newState.doc,
-          });
-        },
-      }}
-    >
+    <StateContext.Provider value={contextValue}>
       {props.children}
     </StateContext.Provider>
   );

--- a/src/core/components/hv-doc/index.tsx
+++ b/src/core/components/hv-doc/index.tsx
@@ -73,7 +73,7 @@ const HvDoc = (props: Props) => {
   const loadUrl = useCallback(
     async (url?: string) => {
       // Updates the state and calls the error handler
-      const raiseError = (err: Error) => {
+      const handleError = (err: Error) => {
         if (navigationContext.onError) {
           navigationContext.onError(err);
         }
@@ -85,7 +85,7 @@ const HvDoc = (props: Props) => {
 
       const targetUrl = url ?? state.url;
       if (!targetUrl) {
-        raiseError(new HvDocError('No URL provided'));
+        handleError(new HvDocError('No URL provided'));
         return;
       }
 
@@ -127,12 +127,12 @@ const HvDoc = (props: Props) => {
         } else {
           // Invalid document
           localDoc.current = undefined;
-          raiseError(new HvDocError('No root element found'));
+          handleError(new HvDocError('No root element found'));
         }
       } catch (err: unknown) {
         // Error
         localDoc.current = undefined;
-        raiseError(err as Error);
+        handleError(err as Error);
       }
     },
     [navigationContext, parser, props.route?.params.delay, state.url],

--- a/src/core/components/hv-doc/index.tsx
+++ b/src/core/components/hv-doc/index.tsx
@@ -74,13 +74,16 @@ const HvDoc = (props: Props) => {
     async (url?: string) => {
       // Updates the state and calls the error handler
       const handleError = (err: Error) => {
-        if (navigationContext.onError) {
-          navigationContext.onError(err);
+        try {
+          if (navigationContext.onError) {
+            navigationContext.onError(err);
+          }
+        } finally {
+          setState(prev => ({
+            ...prev,
+            error: err,
+          }));
         }
-        setState(prev => ({
-          ...prev,
-          error: err,
-        }));
       };
 
       const targetUrl = url ?? state.url;

--- a/src/core/components/hv-doc/types.ts
+++ b/src/core/components/hv-doc/types.ts
@@ -1,13 +1,23 @@
-import { ScreenState } from 'hyperview/src/types';
+import * as NavigatorService from 'hyperview/src/services/navigator';
+import { DOMString, ScreenState } from 'hyperview/src/types';
 
 export type Props = {
   children?: React.ReactNode;
+  doc?: Document;
   element?: Element;
+  route?: NavigatorService.Route<
+    string,
+    {
+      delay?: DOMString | number | null;
+      url?: string | null;
+    }
+  >;
 };
 
 export type StateContextProps = {
   getLocalDoc: () => Document | null;
   getScreenState: () => ScreenState;
+  loadUrl: (url?: string) => void;
   setLocalDoc: (doc: Document | null) => void;
   setScreenState: (state: ScreenState) => void;
 };

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -267,15 +267,23 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
     };
 
     return (
-      <HvDoc>
+      <HvDoc
+        doc={this.props.getLocalDoc()?.cloneNode(true) as Document}
+        route={route}
+      >
         <StateContext.Consumer>
-          {({ getLocalDoc, getScreenState, setLocalDoc, setScreenState }) => (
+          {({
+            getLocalDoc,
+            getScreenState,
+            loadUrl,
+            setLocalDoc,
+            setScreenState,
+          }) => (
             <Contexts.DateFormatContext.Consumer>
               {formatter => (
                 <HvScreen
                   behaviors={this.props.behaviors}
                   components={this.props.components}
-                  doc={this.props.getLocalDoc()?.cloneNode(true) as Document}
                   elementErrorComponent={this.props.elementErrorComponent}
                   entrypointUrl={this.props.entrypointUrl}
                   errorScreen={this.props.errorScreen}
@@ -284,6 +292,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
                   getElement={this.props.getElement}
                   getLocalDoc={getLocalDoc}
                   getScreenState={getScreenState}
+                  loadUrl={loadUrl}
                   navigation={this.navigator}
                   onError={this.props.onError}
                   onParseAfter={this.props.onParseAfter}

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -67,6 +67,7 @@ export type InnerRouteProps = {
   getScreenState: () => ScreenState;
   setLocalDoc: (doc: Document | null) => void;
   setScreenState: (state: ScreenState) => void;
+  loadUrl: (url?: string) => void;
 };
 
 /**

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -20,7 +20,6 @@ export type Props = Omit<
   | 'handleBack'
   | 'logger'
 > & {
-  doc?: Document;
   getElement?: (id: number) => Element | undefined;
   navigation: NavigationProvider;
   onUpdate: HvComponentOnUpdate;
@@ -32,4 +31,5 @@ export type Props = Omit<
   getScreenState: () => ScreenState;
   setLocalDoc: (doc: Document | null) => void;
   setScreenState: (state: ScreenState) => void;
+  loadUrl: (url?: string) => void;
 };


### PR DESCRIPTION
Implementing `fetch` in `hv-doc`, lifting `fetch` out of `hv-route` and `hv-screen`.

- Remove the parser and fetch functionality out of `hv-route` and `hv-screen` and ported the code into `hv-doc`
- Internally handle the state changes which result from the fetch/error
- Implemented the `initialDoc` functionality in `hv-doc` which was previously in use between `hv-route` and `hv-screen`

[Asana](https://app.asana.com/0/1204008699308084/1209771721803047/f)