### PR TITLE
chore(performance): memoize context values

### DIFF
--- a/demo/src/Components/BottomSheet/BottomSheet.tsx
+++ b/demo/src/Components/BottomSheet/BottomSheet.tsx
@@ -407,25 +407,29 @@ const BottomSheet = (props: HvComponentProps) => {
     </GestureDetector>
   );
 
+  const setContentSectionHeight = useCallback(
+    () => (index: number, contentSectionHeight: number) => {
+      setContentSectionHeights(prevHeights => {
+        const currentHeights = [...prevHeights];
+        currentHeights[index] = contentSectionHeight;
+        return currentHeights;
+      });
+    },
+    [],
+  );
+
+  const contextValue = useMemo(() => ({ setContentSectionHeight }), [
+    setContentSectionHeight,
+  ]);
+
   if (height === 0) {
     // Pre-render the content to trigger the layout calculation
     // The content should not be visible as we start with an opacity of 0
     return content;
   }
 
-  const setContentSectionHeight = (
-    index: number,
-    contentSectionHeight: number,
-  ) => {
-    setContentSectionHeights(prevHeights => {
-      const currentHeights = [...prevHeights];
-      currentHeights[index] = contentSectionHeight;
-      return currentHeights;
-    });
-  };
-
   return (
-    <BottomSheetContext.Provider value={{ setContentSectionHeight }}>
+    <BottomSheetContext.Provider value={contextValue}>
       <Modal onShow={animateOpen} transparent visible={visible}>
         <GestureHandlerRootView style={{ flex: 1 }}>
           <Overlay

--- a/demo/src/Contexts/BottomTabBar.tsx
+++ b/demo/src/Contexts/BottomTabBar.tsx
@@ -2,6 +2,7 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useMemo,
   useReducer,
 } from 'react';
 import type { HvComponentProps } from 'hyperview';
@@ -103,11 +104,13 @@ export function BottomTabBarContextProvider(p: { children: React.ReactNode }) {
     },
     [dispatch],
   );
-  return (
-    <Context.Provider value={{ getElementProps, setElement, setElementProps }}>
-      {p.children}
-    </Context.Provider>
+
+  const contextValue = useMemo(
+    () => ({ getElementProps, setElement, setElementProps }),
+    [getElementProps, setElement, setElementProps],
   );
+
+  return <Context.Provider value={contextValue}>{p.children}</Context.Provider>;
 }
 
 export const useBottomTabBarContext = () => useContext(Context);

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -562,33 +562,33 @@ export default class Hyperview extends PureComponent<Types.Props> {
     }
   };
 
+  getContextValue = () => ({
+    behaviors: this.props.behaviors,
+    components: this.props.components,
+    elementErrorComponent: this.props.elementErrorComponent,
+    entrypointUrl: this.props.entrypointUrl,
+    errorScreen: this.props.errorScreen,
+    experimentalFeatures: this.props.experimentalFeatures,
+    fetch: this.props.fetch,
+    handleBack: this.props.handleBack,
+    loadingScreen: this.props.loadingScreen,
+    navigationComponents: this.props.navigationComponents,
+    onError: this.props.onError,
+    onParseAfter: this.props.onParseAfter,
+    onParseBefore: this.props.onParseBefore,
+    onRouteBlur: this.props.onRouteBlur,
+    onRouteFocus: this.props.onRouteFocus,
+    onUpdate: this.onUpdate,
+    reload: this.reload,
+  });
+
   render() {
     return (
       <Contexts.DateFormatContext.Provider value={this.props.formatDate}>
         <Contexts.RefreshControlComponentContext.Provider
           value={this.props.refreshControl}
         >
-          <NavContexts.Context.Provider
-            value={{
-              behaviors: this.props.behaviors,
-              components: this.props.components,
-              elementErrorComponent: this.props.elementErrorComponent,
-              entrypointUrl: this.props.entrypointUrl,
-              errorScreen: this.props.errorScreen,
-              experimentalFeatures: this.props.experimentalFeatures,
-              fetch: this.props.fetch,
-              handleBack: this.props.handleBack,
-              loadingScreen: this.props.loadingScreen,
-              navigationComponents: this.props.navigationComponents,
-              onError: this.props.onError,
-              onParseAfter: this.props.onParseAfter,
-              onParseBefore: this.props.onParseBefore,
-              onRouteBlur: this.props.onRouteBlur,
-              onRouteFocus: this.props.onRouteFocus,
-              onUpdate: this.onUpdate,
-              reload: this.reload,
-            }}
-          >
+          <NavContexts.Context.Provider value={this.getContextValue()}>
             <Contexts.ElementCacheProvider>
               <HvRoute />
             </Contexts.ElementCacheProvider>

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -257,6 +257,10 @@ export default class HvScreen extends React.Component {
     });
   };
 
+  getDocContextValue = () => ({
+    getDoc: () => this.doc,
+  });
+
   /**
    * Renders the XML doc into React components. Shows blank screen until the XML doc is available.
    */
@@ -297,11 +301,7 @@ export default class HvScreen extends React.Component {
     }
 
     return (
-      <Contexts.DocContext.Provider
-        value={{
-          getDoc: () => this.doc,
-        }}
-      >
+      <Contexts.DocContext.Provider value={this.getDocContextValue()}>
         <Contexts.DateFormatContext.Provider value={this.props.formatDate}>
           {elementErrorComponent
             ? React.createElement(elementErrorComponent, {

--- a/src/core/components/scroll/context.tsx
+++ b/src/core/components/scroll/context.tsx
@@ -1,5 +1,11 @@
 import type { Offsets, ScrollOffset } from './types';
-import React, { createContext, useContext, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
 
 export const Context = createContext<{
   offsets: Offsets;
@@ -12,17 +18,20 @@ export const Context = createContext<{
 export const Provider = (props: { children: React.ReactNode }) => {
   const [offsets, setOffsets] = useState<Offsets>({});
 
-  const updateOffset = (viewId: string, offset: ScrollOffset) => {
-    setOffsets({
-      ...offsets,
+  const updateOffset = useCallback((viewId: string, offset: ScrollOffset) => {
+    setOffsets(prev => ({
+      ...prev,
       [viewId]: offset,
-    });
-  };
+    }));
+  }, []);
+
+  const contextValue = useMemo(() => ({ offsets, updateOffset }), [
+    offsets,
+    updateOffset,
+  ]);
 
   return (
-    <Context.Provider value={{ offsets, updateOffset }}>
-      {props.children}
-    </Context.Provider>
+    <Context.Provider value={contextValue}>{props.children}</Context.Provider>
   );
 };
 


### PR DESCRIPTION
Based on suggestions from Cursor, updating the values that are passed into context providers. In most cases this was using a combination of `useMemo` and `useCallback`. For the class-based components, this involves using a get function to provide the value.

[Asana](https://app.asana.com/0/1204008699308084/1209802590586962/f)