### PR TITLE
refactor: remove `LocalName` type

### DIFF
--- a/demo/src/Components/BottomSheet/BottomSheet.tsx
+++ b/demo/src/Components/BottomSheet/BottomSheet.tsx
@@ -17,7 +17,6 @@ import {
   GestureHandlerRootView,
   ScrollView,
 } from 'react-native-gesture-handler';
-import type { HvComponentProps, LocalName } from 'hyperview';
 import type { HvProps, HvStyles } from './types';
 import Hyperview, { Events } from 'hyperview';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -25,6 +24,7 @@ import { dragDownHelper, dragUpHelper } from './utils';
 import { BottomSheetContentSection } from './ContentSection';
 import { Context as BottomSheetContext } from '../../Contexts/BottomSheet';
 import { BottomSheetStopPoint } from './StopPoint';
+import type { HvComponentProps } from 'hyperview';
 import Overlay from './Overlay';
 import { namespace } from './types';
 import styles from './styles';
@@ -441,9 +441,7 @@ const BottomSheet = (props: HvComponentProps) => {
   );
 };
 
-BottomSheet.localName = 'bottom-sheet' as LocalName;
-
-BottomSheet.localNameAliases = [] as LocalName[];
+BottomSheet.localName = 'bottom-sheet';
 
 BottomSheet.namespaceURI = namespace;
 

--- a/demo/src/Components/BottomSheet/ContentSection.tsx
+++ b/demo/src/Components/BottomSheet/ContentSection.tsx
@@ -1,5 +1,5 @@
-import type { HvComponentProps, LocalName } from 'hyperview';
 import { LayoutChangeEvent, View } from 'react-native';
+import type { HvComponentProps } from 'hyperview';
 import Hyperview from 'hyperview';
 import React from 'react';
 import { namespace } from './types';
@@ -27,7 +27,6 @@ const BottomSheetContentSection = (props: HvComponentProps) => {
 };
 
 BottomSheetContentSection.namespaceURI = namespace;
-BottomSheetContentSection.localName = 'content-section' as LocalName;
-BottomSheetContentSection.localNameAliases = [] as LocalName[];
+BottomSheetContentSection.localName = 'content-section';
 
 export { BottomSheetContentSection };

--- a/demo/src/Components/BottomSheet/StopPoint.tsx
+++ b/demo/src/Components/BottomSheet/StopPoint.tsx
@@ -1,4 +1,4 @@
-import type { HvComponentProps, LocalName } from 'hyperview';
+import type { HvComponentProps } from 'hyperview';
 import Hyperview from 'hyperview';
 import React from 'react';
 import { View } from 'react-native';
@@ -15,7 +15,6 @@ const BottomSheetStopPoint = (props: HvComponentProps) => {
 };
 
 BottomSheetStopPoint.namespaceURI = namespace;
-BottomSheetStopPoint.localName = 'stop-point' as LocalName;
-BottomSheetStopPoint.localNameAliases = [] as LocalName[];
+BottomSheetStopPoint.localName = 'stop-point';
 
 export { BottomSheetStopPoint };

--- a/demo/src/Components/BottomTabBar/BottomTabBar.tsx
+++ b/demo/src/Components/BottomTabBar/BottomTabBar.tsx
@@ -1,4 +1,4 @@
-import type { HvComponentProps, LocalName } from 'hyperview';
+import type { HvComponentProps } from 'hyperview';
 import { namespaceURI } from './constants';
 import { useBottomTabBarContext } from '../../Contexts';
 import { useEffect } from 'react';
@@ -37,7 +37,6 @@ const BottomTabBar = (props: HvComponentProps) => {
 };
 
 BottomTabBar.namespaceURI = namespaceURI;
-BottomTabBar.localName = 'bottom-tab-bar' as LocalName;
-BottomTabBar.localNameAliases = [] as LocalName[];
+BottomTabBar.localName = 'bottom-tab-bar';
 
 export { BottomTabBar };

--- a/demo/src/Components/BottomTabBar/BottomTabBarItem.tsx
+++ b/demo/src/Components/BottomTabBar/BottomTabBarItem.tsx
@@ -1,9 +1,5 @@
 import * as Render from 'hyperview/src/services/render';
-import type {
-  HvComponentOnUpdate,
-  HvComponentProps,
-  LocalName,
-} from 'hyperview';
+import type { HvComponentOnUpdate, HvComponentProps } from 'hyperview';
 import { TouchableWithoutFeedback, View } from 'react-native';
 import { createElement, useState } from 'react';
 import { createEventHandler } from 'hyperview/src/core/hyper-ref';
@@ -54,7 +50,6 @@ const BottomTabBarItem = (props: HvComponentProps) => {
 };
 
 BottomTabBarItem.namespaceURI = namespaceURI;
-BottomTabBarItem.localName = 'bottom-tab-bar-item' as LocalName;
-BottomTabBarItem.localNameAliases = [] as LocalName[];
+BottomTabBarItem.localName = 'bottom-tab-bar-item';
 
 export { BottomTabBarItem };

--- a/demo/src/Components/Filter/Filter.tsx
+++ b/demo/src/Components/Filter/Filter.tsx
@@ -1,6 +1,6 @@
 import * as Logging from 'hyperview/src/services/logging';
-import type { HvComponentProps, LocalName } from 'hyperview';
 import Hyperview, { Events, LOCAL_NAME, Namespaces } from 'hyperview';
+import type { HvComponentProps } from 'hyperview';
 import { findElements } from '../../Helpers';
 import { useEffect } from 'react';
 
@@ -110,7 +110,6 @@ const Filter = (props: HvComponentProps) => {
 };
 
 Filter.namespaceURI = FILTER_NS;
-Filter.localName = 'container' as LocalName;
-Filter.localNameAliases = [] as LocalName[];
+Filter.localName = 'container';
 
 export { Filter };

--- a/demo/src/Components/Map/Map.tsx
+++ b/demo/src/Components/Map/Map.tsx
@@ -1,7 +1,7 @@
 import type { AutoZoomToMarker, Coordinate, HvProps } from './types';
-import type { HvComponentProps, LocalName } from 'hyperview';
 import React, { useCallback, useRef } from 'react';
 import type { ElementRef } from 'react';
+import type { HvComponentProps } from 'hyperview';
 import Hyperview from 'hyperview';
 import MapView from 'react-native-maps';
 import { namespace } from './types';
@@ -116,7 +116,6 @@ const Map = (props: HvComponentProps) => {
 };
 
 Map.namespaceURI = namespace;
-Map.localName = 'map' as LocalName;
-Map.localNameAliases = [] as LocalName[];
+Map.localName = 'map';
 
 export { Map };

--- a/demo/src/Components/Map/MapMarker.tsx
+++ b/demo/src/Components/Map/MapMarker.tsx
@@ -1,6 +1,6 @@
-import type { HvComponentProps, LocalName } from 'hyperview';
 import MapView, { MapMarker as RNMapMarker } from 'react-native-maps';
 import React, { useCallback } from 'react';
+import type { HvComponentProps } from 'hyperview';
 import Hyperview from 'hyperview';
 import type { MarkerHvProps } from './types';
 import { Platform } from 'react-native';
@@ -31,7 +31,6 @@ const MapMarker = (props: HvComponentProps) => {
 };
 
 MapMarker.namespaceURI = namespace;
-MapMarker.localName = 'map-marker' as LocalName;
-MapMarker.localNameAliases = [] as LocalName[];
+MapMarker.localName = 'map-marker';
 
 export { MapMarker };

--- a/demo/src/Components/Map/index.web.tsx
+++ b/demo/src/Components/Map/index.web.tsx
@@ -26,7 +26,6 @@ const Map = (props: HvComponentProps) => {
 
 Map.namespaceURI = MapComponent.namespaceURI;
 Map.localName = MapComponent.localName;
-Map.localNameAliases = MapComponent.localNameAliases;
 
 export { Map };
 export { MapMarker } from './MapMarker';

--- a/demo/src/Components/NavBack/NavBack.tsx
+++ b/demo/src/Components/NavBack/NavBack.tsx
@@ -1,4 +1,4 @@
-import type { HvComponentProps, LocalName } from 'hyperview';
+import type { HvComponentProps } from 'hyperview';
 import Hyperview from 'hyperview';
 import { NavigationContext } from '@react-navigation/native';
 import { findElements } from '../../Helpers';
@@ -34,7 +34,6 @@ const NavBack = (props: HvComponentProps) => {
 };
 
 NavBack.namespaceURI = namespaceURI;
-NavBack.localName = 'back' as LocalName;
-NavBack.localNameAliases = [] as LocalName[];
+NavBack.localName = 'back';
 
 export { NavBack };

--- a/demo/src/Components/ProgressBar/ProgressBar.tsx
+++ b/demo/src/Components/ProgressBar/ProgressBar.tsx
@@ -1,6 +1,6 @@
 import { Animated, View } from 'react-native';
-import type { HvComponentProps, LocalName } from 'hyperview';
 import React, { useEffect, useRef, useState } from 'react';
+import type { HvComponentProps } from 'hyperview';
 import Hyperview from 'hyperview';
 
 const namespace = 'https://hyperview.org/progress-bar';
@@ -58,7 +58,6 @@ const ProgressBar = (props: HvComponentProps) => {
 };
 
 ProgressBar.namespaceURI = namespace;
-ProgressBar.localName = 'progress-bar' as LocalName;
-ProgressBar.localNameAliases = [] as LocalName[];
+ProgressBar.localName = 'progress-bar';
 
 export { ProgressBar };

--- a/demo/src/Components/SafeAreaView/SafeAreaView.tsx
+++ b/demo/src/Components/SafeAreaView/SafeAreaView.tsx
@@ -1,5 +1,5 @@
-import type { HvComponentProps, LocalName } from 'hyperview';
 import React, { useMemo } from 'react';
+import type { HvComponentProps } from 'hyperview';
 import Hyperview from 'hyperview';
 import type { InsetsStyle } from './types';
 import { View } from 'react-native';
@@ -97,7 +97,6 @@ const SafeAreaView = (props: HvComponentProps) => {
 };
 
 SafeAreaView.namespaceURI = namespaceURI;
-SafeAreaView.localName = 'safe-area-view' as LocalName;
-SafeAreaView.localNameAliases = [] as LocalName[];
+SafeAreaView.localName = 'safe-area-view';
 
 export { SafeAreaView };

--- a/demo/src/Components/ScrollOpacity/ScrollOpacity.tsx
+++ b/demo/src/Components/ScrollOpacity/ScrollOpacity.tsx
@@ -1,4 +1,3 @@
-import type { HvComponentProps, LocalName } from 'hyperview';
 import Hyperview, { useScrollContext } from 'hyperview';
 import React, { useEffect, useRef } from 'react';
 import {
@@ -8,6 +7,7 @@ import {
   namespaceURI,
 } from './utils';
 import { Animated } from 'react-native';
+import type { HvComponentProps } from 'hyperview';
 
 const ScrollOpacity = (props: HvComponentProps) => {
   const contextKey = props.element.getAttributeNS(namespaceURI, 'context-key');
@@ -64,7 +64,6 @@ const ScrollOpacity = (props: HvComponentProps) => {
 };
 
 ScrollOpacity.namespaceURI = namespaceURI;
-ScrollOpacity.localName = 'scroll-opacity' as LocalName;
-ScrollOpacity.localNameAliases = [] as LocalName[];
+ScrollOpacity.localName = 'scroll-opacity';
 
 export { ScrollOpacity };

--- a/demo/src/Components/Svg/Svg.tsx
+++ b/demo/src/Components/Svg/Svg.tsx
@@ -1,4 +1,4 @@
-import type { HvComponentProps, LocalName } from 'hyperview';
+import type { HvComponentProps } from 'hyperview';
 import { Platform } from 'react-native';
 import React from 'react';
 import { SvgXml } from 'react-native-svg';
@@ -51,7 +51,6 @@ const Svg = (props: HvComponentProps) => {
 };
 
 Svg.namespaceURI = 'http://www.w3.org/2000/svg';
-Svg.localName = 'svg' as LocalName;
-Svg.localNameAliases = [] as LocalName[];
+Svg.localName = 'svg';
 
 export { Svg };

--- a/src/components/hv-date-field/index.tsx
+++ b/src/components/hv-date-field/index.tsx
@@ -1,8 +1,8 @@
 import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Namespaces from 'hyperview/src/services/namespaces';
-import type { HvComponentProps, LocalName } from 'hyperview/src/types';
 import { createDateFromString, createStringFromDate } from './helpers';
 import Field from './field';
+import type { HvComponentProps } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import Picker from './picker';
 import React from 'react';
@@ -121,8 +121,6 @@ const HvDateField = (props: HvComponentProps): JSX.Element | null => {
 HvDateField.namespaceURI = Namespaces.HYPERVIEW;
 
 HvDateField.localName = LOCAL_NAME.DATE_FIELD;
-
-HvDateField.localNameAliases = [] as LocalName[];
 
 HvDateField.getFormInputValues = (element: Element): Array<[string, string]> =>
   getNameValueFormInputValues(element);

--- a/src/components/hv-image/index.ts
+++ b/src/components/hv-image/index.ts
@@ -15,8 +15,6 @@ export default class HvImage extends PureComponent<HvComponentProps> {
 
   static localName = LOCAL_NAME.IMAGE;
 
-  static localNameAliases = [];
-
   render() {
     const { skipHref } = this.props.options || {};
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/hv-list/index.tsx
+++ b/src/components/hv-list/index.tsx
@@ -27,8 +27,6 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
 
   static localName = LOCAL_NAME.LIST;
 
-  static localNameAliases = [];
-
   context: React.ContextType<typeof Contexts.DocContext> = null;
 
   static contextType = Contexts.DocContext;

--- a/src/components/hv-option/index.ts
+++ b/src/components/hv-option/index.ts
@@ -21,8 +21,6 @@ export default class HvOption extends PureComponent<HvComponentProps, State> {
 
   static localName = LOCAL_NAME.OPTION;
 
-  static localNameAliases = [];
-
   state: State = {
     pressed: false,
   };

--- a/src/components/hv-picker-field/index.ios.tsx
+++ b/src/components/hv-picker-field/index.ios.tsx
@@ -28,8 +28,6 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
 
   static localName = LOCAL_NAME.PICKER_FIELD;
 
-  static localNameAliases = [];
-
   static getFormInputValues = (element: Element): Array<[string, string]> => {
     return getNameValueFormInputValues(element);
   };

--- a/src/components/hv-picker-field/index.tsx
+++ b/src/components/hv-picker-field/index.tsx
@@ -26,8 +26,6 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
 
   static localName = LOCAL_NAME.PICKER_FIELD;
 
-  static localNameAliases = [];
-
   static getFormInputValues = (element: Element): Array<[string, string]> => {
     return getNameValueFormInputValues(element);
   };

--- a/src/components/hv-section-list/index.tsx
+++ b/src/components/hv-section-list/index.tsx
@@ -66,8 +66,6 @@ export default class HvSectionList extends PureComponent<
 
   static localName = LOCAL_NAME.SECTION_LIST;
 
-  static localNameAliases = [];
-
   context: React.ContextType<typeof Contexts.DocContext> = null;
 
   static contextType = Contexts.DocContext;

--- a/src/components/hv-select-multiple/index.ts
+++ b/src/components/hv-select-multiple/index.ts
@@ -15,8 +15,6 @@ export default class HvSelectMultiple extends PureComponent<HvComponentProps> {
 
   static localName = LOCAL_NAME.SELECT_MULTIPLE;
 
-  static localNameAliases = [];
-
   static getFormInputValues = (element: Element): Array<[string, string]> => {
     const values: Array<[string, string]> = [];
     const name = element.getAttribute('name');

--- a/src/components/hv-select-single/index.ts
+++ b/src/components/hv-select-single/index.ts
@@ -15,8 +15,6 @@ export default class HvSelectSingle extends PureComponent<HvComponentProps> {
 
   static localName = LOCAL_NAME.SELECT_SINGLE;
 
-  static localNameAliases = [];
-
   static getFormInputValues = (element: Element): Array<[string, string]> => {
     const name = element.getAttribute('name');
     if (!name) {

--- a/src/components/hv-spinner/index.tsx
+++ b/src/components/hv-spinner/index.tsx
@@ -9,8 +9,6 @@ export default class HvSpinner extends PureComponent<HvComponentProps> {
 
   static localName = LOCAL_NAME.SPINNER;
 
-  static localNameAliases = [];
-
   render() {
     const color = this.props.element.getAttribute('color') || '#8d9494';
     return <ActivityIndicator color={color} />;

--- a/src/components/hv-switch/index.ts
+++ b/src/components/hv-switch/index.ts
@@ -36,8 +36,6 @@ export default class HvSwitch extends PureComponent<HvComponentProps> {
 
   static localName = LOCAL_NAME.SWITCH;
 
-  static localNameAliases = [];
-
   static getFormInputValues = (element: Element): Array<[string, string]> => {
     return getNameValueFormInputValues(element);
   };

--- a/src/components/hv-text-field/index.tsx
+++ b/src/components/hv-text-field/index.tsx
@@ -1,10 +1,6 @@
 import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Namespaces from 'hyperview/src/services/namespaces';
-import type {
-  HvComponentProps,
-  LocalName,
-  TextContextType,
-} from 'hyperview/src/types';
+import type { HvComponentProps, TextContextType } from 'hyperview/src/types';
 import React, { MutableRefObject, useCallback, useEffect, useRef } from 'react';
 import {
   createProps,
@@ -115,7 +111,7 @@ const HvTextField = (props: HvComponentProps) => {
 
 HvTextField.namespaceURI = Namespaces.HYPERVIEW;
 HvTextField.localName = LOCAL_NAME.TEXT_FIELD;
-HvTextField.localNameAliases = [] as LocalName[];
+
 HvTextField.getFormInputValues = (
   element: Element,
 ): Array<[string, string]> => {

--- a/src/components/hv-text/index.ts
+++ b/src/components/hv-text/index.ts
@@ -15,8 +15,6 @@ export default class HvText extends PureComponent<HvComponentProps> {
 
   static localName = LOCAL_NAME.TEXT;
 
-  static localNameAliases = [];
-
   render() {
     const { skipHref } = this.props.options || {};
     const props = createProps(

--- a/src/components/hv-web-view/index.tsx
+++ b/src/components/hv-web-view/index.tsx
@@ -12,8 +12,6 @@ export default class HvWebView extends PureComponent<HvComponentProps> {
 
   static localName = LOCAL_NAME.WEB_VIEW;
 
-  static localNameAliases = [];
-
   state = {
     renderLoading: true,
   };

--- a/src/services/components/index.test.ts
+++ b/src/services/components/index.test.ts
@@ -30,8 +30,6 @@ describe('Registry', () => {
 
     static localName = LOCAL_NAME.IMAGE;
 
-    static localNameAliases = [];
-
     static getFormInputValues() {
       return [['a', 'b']];
     }
@@ -41,8 +39,6 @@ describe('Registry', () => {
     static namespaceURI = 'http://bar';
 
     static localName = LOCAL_NAME.IMAGE;
-
-    static localNameAliases = [];
   }
   // eslint-disable-next-line react/no-multi-comp
   class Baz extends PureComponent<HvComponentProps> {

--- a/src/services/components/index.ts
+++ b/src/services/components/index.ts
@@ -1,5 +1,5 @@
 import * as Services from 'hyperview/src/services';
-import type { HvComponent, HvFormValues, LocalName } from 'hyperview/src/types';
+import type { HvComponent, HvFormValues } from 'hyperview/src/types';
 import HvDateField from 'hyperview/src/components/hv-date-field';
 import HvImage from 'hyperview/src/components/hv-image';
 import HvList from 'hyperview/src/components/hv-list';
@@ -81,10 +81,7 @@ export class Registry {
         const ns = c.namespaceURI;
         const localNames = [c.localName, ...(c.localNameAliases || [])];
         localNames.forEach(tag => {
-          const inputElements = formElement.getElementsByTagNameNS(
-            ns,
-            tag as LocalName,
-          );
+          const inputElements = formElement.getElementsByTagNameNS(ns, tag);
           for (let i = 0; i < inputElements.length; i += 1) {
             const inputElement = inputElements.item(i);
             if (inputElement) {

--- a/src/services/dom/errors.ts
+++ b/src/services/dom/errors.ts
@@ -1,7 +1,6 @@
 /* eslint-disable max-classes-per-file */
 
 import * as ErrorService from 'hyperview/src/services/error';
-import type { LocalName } from 'hyperview/src/types';
 import { XMLSerializer } from '@instawork/xmldom';
 
 export class UnsupportedContentTypeError extends ErrorService.HvBaseError {
@@ -29,7 +28,7 @@ export class XMLParserFatalError extends ErrorService.HvBaseError {
 export class XMLRequiredElementNotFound extends ErrorService.HvBaseError {
   name = 'XMLRequiredElementNotFound';
 
-  constructor(tag: LocalName, url: string) {
+  constructor(tag: string, url: string) {
     super(`Required <${tag}> tag not found in the response from ${url}`);
     this.setExtraContext('tag', tag);
     this.setExtraContext('url', url);
@@ -39,7 +38,7 @@ export class XMLRequiredElementNotFound extends ErrorService.HvBaseError {
 export class XMLRestrictedElementFound extends ErrorService.HvBaseError {
   name = 'XMLRestrictedElementFound';
 
-  constructor(tag: LocalName, url: string) {
+  constructor(tag: string, url: string) {
     super(`Restricted <${tag}> tag found in the response from ${url}`);
     this.setExtraContext('tag', tag);
     this.setExtraContext('url', url);

--- a/src/services/dom/helpers.ts
+++ b/src/services/dom/helpers.ts
@@ -1,12 +1,7 @@
 import * as Logging from 'hyperview/src/services/logging';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import { LOCAL_NAME, NODE_TYPE, UPDATE_ACTIONS } from 'hyperview/src/types';
-import type {
-  LocalName,
-  NamespaceURI,
-  NodeType,
-  UpdateAction,
-} from 'hyperview/src/types';
+import type { NamespaceURI, NodeType, UpdateAction } from 'hyperview/src/types';
 import { DocumentGetElementByIdError } from './errors';
 import { uuid } from 'hyperview/src/core/utils';
 
@@ -24,7 +19,7 @@ export const getBehaviorElements = (element: Element) => {
 
 export const getFirstTag = (
   document: Document | Element,
-  localName: LocalName,
+  localName: string,
   namespace: NamespaceURI = Namespaces.HYPERVIEW,
 ) => {
   const elements = document.getElementsByTagNameNS(namespace, localName);
@@ -39,7 +34,7 @@ export const getFirstTag = (
  */
 export const getFirstChildTag = (
   node: Node,
-  localName: LocalName,
+  localName: string,
   namespace: NamespaceURI = Namespaces.HYPERVIEW,
 ): Element | null => {
   if (!node || !node.childNodes) {

--- a/src/services/dom/parser.ts
+++ b/src/services/dom/parser.ts
@@ -17,7 +17,6 @@ import { getFirstTag, processDocument } from './helpers';
 import { DOMParser } from '@instawork/xmldom';
 import { Dimensions } from 'react-native';
 import { LOCAL_NAME } from 'hyperview/src/types';
-import type { LocalName } from 'hyperview/src/types';
 import { version } from 'hyperview/package.json';
 
 const { width, height } = Dimensions.get('window');
@@ -141,7 +140,7 @@ export class Parser {
     const navigatorElement = getFirstTag(docElement, LOCAL_NAME.NAVIGATOR);
     if (!screenElement && !navigatorElement) {
       throw new Errors.XMLRequiredElementNotFound(
-        `${LOCAL_NAME.SCREEN}/${LOCAL_NAME.NAVIGATOR}` as LocalName,
+        `${LOCAL_NAME.SCREEN}/${LOCAL_NAME.NAVIGATOR}`,
         baseUrl,
       );
     }
@@ -161,7 +160,7 @@ export class Parser {
       }
     } else {
       throw new Errors.XMLRequiredElementNotFound(
-        `${LOCAL_NAME.SCREEN}/${LOCAL_NAME.NAVIGATOR}` as LocalName,
+        `${LOCAL_NAME.SCREEN}/${LOCAL_NAME.NAVIGATOR}`,
         baseUrl,
       );
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,8 +49,6 @@ export const LOCAL_NAME = {
   WEB_VIEW: 'web-view',
 } as const;
 
-export type LocalName = typeof LOCAL_NAME[keyof typeof LOCAL_NAME];
-
 export const NODE_TYPE = {
   ATTRIBUTE_NODE: 2,
   CDATA_SECTION_NODE: 4,
@@ -137,14 +135,14 @@ export type NamedNodeMap = {
   getNamedItem: (key: string) => Attribute | null | undefined;
   getNamedItemNS: (
     namespaceURI: NamespaceURI,
-    localName: LocalName,
+    localName: string,
   ) => Attribute | null | undefined;
   item: (index: number) => Attribute | null | undefined;
   length: number;
   removeNamedItem: (key: string) => Attribute | null | undefined;
   removeNamedItemNS: (
     namespaceURI: NamespaceURI,
-    localName: LocalName,
+    localName: string,
   ) => Attribute | null | undefined;
   setNamedItem: (attribute: Attribute) => Attribute | null | undefined;
   setNamedItemNS: (attribute: Attribute) => Attribute | null | undefined;
@@ -219,8 +217,8 @@ export type HvFormValues = {
 };
 
 export type HvComponentStatics = {
-  localName: LocalName;
-  localNameAliases: Array<LocalName | string>;
+  localName: string;
+  localNameAliases?: Array<string>;
   namespaceURI: NamespaceURI;
 };
 

--- a/storybook/helpers.ts
+++ b/storybook/helpers.ts
@@ -1,7 +1,7 @@
 import * as Components from 'hyperview/src/services/components';
 import * as Dom from 'hyperview/src/services/dom';
 import * as Stylesheets from 'hyperview/src/services/stylesheets';
-import type { HvComponent, LocalName, StyleSheets } from 'hyperview/src/types';
+import type { HvComponent, StyleSheets } from 'hyperview/src/types';
 import { DOMParser } from '@instawork/xmldom';
 import humps from 'humps';
 import { storiesOf } from '@storybook/react-native';
@@ -19,10 +19,10 @@ type Render = (options: {
 
 export const stories = (
   Component: HvComponent,
-): ((template: string, render?: Render, tagName?: LocalName) => void) => {
+): ((template: string, render?: Render, tagName?: string) => void) => {
   const componentPath = getComponentPath(Component.name);
   const s = storiesOf(Component.name, module);
-  return (templateName: string, render?: Render, tagName?: LocalName) => {
+  return (templateName: string, render?: Render, tagName?: string) => {
     const templatePath = `${componentPath}/stories/${templateName}.xml`;
     const storyName = humps.pascalize(templateName);
     const parser = new DOMParser();

--- a/test/helpers.tsx
+++ b/test/helpers.tsx
@@ -2,15 +2,15 @@ import * as Components from 'hyperview/src/services/components';
 import * as Dom from 'hyperview/src/services/dom';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Stylesheets from 'hyperview/src/services/stylesheets';
-import type { HvComponent, LocalName } from 'hyperview/src/types';
 import { DOMParser } from '@instawork/xmldom';
+import type { HvComponent } from 'hyperview/src/types';
 import React from 'react';
 
 const parser = new DOMParser();
 
 export const getElements = (
   xml: string,
-  localName: LocalName,
+  localName: string,
   namespaceURI: string = Namespaces.HYPERVIEW,
 ): Element[] => {
   const document = parser.parseFromString(xml);


### PR DESCRIPTION
This type was defined early on, before Hyperview supported a custom components registry. This type no longer make sense and is regularly force-casted to string. This change also makes the localNameAliases optional. We might revisit the concept of typing the element type of a component using generics.