### PR TITLE
chore: fix class component context

### DIFF
--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -49,7 +49,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
 
   parser: Dom.Parser;
 
-  private contextValue: ReturnType<typeof this.getContextValue>;
+  private contextValue: NavContexts.NavigationContextProps;
 
   constructor(props: Types.Props) {
     super(props);
@@ -63,31 +63,35 @@ export default class Hyperview extends PureComponent<Types.Props> {
 
     this.behaviorRegistry = Behaviors.getRegistry(this.props.behaviors);
     this.componentRegistry = new Components.Registry(this.props.components);
-    this.contextValue = this.getContextValue();
+    this.contextValue = this.getContextValue(props);
   }
 
-  componentDidUpdate(prevProps: Types.Props) {
-    // Update context value if any dependencies changed
-    if (
-      prevProps.behaviors !== this.props.behaviors ||
-      prevProps.components !== this.props.components ||
-      prevProps.elementErrorComponent !== this.props.elementErrorComponent ||
-      prevProps.entrypointUrl !== this.props.entrypointUrl ||
-      prevProps.errorScreen !== this.props.errorScreen ||
-      prevProps.experimentalFeatures !== this.props.experimentalFeatures ||
-      prevProps.fetch !== this.props.fetch ||
-      prevProps.handleBack !== this.props.handleBack ||
-      prevProps.loadingScreen !== this.props.loadingScreen ||
-      prevProps.navigationComponents !== this.props.navigationComponents ||
-      prevProps.onError !== this.props.onError ||
-      prevProps.onParseAfter !== this.props.onParseAfter ||
-      prevProps.onParseBefore !== this.props.onParseBefore ||
-      prevProps.onRouteBlur !== this.props.onRouteBlur ||
-      prevProps.onRouteFocus !== this.props.onRouteFocus
-    ) {
-      this.contextValue = this.getContextValue();
-    }
-  }
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillUpdate = (nextProps: Readonly<Types.Props>) => {
+    this.contextValue = this.getContextValue(nextProps);
+  };
+
+  getContextValue = (p: Types.Props) => {
+    return {
+      behaviors: p.behaviors,
+      components: p.components,
+      elementErrorComponent: p.elementErrorComponent,
+      entrypointUrl: p.entrypointUrl,
+      errorScreen: p.errorScreen,
+      experimentalFeatures: p.experimentalFeatures,
+      fetch: p.fetch,
+      handleBack: p.handleBack,
+      loadingScreen: p.loadingScreen,
+      navigationComponents: p.navigationComponents,
+      onError: p.onError,
+      onParseAfter: p.onParseAfter,
+      onParseBefore: p.onParseBefore,
+      onRouteBlur: p.onRouteBlur,
+      onRouteFocus: p.onRouteFocus,
+      onUpdate: this.onUpdate,
+      reload: this.reload,
+    };
+  };
 
   /**
    * Reload if an error occured.
@@ -587,26 +591,6 @@ export default class Hyperview extends PureComponent<Types.Props> {
       Logging.warn(`No behavior registered for action "${action}"`);
     }
   };
-
-  getContextValue = () => ({
-    behaviors: this.props.behaviors,
-    components: this.props.components,
-    elementErrorComponent: this.props.elementErrorComponent,
-    entrypointUrl: this.props.entrypointUrl,
-    errorScreen: this.props.errorScreen,
-    experimentalFeatures: this.props.experimentalFeatures,
-    fetch: this.props.fetch,
-    handleBack: this.props.handleBack,
-    loadingScreen: this.props.loadingScreen,
-    navigationComponents: this.props.navigationComponents,
-    onError: this.props.onError,
-    onParseAfter: this.props.onParseAfter,
-    onParseBefore: this.props.onParseBefore,
-    onRouteBlur: this.props.onRouteBlur,
-    onRouteFocus: this.props.onRouteFocus,
-    onUpdate: this.onUpdate,
-    reload: this.reload,
-  });
 
   render() {
     return (

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -69,7 +69,7 @@ export default class HvScreen extends React.Component {
 
     this.behaviorRegistry = Behaviors.getRegistry(this.props.behaviors);
     this.componentRegistry = new Components.Registry(this.props.components);
-    this.docContextValue = this.getDocContextValue();
+    this.contextValue = this.getContextValue(props);
   }
 
   getRoute = props => {
@@ -159,6 +159,17 @@ export default class HvScreen extends React.Component {
     }
   };
 
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillUpdate = nextProps => {
+    this.contextValue = this.getContextValue(nextProps);
+  };
+
+  getContextValue = () => {
+    return {
+      getDoc: () => this.doc,
+    };
+  };
+
   /**
    * Clear out the preload screen associated with this screen.
    */
@@ -177,11 +188,7 @@ export default class HvScreen extends React.Component {
   /**
    * Fetch data from the url if the screen should reload.
    */
-  componentDidUpdate(prevProps) {
-    if (prevProps.formatDate !== this.props.formatDate) {
-      this.docContextValue = this.getDocContextValue();
-    }
-
+  componentDidUpdate() {
     if (this.needsLoad) {
       this.load(this.state.url);
       this.needsLoad = false;
@@ -262,10 +269,6 @@ export default class HvScreen extends React.Component {
     });
   };
 
-  getDocContextValue = () => ({
-    getDoc: () => this.doc,
-  });
-
   /**
    * Renders the XML doc into React components. Shows blank screen until the XML doc is available.
    */
@@ -306,7 +309,7 @@ export default class HvScreen extends React.Component {
     }
 
     return (
-      <Contexts.DocContext.Provider value={this.docContextValue}>
+      <Contexts.DocContext.Provider value={this.contextValue}>
         <Contexts.DateFormatContext.Provider value={this.props.formatDate}>
           {elementErrorComponent
             ? React.createElement(elementErrorComponent, {


### PR DESCRIPTION
The `componentDidUpdate` appears to be happening too late to update the values used in the context for these class components. Switching to use `UNSAFE_componentWillUpdate` until these components are migrated to FCs.