### PR TITLE
chore(hv-doc): lift error component into hv-doc

### DIFF
--- a/src/core/components/hv-doc/context.ts
+++ b/src/core/components/hv-doc/context.ts
@@ -21,6 +21,7 @@ export const StateContext = createContext<StateContextProps>({
   loadUrl: () => null,
   onUpdate: () => undefined,
   onUpdateCallbacks: callbacks,
+  reload: () => null,
   setNeedsLoadCallback: () => null,
   setScreenState: () => undefined,
 });

--- a/src/core/components/hv-doc/index.tsx
+++ b/src/core/components/hv-doc/index.tsx
@@ -79,7 +79,7 @@ const HvDoc = (props: Props) => {
   const loadUrl = useCallback(
     async (url?: string) => {
       // Updates the state and calls the error handler
-      const handleError = (err: Error) => {
+      const handleError = (err: Error, u?: string | null) => {
         try {
           if (navigationContext.onError) {
             navigationContext.onError(err);
@@ -88,13 +88,14 @@ const HvDoc = (props: Props) => {
           setState(prev => ({
             ...prev,
             error: err,
+            url: u ?? prev.url,
           }));
         }
       };
 
       const targetUrl = url ?? state.url;
       if (!targetUrl) {
-        handleError(new HvDocError('No URL provided'));
+        handleError(new HvDocError('No URL provided'), targetUrl);
         return;
       }
 
@@ -136,12 +137,12 @@ const HvDoc = (props: Props) => {
         } else {
           // Invalid document
           localDoc.current = undefined;
-          handleError(new HvDocError('No root element found'));
+          handleError(new HvDocError('No root element found'), targetUrl);
         }
       } catch (err: unknown) {
         // Error
         localDoc.current = undefined;
-        handleError(err as Error);
+        handleError(err as Error, targetUrl);
       }
     },
     [navigationContext, parser, props.route?.params.delay, state.url],

--- a/src/core/components/hv-doc/types.ts
+++ b/src/core/components/hv-doc/types.ts
@@ -27,6 +27,13 @@ export type StateContextProps = {
   loadUrl: (url?: string) => void;
   onUpdate: HvComponentOnUpdate;
   onUpdateCallbacks: OnUpdateCallbacks;
+  reload: (url?: string | null) => void;
   setNeedsLoadCallback: (callback: () => void) => void;
   setScreenState: (state: ScreenState) => void;
+};
+
+export type ErrorProps = {
+  error: Error | null | undefined;
+  navigationProvider?: NavigationProvider;
+  url: string | null | undefined;
 };

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -223,6 +223,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
             loadUrl,
             onUpdate,
             onUpdateCallbacks,
+            reload,
             setNeedsLoadCallback,
             setScreenState,
           }) => (
@@ -246,7 +247,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
                   onParseBefore={this.props.onParseBefore}
                   onUpdate={onUpdate}
                   onUpdateCallbacks={onUpdateCallbacks}
-                  reload={this.props.reload}
+                  reload={reload}
                   removeElement={this.props.removeElement}
                   route={route}
                   setNeedsLoadCallback={setNeedsLoadCallback}

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -234,17 +234,12 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
                   components={this.props.components}
                   elementErrorComponent={this.props.elementErrorComponent}
                   entrypointUrl={this.props.entrypointUrl}
-                  errorScreen={this.props.errorScreen}
-                  fetch={this.props.fetch}
                   formatDate={formatter}
                   getElement={this.props.getElement}
                   getLocalDoc={getLocalDoc}
                   getScreenState={getScreenState}
                   loadUrl={loadUrl}
                   navigation={this.props.navigator}
-                  onError={this.props.onError}
-                  onParseAfter={this.props.onParseAfter}
-                  onParseBefore={this.props.onParseBefore}
                   onUpdate={onUpdate}
                   onUpdateCallbacks={onUpdateCallbacks}
                   reload={reload}
@@ -252,7 +247,6 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
                   route={route}
                   setNeedsLoadCallback={setNeedsLoadCallback}
                   setScreenState={setScreenState}
-                  url={url || undefined}
                 />
               )}
             </Contexts.DateFormatContext.Consumer>
@@ -582,8 +576,6 @@ function HvRouteFC(props: Types.Props) {
             element={element}
             elementErrorComponent={navigationContext.elementErrorComponent}
             entrypointUrl={navigationContext.entrypointUrl}
-            errorScreen={navigationContext.errorScreen}
-            fetch={navigationContext.fetch}
             getElement={elemenCacheContext.getElement}
             getLocalDoc={getLocalDoc}
             getScreenState={getScreenState}
@@ -591,9 +583,6 @@ function HvRouteFC(props: Types.Props) {
             loadUrl={loadUrl}
             navigation={nav}
             navigator={navigator}
-            onError={navigationContext.onError}
-            onParseAfter={navigationContext.onParseAfter}
-            onParseBefore={navigationContext.onParseBefore}
             onUpdate={onUpdate}
             onUpdateCallbacks={onUpdateCallbacks}
             removeElement={elemenCacheContext.removeElement}

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -13,7 +13,6 @@ import {
   BackBehaviorProvider,
 } from 'hyperview/src/contexts/back-behaviors';
 import HvDoc, { StateContext } from 'hyperview/src/core/components/hv-doc';
-import type { NavigationRouteParams, ScreenState } from 'hyperview/src/types';
 import React, {
   JSXElementConstructor,
   PureComponent,
@@ -23,9 +22,9 @@ import React, {
 import HvNavigator from 'hyperview/src/core/components/hv-navigator';
 import HvScreen from 'hyperview/src/core/components/hv-screen';
 import { LOCAL_NAME } from 'hyperview/src/types';
-import LoadError from 'hyperview/src/core/components/load-error';
 import Loading from 'hyperview/src/core/components/loading';
 import { NavigationContainerRefContext } from '@react-navigation/native';
+import type { ScreenState } from 'hyperview/src/types';
 
 /**
  * Implementation of an HvRoute component
@@ -185,27 +184,6 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
                 this.props.route.params.routeId,
               )
             : undefined;
-        }}
-      />
-    );
-  };
-
-  /**
-   * View shown when there is an error
-   */
-  Error = (props: { error: Error | null | undefined }): React.ReactElement => {
-    const ErrorScreen = this.props.errorScreen || LoadError;
-    return (
-      <ErrorScreen
-        back={() =>
-          this.props.navigator.backAction({} as NavigationRouteParams)
-        }
-        error={props.error}
-        onPressReload={() => this.load()}
-        onPressViewDetails={(uri: string | undefined) => {
-          this.props.navigator.openModalAction({
-            url: uri as string,
-          } as NavigationRouteParams);
         }}
       />
     );
@@ -384,25 +362,16 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
   };
 
   render() {
-    const { Error: Err, Load, Content } = this;
-    try {
-      if (this.props.getScreenState().error) {
-        return <Err error={this.props.getScreenState().error} />;
-      }
-      if (
-        this.props.element ||
-        this.props.getLocalDoc() ||
-        this.props.route?.params?.isModal
-      ) {
-        return <Content />;
-      }
-      return <Load />;
-    } catch (err) {
-      if (this.props.onError) {
-        this.props.onError(err as Error);
-      }
-      return <Err error={err as Error} />;
+    const { Load, Content } = this;
+
+    if (
+      this.props.element ||
+      this.props.getLocalDoc() ||
+      this.props.route?.params?.isModal
+    ) {
+      return <Content />;
     }
+    return <Load />;
   }
 }
 
@@ -626,7 +595,6 @@ function HvRouteFC(props: Types.Props) {
             onParseBefore={navigationContext.onParseBefore}
             onUpdate={onUpdate}
             onUpdateCallbacks={onUpdateCallbacks}
-            reload={navigationContext.reload}
             removeElement={elemenCacheContext.removeElement}
             route={props.route}
             setElement={elemenCacheContext.setElement}

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -49,16 +49,11 @@ export type InnerRouteProps = {
   navigator: NavigatorService.Navigator;
   route?: NavigatorService.Route<string, RouteParams>;
   entrypointUrl: string;
-  fetch: Fetch;
-  onError?: (error: Error) => void;
-  onParseAfter?: (url: string) => void;
-  onParseBefore?: (url: string) => void;
   onUpdate: HvComponentOnUpdate;
   onUpdateCallbacks: OnUpdateCallbacks;
   behaviors?: HvBehavior[];
   components?: HvComponent[];
   elementErrorComponent?: ComponentType<ErrorProps>;
-  errorScreen?: ComponentType<ErrorProps>;
   handleBack?: ComponentType<{ children: ReactNode }>;
   setElement: (key: number, element: Element) => void;
   getElement: (key: number) => Element | undefined;

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -64,7 +64,6 @@ export type InnerRouteProps = {
   getElement: (key: number) => Element | undefined;
   removeElement: (key: number) => void;
   element?: Element;
-  reload: Reload;
   doc: Document | undefined;
   getLocalDoc: () => Document | null;
   getScreenState: () => ScreenState;

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -10,7 +10,6 @@ import * as Stylesheets from 'hyperview/src/services/stylesheets';
 import { createProps, createStyleProp } from 'hyperview/src/services';
 import { HvScreenRenderError } from './errors';
 import LoadElementError from '../load-element-error';
-import LoadError from 'hyperview/src/core/components/load-error';
 import Loading from 'hyperview/src/core/components/loading';
 import React from 'react';
 
@@ -163,33 +162,9 @@ export default class HvScreen extends React.Component {
   };
 
   /**
-   * Reload if an error occured using the screen's current URL
-   */
-  reload = () => {
-    this.props.reload(this.props.getScreenState().url, {
-      onUpdateCallbacks: this.props.updateCallbacks,
-    });
-  };
-
-  Error = ({ error }) => {
-    const errorScreen = this.props.errorScreen || LoadError;
-    return React.createElement(errorScreen, {
-      back: () => this.props.navigation.backAction(),
-      error,
-      onPressReload: () => this.reload(), // Make sure reload() is called without any args
-      onPressViewDetails: uri =>
-        this.props.navigation.openModalAction({ url: uri }),
-    });
-  };
-
-  /**
    * Renders the XML doc into React components. Shows blank screen until the XML doc is available.
    */
   render() {
-    const { Error } = this;
-    if (this.props.getScreenState().error) {
-      return <Error error={this.props.getScreenState().error} />;
-    }
     if (!this.props.getScreenState().doc) {
       return <Loading cachedId={this.props.route?.params?.behaviorElementId} />;
     }
@@ -216,11 +191,7 @@ export default class HvScreen extends React.Component {
       );
     }
     if (!screenElement) {
-      return (
-        <Error
-          error={new HvScreenRenderError('The document has no content.')}
-        />
-      );
+      throw new HvScreenRenderError('The document has no content.');
     }
 
     return (
@@ -235,7 +206,7 @@ export default class HvScreen extends React.Component {
                 error: this.props.getScreenState().elementError,
                 onPressClose: () =>
                   this.props.setScreenState({ elementError: null }),
-                onPressReload: () => this.reload(),
+                onPressReload: () => this.props.reload(),
               })
             : null}
           <Scroll.Provider>{screenElement}</Scroll.Provider>

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -3,7 +3,6 @@ import type {
   HvComponentOnUpdate,
   NavigationProvider,
   OnUpdateCallbacks,
-  Reload,
   ScreenState,
 } from 'hyperview/src/types';
 import { Props as HvRootProps } from 'hyperview/src/core/components/hv-root/types';
@@ -25,7 +24,7 @@ export type Props = Omit<
   navigation: NavigationProvider;
   onUpdate: HvComponentOnUpdate;
   onUpdateCallbacks: OnUpdateCallbacks;
-  reload: Reload;
+  reload: (url?: string | null) => void;
   removeElement?: (id: number) => void;
   route?: NavigatorService.Route<string, { url?: string }>;
   url?: string;

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -19,6 +19,12 @@ export type Props = Omit<
   | 'loadingScreen'
   | 'handleBack'
   | 'logger'
+  | 'errorScreen'
+  | 'fetch'
+  | 'onError'
+  | 'onParseAfter'
+  | 'onParseBefore'
+  | 'url'
 > & {
   getElement?: (id: number) => Element | undefined;
   navigation: NavigationProvider;


### PR DESCRIPTION
Lifting the error component into `hv-doc`.

Also resolved an issue where the `retry` option was faulty. The retry was previously based on the url in state which was only set on success. This meant that a first request failure would have no url to try. It also meant that subsequent requests would end up retrying the previous url instead of the current.

[Asana](https://app.asana.com/0/1204008699308084/1209771721803061/f)