### PR TITLE
chore(modal): update `isModal` param usage

### DIFF
--- a/src/core/components/hv-navigator/index.tsx
+++ b/src/core/components/hv-navigator/index.tsx
@@ -188,13 +188,14 @@ export default class HvNavigator extends PureComponent<Props> {
     id: string,
     type: string,
     href: string | undefined,
-    isModal: boolean,
+    needsSubStack: boolean,
     isFirstScreen = false,
     routeId?: string | undefined,
+    isModal = false,
   ): React.ReactElement => {
     const initialParams = NavigatorService.isDynamicRoute(id)
       ? {}
-      : { id, isModal, routeId, url: href };
+      : { id, isModal, needsSubStack, routeId, url: href };
     if (type === NavigatorService.NAVIGATOR_TYPE.TAB) {
       return (
         <BottomTab.Screen
@@ -206,7 +207,7 @@ export default class HvNavigator extends PureComponent<Props> {
       );
     }
     if (type === NavigatorService.NAVIGATOR_TYPE.STACK) {
-      const gestureEnabled = Platform.OS === 'ios' ? !isModal : false;
+      const gestureEnabled = Platform.OS === 'ios' ? !needsSubStack : false;
       return (
         <Stack.Screen
           key={id}
@@ -216,11 +217,11 @@ export default class HvNavigator extends PureComponent<Props> {
           name={id}
           options={{
             animationEnabled: !isFirstScreen,
-            cardStyleInterpolator: isModal
+            cardStyleInterpolator: needsSubStack
               ? NavigatorService.CardStyleInterpolators.forVerticalIOS
               : undefined,
             gestureEnabled,
-            presentation: isModal
+            presentation: needsSubStack
               ? NavigatorService.ID_MODAL
               : NavigatorService.ID_CARD,
           }}
@@ -308,6 +309,7 @@ export default class HvNavigator extends PureComponent<Props> {
             isModal,
             index === 0,
             id,
+            isModal,
           ),
         );
       }
@@ -421,6 +423,7 @@ export default class HvNavigator extends PureComponent<Props> {
         false,
         false,
         this.props.params.id,
+        true,
       ),
     );
     screens.push(...this.buildDynamicScreens());
@@ -457,7 +460,7 @@ export default class HvNavigator extends PureComponent<Props> {
   };
 
   render() {
-    const Navigator = this.props.params?.isModal
+    const Navigator = this.props.params?.needsSubStack
       ? this.ModalNavigator
       : this.Navigator;
     return (

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -139,7 +139,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
       // When a modal is included, a wrapper stack navigator is created
       // The route which contains the navigator should not load the document
       // The code below prevents the route from loading the document
-      if (this.props.route?.params?.isModal || !this.shouldReload()) {
+      if (this.props.route?.params?.needsSubStack || !this.shouldReload()) {
         return;
       }
 
@@ -381,15 +381,15 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
   Route = (): React.ReactElement => {
     const { Screen } = this;
 
-    const isModal = this.props.route?.params.isModal
-      ? this.props.route.params.isModal
+    const needsSubStack = this.props.route?.params.needsSubStack
+      ? this.props.route.params.needsSubStack
       : false;
 
-    const renderElement: Element | undefined = isModal
+    const renderElement: Element | undefined = needsSubStack
       ? undefined
       : this.getRenderElement();
 
-    if (!isModal) {
+    if (!needsSubStack) {
       if (!renderElement) {
         throw new NavigatorService.HvRenderError('No element found');
       }
@@ -399,7 +399,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
       }
     }
 
-    if (isModal || renderElement?.localName === LOCAL_NAME.NAVIGATOR) {
+    if (needsSubStack || renderElement?.localName === LOCAL_NAME.NAVIGATOR) {
       if (this.localDoc) {
         // The <DocContext> provides doc access to nested navigators
         // The <UpdateContext> provides access to the onUpdate method for this route
@@ -466,7 +466,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
   Content = (): React.ReactElement => {
     if (
       this.props.element === undefined &&
-      !this.props.route?.params?.isModal
+      !this.props.route?.params?.needsSubStack
     ) {
       if (!this.props.url) {
         throw new NavigatorService.HvRouteError('No url received');
@@ -489,7 +489,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
       if (
         this.props.element ||
         this.localDoc ||
-        this.props.route?.params?.isModal
+        this.props.route?.params?.needsSubStack
       ) {
         return <Content />;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -392,6 +392,7 @@ export type RouteParams = {
   preloadScreen?: number;
   isModal?: boolean;
   routeId?: string;
+  needsSubStack?: boolean;
 };
 
 export const ON_EVENT_DISPATCH = 'hyperview:on-event';


### PR DESCRIPTION
Using a navigation structure with a modal:
```
<navigator id="home" type="stack">
  <nav-route id="test" href="foo" modal="true" />
</navigator>
```
The components will automatically inject a stack navigator into the modal, resulting in the following:
```
<navigator id="home" type="stack">
  <nav-route id="test" href="foo" modal="true">    <--- modal=true
    <navigator id="modal-stack" type="stack">
      <nav-route id="modal-test" href="foo" modal="false" />   <--- modal=false
    </navigator>
  </nav-route>
</navigator>
```
Note in this case the inner route "modal-test" is the one which performs the load. In current Hyperview, the modal is set to false for this route.

The change will preserve all existing functionality but ensure the "isModal" param for both routes will be "true". The new `needsSubStack` property will be used internally to handle the required setup, and the `isModal` will be purely informational indicating both the original route and the created sub-stack route both have a value of `true`.

| Before | After |
| -- | -- |
| ![before](https://github.com/user-attachments/assets/dc264dc0-8512-4253-a425-fc7b1e45cd1d) | ![after](https://github.com/user-attachments/assets/f070238a-5d18-45de-b298-ada7eefac745) |

[Asana](https://app.asana.com/0/1204008699308084/1209939499908844/f)