### PR TITLE
feat(unload): add support for `unload` trigger

### DIFF
--- a/demo/backend/behaviors/basic/triggers/unload/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/unload/index.xml.njk
@@ -1,0 +1,30 @@
+---
+permalink: "/behaviors/basic/unload/index.xml"
+tags: "Behaviors/Basic/Triggers"
+hv_title: "Unload"
+hv_button_behavior: "back"
+---
+
+{% extends 'templates/scrollview.xml.njk' %}
+{% from 'macros/button/index.xml.njk' import button %}
+{% from 'macros/description/index.xml.njk' import description %}
+
+{% block content %}
+  {{ description('Navigate to the next screen. When you navigate back, a message will be displayed.') }}
+
+  <view id="confirmation" style="container-style" hide="true">
+    <text style="confirmation-label">The screen was unloaded</text>
+  </view>
+
+  {% call button('Next', attributes={xmlns:"https://hyperview.org/hyperview"}) -%}
+    <behavior action="push" href="/hyperview/public/behaviors/basic/triggers/unload/unload.xml" />
+  {%- endcall %}
+
+  <behavior
+    action="show"
+    target="confirmation"
+    trigger="on-event"
+    event-name="unload-example"
+  />
+
+{% endblock %}

--- a/demo/backend/behaviors/basic/triggers/unload/unload.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/unload/unload.xml.njk
@@ -1,0 +1,22 @@
+---
+permalink: "/behaviors/basic/triggers/unload/unload.xml"
+---
+
+{% extends 'templates/scrollview.xml.njk' %}
+{% from 'macros/button/index.xml.njk' import button %}
+{% from 'macros/description/index.xml.njk' import description %}
+
+{% block content %}
+  {{ description('Navigate back to the previous screen to see the confirmation message.') }}
+
+  {% call button('Go back', attributes={xmlns:"https://hyperview.org/hyperview"}) -%}
+    <behavior action="back" />
+  {%- endcall %}
+
+  <behavior
+    trigger="unload"
+    event-name="unload-example"
+    action="dispatch-event"
+  />
+
+{% endblock %}

--- a/docs/reference_behavior_attributes.md
+++ b/docs/reference_behavior_attributes.md
@@ -105,6 +105,16 @@ These elements support the `load` trigger:
 - [`<text>`](/docs/reference_text)
 - [`<image>`](/docs/reference_image)
 
+### `unload`
+
+Triggers when the element is unloaded in the screen.
+
+> Elements with `hide="true"` are not unloaded in the screen. This means any hidden element (or child element) with the `unload` trigger will not be executed.
+
+These elements support the `unload` trigger:
+
+- [`<view>`](/docs/reference_view)
+
 ### `select`
 
 Triggers when the element is selected. Only works on selectable elements.

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -42,6 +42,7 @@
       <xs:enumeration value="on-event" />
       <xs:enumeration value="change" />
       <xs:enumeration value="load-stale-error" />
+      <xs:enumeration value="unload" />
     </xs:restriction>
   </xs:simpleType>
 

--- a/src/core/hyper-ref/index.tsx
+++ b/src/core/hyper-ref/index.tsx
@@ -100,6 +100,9 @@ export default class HyperRef extends PureComponent<Props, State> {
     Events.unsubscribe(this.onEventDispatch);
     // Deregister event listener for back triggers
     this.removeBackBehaviors();
+    if (this.props.element.localName === LOCAL_NAME.VIEW) {
+      this.triggerUnLoadBehaviors();
+    }
   }
 
   updateBehaviorElements = () => {
@@ -213,6 +216,27 @@ export default class HyperRef extends PureComponent<Props, State> {
       Behaviors.triggerBehaviors(
         this.props.element,
         loadBehaviors,
+        this.props.onUpdate,
+      );
+    }
+  };
+
+  triggerUnLoadBehaviors = () => {
+    let unloadBehaviors = this.getBehaviorElements(TRIGGERS.UNLOAD);
+    if (
+      this.props.options?.staleHeaderType ===
+      X_RESPONSE_STALE_REASON.STALE_IF_ERROR
+    ) {
+      const loadStaleBehaviors = this.getBehaviorElements(
+        TRIGGERS.LOAD_STALE_ERROR,
+      );
+      unloadBehaviors = unloadBehaviors.concat(loadStaleBehaviors);
+    }
+
+    if (unloadBehaviors.length > 0) {
+      Behaviors.triggerBehaviors(
+        this.props.element,
+        unloadBehaviors,
         this.props.onUpdate,
       );
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -276,6 +276,7 @@ export const TRIGGERS = Object.freeze({
   PRESS_OUT: 'pressOut',
   REFRESH: 'refresh',
   SELECT: 'select',
+  UNLOAD: 'unload',
   VISIBLE: 'visible',
 });
 


### PR DESCRIPTION
Adding a new `unload` trigger which is triggered when a `view` is unmounted.

[Asana](https://app.asana.com/0/1204008699308084/1209860719801774/f)


https://github.com/user-attachments/assets/bf0f0079-ff02-41bf-903e-be9d6de9d36e

