### PR TITLE
feat: font scale props

### DIFF
--- a/docs/reference_datefield.md
+++ b/docs/reference_datefield.md
@@ -41,6 +41,9 @@ A `<date-field>` element can appear anywhere within a `<form>` element.
 - [`modal-text-style`](#modal-text-style)
 - [`id`](#id)
 - [`hide`](#hide)
+- [`allowFontScaling`](#allowFontScaling)
+- [`maxFontSizeMultiplier`](#maxFontSizeMultiplier)
+- [`minimumFontScale`](#minimumFontScale)
 
 #### Behavior attributes
 
@@ -193,3 +196,27 @@ A global attribute uniquely identifying the element in the whole document.
 | **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.
+
+#### `allowFontScaling`
+
+| Type    | Required |
+| ------- | -------- |
+| boolean | No       |
+
+Specifies whether fonts should scale to respect Text Size accessibility setting
+
+#### `maxFontSizeMultiplier`
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+Specifies whether fonts should scale to respect Text Size accessibility setting
+
+#### `minimumFontScale` (iOS)
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+Specifies the smallest possible scale a font can reach when adjustsFontSizeToFit is enabled. (values 0.01-1.0).

--- a/docs/reference_pickerfield.md
+++ b/docs/reference_pickerfield.md
@@ -51,6 +51,9 @@ A `<picker-field`> element can appear anywhere within a `<form>` element. Its ch
 - [`modal-text-style`](#modal-text-style)
 - [`id`](#id)
 - [`hide`](#hide)
+- [`allowFontScaling`](#allowFontScaling)
+- [`maxFontSizeMultiplier`](#maxFontSizeMultiplier)
+- [`minimumFontScale`](#minimumFontScale)
 
 #### Behavior attributes
 
@@ -179,3 +182,27 @@ A global attribute uniquely identifying the element in the whole document. Add a
 | **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.
+
+#### `allowFontScaling`
+
+| Type    | Required |
+| ------- | -------- |
+| boolean | No       |
+
+Specifies whether fonts should scale to respect Text Size accessibility setting
+
+#### `maxFontSizeMultiplier`
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+Specifies whether fonts should scale to respect Text Size accessibility setting
+
+#### `minimumFontScale` (iOS)
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+Specifies the smallest possible scale a font can reach when adjustsFontSizeToFit is enabled. (values 0.01-1.0).

--- a/docs/reference_text.md
+++ b/docs/reference_text.md
@@ -55,6 +55,9 @@ A `<view>` element can only appear anywhere within a `<screen>` element.
 - [`hide`](#hide)
 - [`selectable`](#selectable)
 - [`adjustsFontSizeToFit`](#adjustsFontSizeToFit)
+- [`allowFontScaling`](#allowFontScaling)
+- [`maxFontSizeMultiplier`](#maxFontSizeMultiplier)
+- [`minimumFontScale`](#minimumFontScale)
 - [`preformatted`](#preformatted)
 
 #### Behavior attributes
@@ -108,6 +111,30 @@ A boolean that allows users to select the content of `<text>` element.
 | boolean | No       |
 
 If `adjustsFontSizeToFit="true"`, fonts will be scaled down automatically to fit given style constraints.
+
+#### `allowFontScaling`
+
+| Type    | Required |
+| ------- | -------- |
+| boolean | No       |
+
+Specifies whether fonts should scale to respect Text Size accessibility setting
+
+#### `maxFontSizeMultiplier`
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+Specifies whether fonts should scale to respect Text Size accessibility setting
+
+#### `minimumFontScale` (iOS)
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+Specifies the smallest possible scale a font can reach when adjustsFontSizeToFit is enabled. (values 0.01-1.0).
 
 #### `preformatted`
 

--- a/docs/reference_textfield.md
+++ b/docs/reference_textfield.md
@@ -38,6 +38,10 @@ A `<text-field>` element can appear anywhere within a `<form>` element.
 - [`hide`](#hide)
 - [`auto-focus`](#auto-focus)
 - [`secure-text`](#secure-text)
+- [`text-content-type`](#text-content-type)
+- [`allowFontScaling`](#allowFontScaling)
+- [`maxFontSizeMultiplier`](#maxFontSizeMultiplier)
+- [`minimumFontScale`](#minimumFontScale)
 
 #### Behavior attributes
 
@@ -201,3 +205,27 @@ If `secure-text="true"`, the input in the text field will be obscured. Appropria
 | **none** (default), none, URL, addressCity, addressCityAndState, addressState, countryName, creditCardNumber, emailAddress, familyName, fullStreetAddress, givenName, jobTitle, location, middleName, name, namePrefix, nameSuffix, nickname, organizationName, postalCode, streetAddressLine1, streetAddressLine2, sublocality, telephoneNumber, username, password, newPassword, oneTimeCode | No       |
 
 The `text-content-type` autofills available fields (for example, for iOS 12+ `oneTimeCode` can be used to indicate that a field can be autofilled by a code arriving in an SMS).
+
+#### `allowFontScaling`
+
+| Type    | Required |
+| ------- | -------- |
+| boolean | No       |
+
+Specifies whether fonts should scale to respect Text Size accessibility setting
+
+#### `maxFontSizeMultiplier`
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+Specifies whether fonts should scale to respect Text Size accessibility setting
+
+#### `minimumFontScale` (iOS)
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+Specifies the smallest possible scale a font can reach when adjustsFontSizeToFit is enabled. (values 0.01-1.0).

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -418,6 +418,12 @@
     <xs:attribute name="network-retry-event" type="hv:eventName" />
   </xs:attributeGroup>
 
+  <xs:attributeGroup name="fontScaleAttributes">
+    <xs:attribute name="allowFontScaling" type="xs:boolean" />
+    <xs:attribute name="maxFontSizeMultiplier" type="xs:float" />
+    <xs:attribute name="minimumFontScale" type="xs:float" />
+  </xs:attributeGroup>
+
   <xs:attributeGroup name="scrollAttributes">
     <xs:attribute name="scroll" type="xs:boolean" />
     <xs:attribute name="scroll-orientation">
@@ -858,6 +864,7 @@
       <xs:attribute name="value" type="xs:string" />
       <xs:attribute name="adjustsFontSizeToFit" type="xs:boolean" />
       <xs:attributeGroup ref="hv:behaviorAttributes" />
+      <xs:attributeGroup ref="hv:fontScaleAttributes" />
     </xs:complexType>
   </xs:element>
 
@@ -1033,6 +1040,7 @@
       <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attributeGroup ref="hv:behaviorAttributes" />
+      <xs:attributeGroup ref="hv:fontScaleAttributes" />
     </xs:complexType>
   </xs:element>
 
@@ -1066,6 +1074,7 @@
       <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attributeGroup ref="hv:behaviorAttributes" />
+      <xs:attributeGroup ref="hv:fontScaleAttributes" />
     </xs:complexType>
   </xs:element>
 
@@ -1165,6 +1174,7 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>
+      <xs:attributeGroup ref="hv:fontScaleAttributes" />
     </xs:complexType>
   </xs:element>
 

--- a/src/components/hv-date-field/field-label/index.tsx
+++ b/src/components/hv-date-field/field-label/index.tsx
@@ -1,3 +1,4 @@
+import * as FontScale from 'hyperview/src/services/font-scale';
 import type { Props } from './types';
 import React from 'react';
 import type { StyleSheet } from 'hyperview/src/types';
@@ -22,5 +23,10 @@ export default (props: Props) => {
     ? props.formatter(props.value, labelFormat || undefined)
     : placeholder || '';
 
-  return <Text style={labelStyles}>{label}</Text>;
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <Text style={labelStyles} {...FontScale.getFontScaleProps(props.element)}>
+      {label}
+    </Text>
+  );
 };

--- a/src/components/hv-picker-field/field-label/index.tsx
+++ b/src/components/hv-picker-field/field-label/index.tsx
@@ -1,3 +1,4 @@
+import * as FontScale from 'hyperview/src/services/font-scale';
 import { StyleSheet, Text } from 'react-native';
 import type { Props } from './types';
 import React from 'react';
@@ -29,5 +30,10 @@ export default (props: Props) => {
 
   const label: string = props.value ? props.value : placeholder || '';
 
-  return <Text style={labelStyles}>{label}</Text>;
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <Text style={labelStyles} {...FontScale.getFontScaleProps(props.element)}>
+      {label}
+    </Text>
+  );
 };

--- a/src/core/components/modal/modal-button/index.tsx
+++ b/src/core/components/modal/modal-button/index.tsx
@@ -1,3 +1,4 @@
+import * as FontScale from 'hyperview/src/services/font-scale';
 import React, { useState } from 'react';
 import { Text, TouchableWithoutFeedback, View } from 'react-native';
 import type { Props } from './types';
@@ -27,7 +28,9 @@ export default (props: Props) => {
       onPressOut={() => setPressed(false)}
     >
       <View>
-        <Text style={style}>{props.label}</Text>
+        <Text style={style} {...FontScale.getFontScaleProps(props.element)}>
+          {props.label}
+        </Text>
       </View>
     </TouchableWithoutFeedback>
   );

--- a/src/services/font-scale/index.ts
+++ b/src/services/font-scale/index.ts
@@ -1,0 +1,23 @@
+import type { FontScaleProps } from './types';
+
+export const getFontScaleProps = (element: Element): FontScaleProps => {
+  const allowFontScaling =
+    element.getAttribute('allowFontScaling') || undefined;
+  const maxFontSizeMultiplier =
+    element.getAttribute('maxFontSizeMultiplier') || undefined;
+  const minimumFontScale =
+    element.getAttribute('minimumFontScale') || undefined;
+  const props: FontScaleProps = {};
+  if (allowFontScaling !== undefined) {
+    props.allowFontScaling = allowFontScaling !== 'false';
+  }
+  if (maxFontSizeMultiplier !== undefined) {
+    props.maxFontSizeMultiplier = parseFloat(maxFontSizeMultiplier);
+  }
+  if (minimumFontScale !== undefined) {
+    props.minimumFontScale = parseFloat(minimumFontScale);
+  }
+  return props;
+};
+
+export * from './types';

--- a/src/services/font-scale/types.ts
+++ b/src/services/font-scale/types.ts
@@ -1,0 +1,5 @@
+export type FontScaleProps = {
+  allowFontScaling?: boolean | undefined;
+  maxFontSizeMultiplier?: number | undefined;
+  minimumFontScale?: number | undefined;
+};

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -91,7 +91,13 @@ export const createProps = (
   options: HvComponentOptions,
 ) => {
   const numericRules = ['numberOfLines'];
-  const booleanRules = ['multiline', 'selectable', 'adjustsFontSizeToFit'];
+  const booleanRules = [
+    'adjustsFontSizeToFit',
+    'allowFontScaling',
+    'multiline',
+    'selectable',
+  ];
+  const floatRules = ['maxFontSizeMultiplier', 'minimumFontScale'];
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const props: Record<string, any> = {};
@@ -106,6 +112,9 @@ export const createProps = (
         props[attr.name] = intValue || 0;
       } else if (booleanRules.indexOf(attr.name) >= 0) {
         props[attr.name] = attr.value === 'true';
+      } else if (floatRules.indexOf(attr.name) >= 0) {
+        const floatValue = parseFloat(attr.value);
+        props[attr.name] = floatValue || 0;
       } else {
         props[attr.name] = attr.value;
       }


### PR DESCRIPTION
Refactor date-field / picker-field element to delegate to underlying components that render `Text` components the responsibility to extract their props and styles from the Hyperview props (element / options / stylesheets).
This is a pre-requisite to make it easier for this other change (#37760) to apply font scale props to Text components.

No demo yet, as the feature is broken in Expo SDK 52. See https://github.com/expo/expo/issues/32900 and https://github.com/facebook/react-native/issues/47499.