### PR TITLE
chore(hv-doc): improve state stability and data

### DIFF
--- a/src/core/components/hv-doc/index.tsx
+++ b/src/core/components/hv-doc/index.tsx
@@ -173,8 +173,34 @@ const HvDoc = (props: Props) => {
     [hasElement],
   );
 
+  const onUpdateCallbacksRef = useRef<OnUpdateCallbacks>();
+
+  const onUpdate = useCallback(
+    (
+      href: DOMString | null | undefined,
+      action: DOMString | null | undefined,
+      element: Element,
+      options: HvComponentOptions,
+    ) => {
+      navigationContext.onUpdate(href, action, element, {
+        ...options,
+        onUpdateCallbacks: onUpdateCallbacksRef.current,
+      });
+    },
+    [navigationContext],
+  );
+
+  const reload = useCallback(
+    (url?: string | null) => {
+      navigationContext.reload(url, {
+        onUpdateCallbacks: onUpdateCallbacksRef.current,
+      });
+    },
+    [navigationContext],
+  );
+
   const contextValue = useMemo(() => {
-    const onUpdateCallbacks: OnUpdateCallbacks = {
+    onUpdateCallbacksRef.current = {
       clearElementError: () => {
         if (state.elementError) {
           setState(prev => ({
@@ -191,30 +217,12 @@ const HvDoc = (props: Props) => {
       setState: setScreenState,
     };
 
-    const reload = (url?: string | null) => {
-      navigationContext.reload(url, {
-        onUpdateCallbacks,
-      });
-    };
-
-    const onUpdate = (
-      href: DOMString | null | undefined,
-      action: DOMString | null | undefined,
-      element: Element,
-      options: HvComponentOptions,
-    ) => {
-      navigationContext.onUpdate(href, action, element, {
-        ...options,
-        onUpdateCallbacks,
-      });
-    };
-
     return {
       getLocalDoc: getDoc,
       getScreenState,
       loadUrl,
       onUpdate,
-      onUpdateCallbacks,
+      onUpdateCallbacks: onUpdateCallbacksRef.current,
       reload,
       setNeedsLoadCallback: (callback: () => void) => {
         needsLoadCallback.current = callback;
@@ -226,7 +234,8 @@ const HvDoc = (props: Props) => {
     getNavigation,
     getScreenState,
     loadUrl,
-    navigationContext,
+    onUpdate,
+    reload,
     setScreenState,
     state.elementError,
   ]);

--- a/src/core/components/hv-doc/index.tsx
+++ b/src/core/components/hv-doc/index.tsx
@@ -158,6 +158,7 @@ const HvDoc = (props: Props) => {
   const getNavigation = useCallback(() => props.navigationProvider, [
     props.navigationProvider,
   ]);
+  const hasElement = !!props.element;
   const setScreenState = useCallback(
     (newState: ScreenState) => {
       if (newState.doc !== undefined) {
@@ -166,10 +167,10 @@ const HvDoc = (props: Props) => {
       setState(prev => ({
         ...prev,
         ...newState,
-        doc: props.element ? null : newState.doc ?? prev.doc,
+        doc: hasElement ? null : newState.doc ?? prev.doc,
       }));
     },
-    [props.element],
+    [hasElement],
   );
 
   const contextValue = useMemo(() => {


### PR DESCRIPTION
1. Having the `onUpdate` inside the `useMemo` was causing occasional infinite loops with external components which have `useEffect` hooks that depend on `onUpdate` (see [example](https://github.com/Instawork/mobile/blob/81b00f1974f373150580b9c76e113627eca312b4/core-mobile/src/components/hyperview-s3-file-upload/hooks/ui-state.ts#L38-L83)). By moving the `onUpdate` outside of the memo, it becomes a stable reference and does not trigger external hooks.

2. Also stabilized the `setScreenState` callback by depending on the presence of an element rather than the element itself.

3. Temporarily provide immediate access to the `url` value of state. Currently external components are still calling loadUrl which is occurring before the state has completed. Once the load hooks are internalized, this change can be removed.