### PR TITLE
feat(demo): `safe-area` element

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -1,11 +1,6 @@
 import './src/gesture-handler';
 import * as Linking from 'expo-linking';
 import { Logger, fetchWrapper, formatDate } from './src/Helpers';
-import {
-  SafeAreaInsetsContext,
-  SafeAreaProvider,
-} from 'react-native-safe-area-context';
-import { Platform, View } from 'react-native';
 import Behaviors from './src/Behaviors';
 import { BottomTabBar } from './src/Core';
 import { BottomTabBarContextProvider } from './src/Contexts';
@@ -15,6 +10,7 @@ import Hyperview from 'hyperview';
 import LoadingScreen from './src/loading-screen';
 import { NavigationContainer } from '@react-navigation/native';
 import React from 'react';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 // this value needs to match the path prefix where the app is hosted
 // our demo app is hosted under instawork.github.io/hyperview
@@ -39,38 +35,22 @@ const linking = {
 
 export default () => (
   <SafeAreaProvider>
-    <SafeAreaInsetsContext.Consumer>
-      {insets => (
-        <View
-          style={{
-            flex: 1,
-
-            // Padding to handle safe area
-            paddingBottom: insets?.bottom,
-            paddingLeft: insets?.left,
-            paddingRight: insets?.right,
-            paddingTop: insets?.top,
+    <NavigationContainer linking={linking}>
+      <BottomTabBarContextProvider>
+        <Hyperview
+          behaviors={Behaviors}
+          components={Components}
+          entrypointUrl={`${Constants.expoConfig?.extra?.baseUrl}/hyperview/public/index.xml`}
+          experimentalFeatures={{ navStateMutationsDelay: 10 }}
+          fetch={fetchWrapper}
+          formatDate={formatDate}
+          loadingScreen={LoadingScreen}
+          logger={new Logger(Logger.Level.log)}
+          navigationComponents={{
+            BottomTabBar,
           }}
-        >
-          <NavigationContainer linking={linking}>
-            <BottomTabBarContextProvider>
-              <Hyperview
-                behaviors={Behaviors}
-                components={Components}
-                entrypointUrl={`${Constants.expoConfig?.extra?.baseUrl}/hyperview/public/index.xml`}
-                experimentalFeatures={{ navStateMutationsDelay: 10 }}
-                fetch={fetchWrapper}
-                formatDate={formatDate}
-                loadingScreen={LoadingScreen}
-                logger={new Logger(Logger.Level.log)}
-                navigationComponents={{
-                  BottomTabBar,
-                }}
-              />
-            </BottomTabBarContextProvider>
-          </NavigationContainer>
-        </View>
-      )}
-    </SafeAreaInsetsContext.Consumer>
+        />
+      </BottomTabBarContextProvider>
+    </NavigationContainer>
   </SafeAreaProvider>
 );

--- a/demo/backend/_includes/macros/tabbar-bottom/index.xml.njk
+++ b/demo/backend/_includes/macros/tabbar-bottom/index.xml.njk
@@ -3,10 +3,16 @@
     xmlns:navigation="https://hyperview.org/navigation"
     navigation:navigator="{{ navigator }}"
   >
-    <view style="tabbar-bottom" key="tabbar-bottom">
+    <safe-area:safe-area-view
+      xmlns:safe-area="https://hyperview.org/safe-area"
+      key="tabbar-bottom"
+      style="tabbar-bottom"
+      safe-area:mode="padding"
+      safe-area:insets="[&quot;right&quot;,&quot;bottom&quot;,&quot;left&quot;]"
+    >
       {% if caller %}
         {{ caller() }}
       {% endif %}
-    </view>
+    </safe-area:safe-area-view>
   </navigation:bottom-tab-bar>
 {% endmacro %}

--- a/demo/backend/_includes/macros/tabbar-bottom/styles.xml.njk
+++ b/demo/backend/_includes/macros/tabbar-bottom/styles.xml.njk
@@ -6,7 +6,6 @@
   flexDirection="row"
   flexShrink="1"
   flexGrow="0"
-  height="48"
   justifyContent="space-around"
   backgroundColor="white"
   width="100%"

--- a/demo/backend/_includes/templates/base.xml.njk
+++ b/demo/backend/_includes/templates/base.xml.njk
@@ -10,7 +10,7 @@
         {% block styles %}
         {% endblock %}
       </styles>
-      <body style="body" safe-area="true">
+      <body style="body">
         {% block body %}
           {% include 'templates/header.xml.njk' %}
           {% block container %}{% endblock %}

--- a/demo/backend/_includes/templates/header.xml.njk
+++ b/demo/backend/_includes/templates/header.xml.njk
@@ -1,12 +1,20 @@
-<header style="header">
-  {% if hv_button_behavior == 'close' %}
-    <view action="close" href="#" style="header-btn">
-      {% include 'icons/close.svg' %}
-    </view>
-  {% elif hv_button_behavior == 'back' %}
-    <view action="back" href="#" style="header-btn">
-      {% include 'icons/back.svg' %}
-    </view>
-  {% endif %}
-  <text style="header-title">{{ hv_title }}</text>
-</header>
+<safe-area:safe-area-view
+  xmlns:safe-area="https://hyperview.org/safe-area"
+  key="header-container"
+  safe-area:mode="padding"
+  safe-area:insets="[&quot;right&quot;,&quot;top&quot;,&quot;left&quot;]"
+  style="debug"
+>
+  <header style="header" key="header">
+    {% if hv_button_behavior == 'close' %}
+      <view action="close" href="#" style="header-btn">
+        {% include 'icons/close.svg' %}
+      </view>
+    {% elif hv_button_behavior == 'back' %}
+      <view action="back" href="#" style="header-btn">
+        {% include 'icons/back.svg' %}
+      </view>
+    {% endif %}
+    <text style="header-title">{{ hv_title }}</text>
+  </header>
+</safe-area:safe-area-view>

--- a/demo/backend/_includes/templates/styles.xml.njk
+++ b/demo/backend/_includes/templates/styles.xml.njk
@@ -22,7 +22,6 @@
   paddingBottom="16"
   paddingLeft="24"
   paddingRight="24"
-  height="48"
 />
 <style
   id="header-btn"
@@ -32,7 +31,7 @@
   paddingRight="16"
 />
 <style id="header-title" color="black" fontSize="24" fontWeight="600" />
-<style id="body" backgroundColor="white" flex="1" paddingTop="24" />
+<style id="body" backgroundColor="white" flex="1" />
 <style id="description" fontSize="16" margin="24" />
 <style
   id="item"

--- a/demo/schema/hyperview.xsd
+++ b/demo/schema/hyperview.xsd
@@ -7,6 +7,7 @@
   xmlns:alert="https://hyperview.org/hyperview-alert"
   xmlns:filter="https://hyperview.org/filter"
   xmlns:nav="https://hyperview.org/navigation"
+  xmlns:safe-area="https://hyperview.org/safe-area"
   xmlns:scroll="https://hyperview.org/hyperview-scroll"
   xmlns:share="https://hyperview.org/share"
 >
@@ -37,6 +38,10 @@
   <xs:import
     namespace="https://hyperview.org/progress-bar"
     schemaLocation="progress-bar.xsd"
+  />
+  <xs:import
+    namespace="https://hyperview.org/safe-area"
+    schemaLocation="safe-area.xsd"
   />
   <xs:import
     namespace="https://hyperview.org/scroll-opacity"

--- a/demo/schema/safe-area.xsd
+++ b/demo/schema/safe-area.xsd
@@ -1,0 +1,30 @@
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  attributeFormDefault="qualified"
+  elementFormDefault="qualified"
+  targetNamespace="https://hyperview.org/safe-area"
+  xmlns:hv="https://hyperview.org/hyperview"
+  xmlns:safe-area="https://hyperview.org/safe-area"
+>
+  <xs:import
+    namespace="https://hyperview.org/hyperview"
+    schemaLocation="hyperview.xsd"
+  />
+  <xs:simpleType name="mode">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="margin" />
+      <xs:enumeration value="padding" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:element name="safe-area-view">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:any minOccurs="0" maxOccurs="unbounded" />
+      </xs:sequence>
+      <xs:attribute name="key" type="hv:KEY" form="unqualified" />
+      <xs:attribute name="style" type="hv:styleList" form="unqualified" />
+      <xs:attribute name="mode" type="safe-area:mode" />
+      <xs:attribute name="insets" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/demo/src/Components/SafeAreaView/SafeAreaView.tsx
+++ b/demo/src/Components/SafeAreaView/SafeAreaView.tsx
@@ -1,0 +1,103 @@
+import type { HvComponentProps, LocalName } from 'hyperview';
+import React, { useMemo } from 'react';
+import Hyperview from 'hyperview';
+import type { InsetsStyle } from './types';
+import { View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+const namespaceURI = 'https://hyperview.org/safe-area';
+
+const defaultMode = 'padding';
+const defaultInsets = JSON.stringify(['top', 'bottom', 'left', 'right']);
+
+/**
+ * A component that applies safe area insets to its children.
+ * Supported attributes:
+ * - mode: 'margin' | 'padding' (default: 'padding')
+ * - insets: list'top' | 'bottom' | 'left' | 'right' (default: 'top' | 'bottom' | 'left' | 'right')
+ *
+ * Usage:
+ * ```xml
+ * <safe-area:safe-area-view
+ *  xmlns:safe-area="https://hyperview.org/safe-area"
+ *  safe-area:mode="padding"
+ *  safe-area:insets="[&quot;left&quot;, &quot;bottom&quot;, &quot;right&quot;]"
+ * >
+ *   <view>
+ *     <text>Hello, world!</text>
+ *   </view>
+ * </safe-area:safe-area-view>
+ */
+const SafeAreaView = (props: HvComponentProps) => {
+  const key = props.element.getAttribute('key') || undefined;
+  const mode =
+    props.element.getAttributeNS(namespaceURI, 'mode') || defaultMode;
+  const insets =
+    props.element.getAttributeNS(namespaceURI, 'insets') || defaultInsets;
+  const children = Hyperview.renderChildren(
+    props.element,
+    props.stylesheets,
+    props.onUpdate,
+    props.options,
+  );
+  const extraStyle = Hyperview.createStyleProp(
+    props.element,
+    props.stylesheets,
+    props.options,
+  );
+  const safeAreaInsets = useSafeAreaInsets();
+  const style = useMemo(() => {
+    const styles: InsetsStyle = {};
+    try {
+      const styleProps = JSON.parse(insets);
+      switch (mode) {
+        case 'margin':
+          if (styleProps.includes('bottom')) {
+            styles.marginBottom = safeAreaInsets.bottom;
+          }
+          if (styleProps.includes('left')) {
+            styles.marginLeft = safeAreaInsets.left;
+          }
+          if (styleProps.includes('right')) {
+            styles.marginRight = safeAreaInsets.right;
+          }
+          if (styleProps.includes('top')) {
+            styles.marginTop = safeAreaInsets.top;
+          }
+          break;
+        case 'padding':
+          if (styleProps.includes('bottom')) {
+            styles.paddingBottom = safeAreaInsets.bottom;
+          }
+          if (styleProps.includes('left')) {
+            styles.paddingLeft = safeAreaInsets.left;
+          }
+          if (styleProps.includes('right')) {
+            styles.paddingRight = safeAreaInsets.right;
+          }
+          if (styleProps.includes('top')) {
+            styles.paddingTop = safeAreaInsets.top;
+          }
+          break;
+        default:
+          break;
+      }
+    } catch (e) {
+      // Swallow errors
+    }
+    return [styles, extraStyle];
+  }, [insets, mode, safeAreaInsets, extraStyle]);
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <View key={key} style={style}>
+      {children}
+    </View>
+  );
+};
+
+SafeAreaView.namespaceURI = namespaceURI;
+SafeAreaView.localName = 'safe-area-view' as LocalName;
+SafeAreaView.localNameAliases = [] as LocalName[];
+
+export { SafeAreaView };

--- a/demo/src/Components/SafeAreaView/index.ts
+++ b/demo/src/Components/SafeAreaView/index.ts
@@ -1,0 +1,1 @@
+export { SafeAreaView } from './SafeAreaView';

--- a/demo/src/Components/SafeAreaView/types.ts
+++ b/demo/src/Components/SafeAreaView/types.ts
@@ -1,0 +1,10 @@
+export type InsetsStyle = {
+  marginBottom?: number;
+  marginLeft?: number;
+  marginRight?: number;
+  marginTop?: number;
+  paddingBottom?: number;
+  paddingLeft?: number;
+  paddingRight?: number;
+  paddingTop?: number;
+};

--- a/demo/src/Components/index.ts
+++ b/demo/src/Components/index.ts
@@ -8,6 +8,7 @@ import { Map, MapMarker } from './Map';
 import { Filter } from './Filter';
 import { NavBack } from './NavBack';
 import { ProgressBar } from './ProgressBar';
+import { SafeAreaView } from './SafeAreaView';
 import { ScrollOpacity } from './ScrollOpacity';
 import { Svg } from './Svg';
 
@@ -22,6 +23,7 @@ export default [
   MapMarker,
   NavBack,
   ProgressBar,
+  SafeAreaView,
   ScrollOpacity,
   Svg,
 ];

--- a/docs/reference_body.md
+++ b/docs/reference_body.md
@@ -32,7 +32,7 @@ A `<body>` element can only appear as a direct child of a `<screen>` element. Th
 ## Attributes
 
 - [Behavior attributes](#behavior-attributes)
-- [`safe-area`](#safe-area)
+- [`safe-area (deprecated)`](#safe-area)
 - [`style`](#style)
 - [`scroll`](#scroll)
 - [`scroll-orientation`](#scroll-orientation)
@@ -50,6 +50,8 @@ A `<body>` element accepts the standard [behavior attributes](/docs/reference_be
 | boolean, **false** (default) | No       |
 
 If true, the body will be rendered in the safe area of the mobile device (avoiding notches at the top or bottom). Note that `safe-area` will only have an effect if `scroll` is false.
+
+Deprecation note: support for this attribute will be removed in a future release. Instead, implement the custom [safe-area element](https://github.com/Instawork/hyperview/blob/master/demo/src/Components/SafeAreaView/SafeAreaView.tsx).
 
 #### `style`
 

--- a/docs/reference_header.md
+++ b/docs/reference_header.md
@@ -28,7 +28,7 @@ An example header on a screen with a scrolling view.
 ## Attributes
 
 - [Behavior attributes](#behavior-attributes)
-- [`safe-area`](#safe-area)
+- [`safe-area (deprecated)`](#safe-area)
 - [`style`](#style)
 - [`id`](#id)
 - [`hide`](#hide)
@@ -44,6 +44,8 @@ A `<header>` element accepts the standard [behavior attributes](/docs/reference_
 | boolean, **false** (default) | No       |
 
 If true, the body will be rendered in the safe area of the mobile device (avoiding notches at the top or bottom). Note that `safe-area` will only have an effect if `scroll` is false.
+
+Deprecation note: support for this attribute will be removed in a future release. Instead, implement the custom [safe-area element](https://github.com/Instawork/hyperview/blob/master/demo/src/Components/SafeAreaView/SafeAreaView.tsx).
 
 #### `style`
 

--- a/docs/reference_view.md
+++ b/docs/reference_view.md
@@ -50,7 +50,7 @@ A `<view>` element can only appear anywhere within a `<screen>` element.
 ## Attributes
 
 - [Behavior attributes](#behavior-attributes)
-- [`safe-area`](#safe-area)
+- [`safe-area (deprecated)`](#safe-area)
 - [`style`](#style)
 - [`content-container-style`](#content-container-style)
 - [`scroll`](#scroll)
@@ -74,6 +74,8 @@ A `<view>` element accepts the standard [behavior attributes](/docs/reference_be
 | boolean, **false** (default) | No       |
 
 If true, the body will be rendered in the safe area of the mobile device (avoiding notches at the top or bottom). Note that `safe-area` will only have an effect if `scroll` is false.
+
+Deprecation note: support for this attribute will be removed in a future release. Instead, implement the custom [safe-area element](https://github.com/Instawork/hyperview/blob/master/demo/src/Components/SafeAreaView/SafeAreaView.tsx).
 
 #### `style`
 


### PR DESCRIPTION
Add a new element that acts as a safe area container, then update the demo app server code to make use of it.

See commits breakdown for details

| iOS | Android |
|--|--|
| ![iOS](https://github.com/user-attachments/assets/5ea721a5-8a55-48ed-b04c-4ac0244a1adc) | ![Android](https://github.com/user-attachments/assets/21a33fbb-dd03-45ac-ba4e-0f00f7350263) |
