### PR TITLE
chore(cursor): create rule to help with launching demo

### DIFF
--- a/.cursor/rules/demo-run.mdc
+++ b/.cursor/rules/demo-run.mdc
@@ -1,0 +1,48 @@
+---
+description: Set up terminal windows for running the Hyperview demo for iOS or Android
+globs:
+alwaysApply: true
+---
+
+# Terminal Windows Setup for Hyperview Demo
+
+```yaml
+terminalWindows:
+  - name: "Hyperview Sync"
+    command: "yarn sync"
+    directory: "."
+    openInNewWindow: true
+    executeCommand: true
+  - name: "Demo Server"
+    command: "yarn server"
+    directory: "./demo"
+    openInNewWindow: true
+    executeCommand: true
+  - name: "Demo iOS"
+    command: "yarn ios"
+    directory: "./demo"
+    openInNewWindow: true
+    executeCommand: true
+  - name: "Demo Android"
+    command: "adb reverse tcp:8085 tcp:8085 && yarn android"
+    directory: "./demo"
+    openInNewWindow: true
+    executeCommand: true
+```
+
+# How to Run the Demo
+
+This configuration sets up the necessary terminal windows:
+1. "Hyperview Sync" - Keeps demo app in sync with source changes
+2. "Demo Server" - Builds XML and hosts local demo server
+3. "Demo iOS" - Runs Expo demo app for iOS (preferred platform)
+4. "Demo Android" - Alternative to iOS for Android testing
+5. For Android: Set up port forwarding (adb reverse tcp:8085 tcp:8085)
+
+
+## Important Notes:
+- The sync and server processes must be running for the demo to work
+- iOS is the preferred platform for testing
+- Use Android configuration only when specifically needed. Android requires setting port forwarding (adb reverse tcp:8085 tcp:8085)
+- Each window will open in a new terminal window
+- Wait for the sync and server processes to fully start before the mobile app will work


### PR DESCRIPTION
Create a rule to help developers demo their changes. This rule will automatically create three terminal windows and run the appropriate scripts to run the Hyperview demo on iOS or Android.

## Demo iOS
- Made a change to `demo/backend/index.xml.njk`
- Asked Cursor to "demo this change"
- Cursor created three terminal windows (in Cursor)
<img width="1501" alt="example1-ios" src="https://github.com/user-attachments/assets/cd04b9aa-b4b0-49d2-81ea-ad50e5175cb5" />

## Demo Android
- I followed up with a request to "Run this in android"
<img width="1501" alt="example1-android" src="https://github.com/user-attachments/assets/ae4620a6-8d96-4b86-9ff4-2723931ae928" />


[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1209928413172898?focus=true)