### PR TITLE
chore(performance): memoize doc cloning

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -20,7 +20,12 @@ import type {
   OnUpdateCallbacks,
   ScreenState,
 } from 'hyperview/src/types';
-import React, { JSXElementConstructor, PureComponent, useContext } from 'react';
+import React, {
+  JSXElementConstructor,
+  PureComponent,
+  useContext,
+  useMemo,
+} from 'react';
 import HvNavigator from 'hyperview/src/core/components/hv-navigator';
 import HvScreen from 'hyperview/src/core/components/hv-screen';
 import { LOCAL_NAME } from 'hyperview/src/types';
@@ -337,13 +342,18 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
       },
     };
 
+    const { localDoc } = this;
+    const localClone = useMemo(() => {
+      return localDoc?.cloneNode(true) as Document;
+    }, [localDoc]);
+
     return (
       <Contexts.DateFormatContext.Consumer>
         {formatter => (
           <HvScreen
             behaviors={this.props.behaviors}
             components={this.props.components}
-            doc={this.localDoc?.cloneNode(true) as Document}
+            doc={localClone}
             elementErrorComponent={this.props.elementErrorComponent}
             entrypointUrl={this.props.entrypointUrl}
             errorScreen={this.props.errorScreen}


### PR DESCRIPTION
The cloned doc being passed from `hv-route` to `hv-screen` was being cloned every render. Memoizing the cloning reduces this and improves performance.

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/a7b560d8-6e19-410d-bf22-e8ac500132d3) | ![after](https://github.com/user-attachments/assets/92827918-d877-47f9-b014-2ae1b6d4dce2) |

[Asana](https://app.asana.com/0/1204008699308084/1209802590586966/f)

https://github.com/user-attachments/assets/a7b560d8-6e19-410d-bf22-e8ac500132d3

https://github.com/user-attachments/assets/92827918-d877-47f9-b014-2ae1b6d4dce2
