### PR TITLE
chore: lift navigation service instance into FC

### DIFF
--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -45,6 +45,7 @@ export type RouteProps = NavigatorService.Route<string, { url?: string }>;
 export type InnerRouteProps = {
   url?: string;
   navigation?: NavigatorService.NavigationProp;
+  navigator: NavigatorService.Navigator;
   route?: NavigatorService.Route<string, RouteParams>;
   entrypointUrl: string;
   fetch: Fetch;

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -1,6 +1,5 @@
 import * as Components from 'hyperview/src/services/components';
 import * as Helpers from './helpers';
-import * as HvRoute from 'hyperview/src/core/components/hv-route';
 import * as Imports from './imports';
 import * as Logging from 'hyperview/src/services/logging';
 import * as Namespaces from 'hyperview/src/services/namespaces';
@@ -13,28 +12,17 @@ import type {
   NavigationRouteParams,
 } from 'hyperview/src/types';
 import { NAV_ACTIONS } from 'hyperview/src/types';
-import { NavigationContainerRefContext } from '@react-navigation/native';
 import { uuidNumber } from 'hyperview/src/core/utils';
 
 /**
  * Provide navigation action implementations
  */
 export class Navigator implements NavigationProvider {
-  props: HvRoute.InnerRouteProps;
+  props: Types.Props;
 
-  context:
-    | React.ContextType<typeof NavigationContainerRefContext>
-    | undefined = undefined;
-
-  constructor(props: HvRoute.InnerRouteProps) {
+  constructor(props: Types.Props) {
     this.props = props;
   }
-
-  setContext = (
-    context: React.ContextType<typeof NavigationContainerRefContext>,
-  ) => {
-    this.context = context;
-  };
 
   /**
    * Process the request by changing params before going back
@@ -75,7 +63,7 @@ export class Navigator implements NavigationProvider {
 
     // Update the params of the new focused route
     if (routeParams) {
-      const route = this.context?.getCurrentRoute();
+      const route = this.props.rootNavigation?.getCurrentRoute();
       if (route) {
         navigation.dispatch({
           ...Imports.CommonActions.setParams({

--- a/src/services/navigator/types.ts
+++ b/src/services/navigator/types.ts
@@ -1,4 +1,5 @@
-import type { NavigationRouteParams } from 'hyperview/src/types';
+import type { NavigationRouteParams, RouteParams } from 'hyperview/src/types';
+import { NavigationContainerRefContext } from '@react-navigation/native';
 import type { BottomTabBarProps as RNBottomTabBarProps } from '@react-navigation/bottom-tabs';
 
 export const ANCHOR_ID_SEPARATOR = '#';
@@ -17,6 +18,16 @@ export const KEY_HREF = 'href';
 export const NAVIGATOR_TYPE = {
   STACK: 'stack',
   TAB: 'tab',
+};
+
+export type Props = {
+  navigation?: NavigationProp;
+  route?: Route<string, RouteParams>;
+  entrypointUrl: string;
+  rootNavigation?:
+    | React.ContextType<typeof NavigationContainerRefContext>
+    | undefined;
+  setElement: (key: number, element: Element) => void;
 };
 
 /**


### PR DESCRIPTION
Lifting the instantiation of the Navigator service from the class to the FC. This is in preparation for future migrations. It also allows cleaning up the implementation by removing the static context and the `setContext` method.

[Asana](https://app.asana.com/0/1205761271270033/1209828747042806/f)