### PR TITLE
refactor: bring `element` prop closer to `Text` instances

### DIFF
--- a/src/components/hv-date-field/field-label/index.tsx
+++ b/src/components/hv-date-field/field-label/index.tsx
@@ -8,14 +8,19 @@ import { Text } from 'react-native';
  * or show the placeholder, including applying the right styles.
  */
 export default (props: Props) => {
+  const labelFormat = props.element.getAttribute('label-format');
+  const placeholder = props.element.getAttribute('placeholder');
+  const placeholderTextColor = props.element.getAttribute(
+    'placeholderTextColor',
+  );
   const labelStyles: Array<StyleSheet> = [props.style];
-  if (!props.value && props.placeholderTextColor) {
-    labelStyles.push({ color: props.placeholderTextColor });
+  if (!props.value && placeholderTextColor) {
+    labelStyles.push({ color: placeholderTextColor });
   }
 
   const label: string | undefined = props.value
-    ? props.formatter(props.value, props.labelFormat || undefined)
-    : props.placeholder || '';
+    ? props.formatter(props.value, labelFormat || undefined)
+    : placeholder || '';
 
   return <Text style={labelStyles}>{label}</Text>;
 };

--- a/src/components/hv-date-field/field-label/types.ts
+++ b/src/components/hv-date-field/field-label/types.ts
@@ -1,14 +1,12 @@
 import type { StyleSheet } from 'hyperview/src/types';
 
 export type Props = {
+  element: Element;
   focused: boolean;
   formatter: (
     date: Date | null | undefined,
     format: string | undefined,
   ) => string | undefined;
-  labelFormat: string | null | undefined;
-  placeholder: string | null | undefined;
-  placeholderTextColor: string | null | undefined;
   pressed: boolean;
   style: StyleSheet;
   value: Date | null | undefined;

--- a/src/components/hv-date-field/field/index.tsx
+++ b/src/components/hv-date-field/field/index.tsx
@@ -41,13 +41,9 @@ export default (props: Props) => {
         <Contexts.DateFormatContext.Consumer>
           {formatter => (
             <FieldLabel
+              element={props.element}
               focused={props.focused}
               formatter={formatter}
-              labelFormat={props.element.getAttribute('label-format')}
-              placeholder={props.element.getAttribute('placeholder')}
-              placeholderTextColor={props.element.getAttribute(
-                'placeholderTextColor',
-              )}
               pressed={pressed}
               style={labelStyle}
               value={props.value}

--- a/src/components/hv-picker-field/field-label/index.tsx
+++ b/src/components/hv-picker-field/field-label/index.tsx
@@ -1,19 +1,33 @@
+import { StyleSheet, Text } from 'react-native';
 import type { Props } from './types';
 import React from 'react';
-import type { StyleSheet } from 'hyperview/src/types';
-import { Text } from 'react-native';
+import type { StyleSheet as StyleSheetType } from 'hyperview/src/types';
+import { createStyleProp } from 'hyperview/src/services';
 
 /**
  * This text label of the field. Contains logic to decide how to format the value
  * or show the placeholder, including applying the right styles.
  */
 export default (props: Props) => {
-  const labelStyles: Array<StyleSheet> = [props.style];
-  if (!props.value && props.placeholderTextColor) {
-    labelStyles.push({ color: props.placeholderTextColor });
+  const placeholder = props.element.getAttribute('placeholder');
+  const placeholderTextColor = props.element.getAttribute(
+    'placeholderTextColor',
+  );
+  const style: StyleSheetType = StyleSheet.flatten(
+    createStyleProp(props.element, props.stylesheets, {
+      ...props.options,
+      focused: props.focused,
+      pressed: props.pressed,
+      styleAttr: 'field-text-style',
+    }),
+  );
+
+  const labelStyles: Array<StyleSheetType> = [style];
+  if (!props.value && placeholderTextColor) {
+    labelStyles.push({ color: placeholderTextColor });
   }
 
-  const label: string = props.value ? props.value : props.placeholder || '';
+  const label: string = props.value ? props.value : placeholder || '';
 
   return <Text style={labelStyles}>{label}</Text>;
 };

--- a/src/components/hv-picker-field/field-label/types.ts
+++ b/src/components/hv-picker-field/field-label/types.ts
@@ -1,11 +1,14 @@
-import type { DOMString, StyleSheet } from 'hyperview/src/types';
+import type {
+  DOMString,
+  HvComponentOptions,
+  StyleSheets,
+} from 'hyperview/src/types';
 
 export type Props = {
+  element: Element;
   focused: boolean;
-  labelFormat: string | null | undefined;
-  placeholder: string | null | undefined;
-  placeholderTextColor: string | null | undefined;
+  options: HvComponentOptions;
   pressed: boolean;
-  style: StyleSheet;
+  stylesheets: StyleSheets;
   value: DOMString | null | undefined;
 };

--- a/src/components/hv-picker-field/field/index.tsx
+++ b/src/components/hv-picker-field/field/index.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
-import { StyleSheet, TouchableWithoutFeedback, View } from 'react-native';
-import { createProps, createStyleProp } from 'hyperview/src/services';
+import { TouchableWithoutFeedback, View } from 'react-native';
 import FieldLabel from '../field-label';
 import type { Props } from './types';
-import type { StyleSheet as StyleSheetType } from 'hyperview/src/types';
+import { createProps } from 'hyperview/src/services';
 
 /**
  * The input field component. This is a box with text in it.
@@ -21,15 +20,6 @@ export default (props: Props) => {
     styleAttr: 'field-style',
   });
 
-  const labelStyle: StyleSheetType = StyleSheet.flatten(
-    createStyleProp(props.element, props.stylesheets, {
-      ...props.options,
-      focused: props.focused,
-      pressed,
-      styleAttr: 'field-text-style',
-    }),
-  );
-
   return (
     <TouchableWithoutFeedback
       onPress={props.onPress}
@@ -41,14 +31,11 @@ export default (props: Props) => {
         {...viewProps}
       >
         <FieldLabel
+          element={props.element}
           focused={props.focused}
-          labelFormat={props.element.getAttribute('label-format')}
-          placeholder={props.element.getAttribute('placeholder')}
-          placeholderTextColor={props.element.getAttribute(
-            'placeholderTextColor',
-          )}
+          options={props.options}
           pressed={pressed}
-          style={labelStyle}
+          stylesheets={props.stylesheets}
           value={props.value}
         />
         {props.children}

--- a/src/core/components/modal/index.tsx
+++ b/src/core/components/modal/index.tsx
@@ -43,13 +43,6 @@ export default (props: Props): JSX.Element => {
     props.element.getAttribute('cancel-label') || 'Cancel';
   const doneLabel: string = props.element.getAttribute('done-label') || 'Done';
 
-  const getTextStyle = (pressed: boolean): Array<StyleSheetType> =>
-    createStyleProp(props.element, props.stylesheets, {
-      ...props.options,
-      pressed,
-      styleAttr: 'modal-text-style',
-    });
-
   const overlayStyle = StyleSheet.flatten(
     createStyleProp(props.element, props.stylesheets, {
       ...props.options,
@@ -150,14 +143,18 @@ export default (props: Props): JSX.Element => {
         <View style={style}>
           <View style={styles.actions}>
             <ModalButton
-              getStyle={getTextStyle}
+              element={props.element}
               label={cancelLabel}
               onPress={onDismiss}
+              options={props.options}
+              stylesheets={props.stylesheets}
             />
             <ModalButton
-              getStyle={getTextStyle}
+              element={props.element}
               label={doneLabel}
               onPress={onDone}
+              options={props.options}
+              stylesheets={props.stylesheets}
             />
           </View>
           {props.children}

--- a/src/core/components/modal/modal-button/index.tsx
+++ b/src/core/components/modal/modal-button/index.tsx
@@ -1,12 +1,24 @@
 import React, { useState } from 'react';
 import { Text, TouchableWithoutFeedback, View } from 'react-native';
 import type { Props } from './types';
+import type { StyleSheet } from 'hyperview/src/types';
+import { createStyleProp } from 'hyperview/src/services';
 
 /**
  * Component used to render the Cancel/Done buttons in the picker modal.
  */
 export default (props: Props) => {
   const [pressed, setPressed] = useState(false);
+
+  const style: Array<StyleSheet> = createStyleProp(
+    props.element,
+    props.stylesheets,
+    {
+      ...props.options,
+      pressed,
+      styleAttr: 'modal-text-style',
+    },
+  );
 
   return (
     <TouchableWithoutFeedback
@@ -15,7 +27,7 @@ export default (props: Props) => {
       onPressOut={() => setPressed(false)}
     >
       <View>
-        <Text style={props.getStyle(pressed)}>{props.label}</Text>
+        <Text style={style}>{props.label}</Text>
       </View>
     </TouchableWithoutFeedback>
   );

--- a/src/core/components/modal/modal-button/types.ts
+++ b/src/core/components/modal/modal-button/types.ts
@@ -1,7 +1,9 @@
-import type { StyleSheet } from 'hyperview/src/types';
+import type { HvComponentOptions, StyleSheets } from 'hyperview/src/types';
 
 export type Props = {
-  getStyle: (pressed: boolean) => Array<StyleSheet>;
+  element: Element;
   label: string;
   onPress: () => void;
+  options: HvComponentOptions;
+  stylesheets: StyleSheets;
 };


### PR DESCRIPTION
Refactor date-field / picker-field element to delegate to underlying components that render `Text` components the responsibility to extract their props and styles from the Hyperview props (element / options / stylesheets). This is a pre-requisite to make it easier for this other change (#1129) to apply font scale props to Text components.