### PR TITLE
chore(hv-doc): internalize loading logic

### DIFF
--- a/src/core/components/hv-doc/context.ts
+++ b/src/core/components/hv-doc/context.ts
@@ -18,7 +18,6 @@ const callbacks = {
 export const StateContext = createContext<StateContextProps>({
   getLocalDoc: () => null,
   getScreenState: () => ({}),
-  loadUrl: () => null,
   onUpdate: () => undefined,
   onUpdateCallbacks: callbacks,
   reload: () => null,

--- a/src/core/components/hv-doc/context.ts
+++ b/src/core/components/hv-doc/context.ts
@@ -11,8 +11,8 @@ const callbacks = {
   }),
   getOnUpdate: () => () => undefined,
   getState: () => ({}),
-  setNeedsLoad: () => null,
   setState: () => undefined,
+  updateUrl: () => null,
 };
 
 export const StateContext = createContext<StateContextProps>({
@@ -21,6 +21,5 @@ export const StateContext = createContext<StateContextProps>({
   onUpdate: () => undefined,
   onUpdateCallbacks: callbacks,
   reload: () => null,
-  setNeedsLoadCallback: () => null,
   setScreenState: () => undefined,
 });

--- a/src/core/components/hv-doc/index.tsx
+++ b/src/core/components/hv-doc/index.tsx
@@ -177,9 +177,6 @@ const HvDoc = (props: Props) => {
     ],
   );
 
-  const needsLoadCallback = useRef(() => {
-    // Noop
-  });
   // Monitor props.url changes
   useEffect(() => {
     if (
@@ -272,8 +269,10 @@ const HvDoc = (props: Props) => {
       getNavigation,
       getOnUpdate: () => onUpdate,
       getState: getScreenState,
-      setNeedsLoad: needsLoadCallback.current,
       setState: setScreenState,
+      updateUrl: (url: string) => {
+        setLoadingUrl(url);
+      },
     };
 
     return {
@@ -282,9 +281,6 @@ const HvDoc = (props: Props) => {
       onUpdate,
       onUpdateCallbacks: onUpdateCallbacksRef.current,
       reload,
-      setNeedsLoadCallback: (callback: () => void) => {
-        needsLoadCallback.current = callback;
-      },
       setScreenState,
     };
   }, [

--- a/src/core/components/hv-doc/index.tsx
+++ b/src/core/components/hv-doc/index.tsx
@@ -104,13 +104,14 @@ const HvDoc = (props: Props) => {
         handleError(new HvDocError('No URL provided'), targetUrl);
         return;
       }
+      const params = props.route?.params ?? {};
 
       try {
-        if (props.route?.params.delay) {
+        if (params.delay) {
           const delay =
-            typeof props.route.params.delay === 'number'
-              ? props.route.params.delay
-              : parseInt(props.route.params.delay, 10);
+            typeof params.delay === 'number'
+              ? params.delay
+              : parseInt(params.delay, 10);
           await later(delay);
         }
 

--- a/src/core/components/hv-doc/index.tsx
+++ b/src/core/components/hv-doc/index.tsx
@@ -255,6 +255,13 @@ const HvDoc = (props: Props) => {
     [navigationContext],
   );
 
+  const updateUrl = useCallback((url: string) => {
+    setState(prev => ({
+      ...prev,
+      loadingUrl: url,
+    }));
+  }, []);
+
   const contextValue = useMemo(() => {
     onUpdateCallbacksRef.current = {
       clearElementError: () => {
@@ -270,7 +277,7 @@ const HvDoc = (props: Props) => {
       getOnUpdate: () => onUpdate,
       getState: getScreenState,
       setState: setScreenState,
-      updateUrl: setLoadingUrl,
+      updateUrl,
     };
 
     return {
@@ -289,6 +296,7 @@ const HvDoc = (props: Props) => {
     reload,
     setScreenState,
     state.elementError,
+    updateUrl,
   ]);
 
   /**

--- a/src/core/components/hv-doc/types.ts
+++ b/src/core/components/hv-doc/types.ts
@@ -31,7 +31,6 @@ export type StateContextProps = {
   onUpdate: HvComponentOnUpdate;
   onUpdateCallbacks: OnUpdateCallbacks;
   reload: (url?: string | null) => void;
-  setNeedsLoadCallback: (callback: () => void) => void;
   setScreenState: (state: ScreenState) => void;
 };
 

--- a/src/core/components/hv-doc/types.ts
+++ b/src/core/components/hv-doc/types.ts
@@ -39,3 +39,7 @@ export type ErrorProps = {
   navigationProvider?: NavigationProvider;
   url: string | null | undefined;
 };
+
+export type DocState = ScreenState & {
+  loadingUrl?: string | null | undefined;
+};

--- a/src/core/components/hv-doc/types.ts
+++ b/src/core/components/hv-doc/types.ts
@@ -15,16 +15,19 @@ export type Props = {
   route?: NavigatorService.Route<
     string,
     {
+      behaviorElementId?: number;
       delay?: DOMString | number | null;
+      needsSubStack?: boolean;
+      preloadScreen?: number;
       url?: string | null;
     }
   >;
+  url: string;
 };
 
 export type StateContextProps = {
   getLocalDoc: () => Document | null;
   getScreenState: () => ScreenState;
-  loadUrl: (url?: string) => void;
   onUpdate: HvComponentOnUpdate;
   onUpdateCallbacks: OnUpdateCallbacks;
   reload: (url?: string | null) => void;

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -124,13 +124,13 @@ export default class Hyperview extends PureComponent<Types.Props> {
     }
 
     // Re-render the modifications
-    opts.onUpdateCallbacks?.setNeedsLoad();
     opts.onUpdateCallbacks?.setState({
       doc: newRoot,
       elementError: null,
       error: null,
       url,
     });
+    opts.onUpdateCallbacks?.updateUrl(url);
   };
 
   /**

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -47,20 +47,6 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
     });
   }
 
-  componentDidMount() {
-    // When a nested navigator is found, the document is not loaded from url
-    if (this.props.element === undefined) {
-      this.load();
-    }
-  }
-
-  componentDidUpdate(prevProps: Types.InnerRouteProps) {
-    if (prevProps.url !== this.props.url || this.needsLoad) {
-      this.load();
-      this.needsLoad = false;
-    }
-  }
-
   getUrl = (): string => {
     return UrlService.getUrlFromHref(
       (this.needsLoad ? this.props.getScreenState().url : undefined) ||
@@ -79,21 +65,6 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
       !this.props.getLocalDoc() ||
       !(this.getRenderElement()?.localName === LOCAL_NAME.SCREEN)
     );
-  };
-
-  /**
-   * Load the url and resolve the xml.
-   */
-  load = async (): Promise<void> => {
-    // When a modal is included, a wrapper stack navigator is created
-    // The route which contains the navigator should not load the document
-    // The code below prevents the route from loading the document
-    if (this.props.route?.params?.needsSubStack || !this.shouldReload()) {
-      return;
-    }
-
-    const url: string = this.getUrl();
-    this.props.loadUrl(url);
   };
 
   getRenderElement = (): Element | undefined => {
@@ -215,12 +186,12 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
         doc={localDoc}
         navigationProvider={this.props.navigator}
         route={route}
+        url={url}
       >
         <StateContext.Consumer>
           {({
             getLocalDoc,
             getScreenState,
-            loadUrl,
             onUpdate,
             onUpdateCallbacks,
             reload,
@@ -238,7 +209,6 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
                   getElement={this.props.getElement}
                   getLocalDoc={getLocalDoc}
                   getScreenState={getScreenState}
-                  loadUrl={loadUrl}
                   navigation={this.props.navigator}
                   onUpdate={onUpdate}
                   onUpdateCallbacks={onUpdateCallbacks}
@@ -547,12 +517,16 @@ function HvRouteFC(props: Types.Props) {
   }, [nav, props.route, backContext, docContext, navigationContext]);
 
   return (
-    <HvDoc element={element} navigationProvider={navigator}>
+    <HvDoc
+      element={element}
+      navigationProvider={navigator}
+      route={props.route}
+      url={url}
+    >
       <StateContext.Consumer>
         {({
           getLocalDoc,
           getScreenState,
-          loadUrl,
           onUpdate,
           onUpdateCallbacks,
           setNeedsLoadCallback,
@@ -569,7 +543,6 @@ function HvRouteFC(props: Types.Props) {
             getLocalDoc={getLocalDoc}
             getScreenState={getScreenState}
             handleBack={navigationContext.handleBack}
-            loadUrl={loadUrl}
             navigation={nav}
             navigator={navigator}
             onUpdate={onUpdate}

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -500,13 +500,7 @@ function HvRouteFC(props: Types.Props) {
       url={url}
     >
       <StateContext.Consumer>
-        {({
-          getLocalDoc,
-          getScreenState,
-          onUpdate,
-          onUpdateCallbacks,
-          setScreenState,
-        }) => (
+        {({ getLocalDoc, onUpdate, setScreenState }) => (
           <HvRouteInner
             behaviors={navigationContext.behaviors}
             components={navigationContext.components}
@@ -516,15 +510,11 @@ function HvRouteFC(props: Types.Props) {
             entrypointUrl={navigationContext.entrypointUrl}
             getElement={elemenCacheContext.getElement}
             getLocalDoc={getLocalDoc}
-            getScreenState={getScreenState}
             handleBack={navigationContext.handleBack}
-            navigation={nav}
             navigator={navigator}
             onUpdate={onUpdate}
-            onUpdateCallbacks={onUpdateCallbacks}
             removeElement={elemenCacheContext.removeElement}
             route={props.route}
-            setElement={elemenCacheContext.setElement}
             setScreenState={setScreenState}
             url={url}
           />

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -504,7 +504,7 @@ function HvRouteFC(props: Types.Props) {
           <HvRouteInner
             behaviors={navigationContext.behaviors}
             components={navigationContext.components}
-            doc={docContext?.getDoc()}
+            doc={getLocalDoc() || undefined}
             element={element}
             elementErrorComponent={navigationContext.elementErrorComponent}
             entrypointUrl={navigationContext.entrypointUrl}

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -41,17 +41,6 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
     this.componentRegistry = new Components.Registry(this.props.components);
   }
 
-  /**
-   * Fix for both route and screen loading the document when url changes
-   * The route will not perform a load if a screen has already been rendered
-   */
-  shouldReload = (): boolean => {
-    return (
-      !this.props.getLocalDoc() ||
-      !(this.getRenderElement()?.localName === LOCAL_NAME.SCREEN)
-    );
-  };
-
   getRenderElement = (): Element | undefined => {
     if (this.props.element) {
       return this.props.element;

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -6,7 +6,6 @@ import {
   HvBehavior,
   HvComponent,
   HvComponentOnUpdate,
-  OnUpdateCallbacks,
   Reload,
   Route,
   RouteParams,
@@ -45,23 +44,19 @@ export type RouteProps = NavigatorService.Route<string, { url?: string }>;
  */
 export type InnerRouteProps = {
   url?: string;
-  navigation?: NavigatorService.NavigationProp;
   navigator: NavigatorService.Navigator;
   route?: NavigatorService.Route<string, RouteParams>;
   entrypointUrl: string;
   onUpdate: HvComponentOnUpdate;
-  onUpdateCallbacks: OnUpdateCallbacks;
   behaviors?: HvBehavior[];
   components?: HvComponent[];
   elementErrorComponent?: ComponentType<ErrorProps>;
   handleBack?: ComponentType<{ children: ReactNode }>;
-  setElement: (key: number, element: Element) => void;
   getElement: (key: number) => Element | undefined;
   removeElement: (key: number) => void;
   element?: Element;
   doc: Document | undefined;
   getLocalDoc: () => Document | null;
-  getScreenState: () => ScreenState;
   setScreenState: (state: ScreenState) => void;
 };
 

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -64,7 +64,6 @@ export type InnerRouteProps = {
   getScreenState: () => ScreenState;
   setScreenState: (state: ScreenState) => void;
   setNeedsLoadCallback: (callback: () => void) => void;
-  loadUrl: (url?: string) => void;
 };
 
 /**

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -63,7 +63,6 @@ export type InnerRouteProps = {
   getLocalDoc: () => Document | null;
   getScreenState: () => ScreenState;
   setScreenState: (state: ScreenState) => void;
-  setNeedsLoadCallback: (callback: () => void) => void;
 };
 
 /**

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -26,13 +26,8 @@ export default class HvScreen extends React.Component {
   constructor(props) {
     super(props);
 
-    this.needsLoad = false;
-
     this.behaviorRegistry = Behaviors.getRegistry(this.props.behaviors);
     this.componentRegistry = new Components.Registry(this.props.components);
-    this.props.setNeedsLoadCallback(() => {
-      this.needsLoad = true;
-    });
   }
 
   getRoute = props => {
@@ -62,7 +57,6 @@ export default class HvScreen extends React.Component {
       ? Stylesheets.createStylesheets(preloadScreen)
       : {};
 
-    this.needsLoad = !this.props.getScreenState().doc;
     if (preloadScreen && !this.props.getScreenState().doc) {
       this.props.setScreenState({
         doc: preloadScreen,
@@ -106,8 +100,6 @@ export default class HvScreen extends React.Component {
     }
 
     if (newUrl && newUrl !== oldUrl) {
-      this.needsLoad = true;
-
       const preloadScreen = newPreloadScreen
         ? this.props.getElement(newPreloadScreen)
         : null;

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -138,30 +138,6 @@ export default class HvScreen extends React.Component {
   }
 
   /**
-   * Fetch data from the url if the screen should reload.
-   */
-  componentDidUpdate() {
-    if (this.needsLoad) {
-      this.load(this.props.getScreenState().url);
-      this.needsLoad = false;
-    }
-  }
-
-  /**
-   * Performs a full load of the screen.
-   */
-  load = async () => {
-    const { params } = this.getRoute(this.props);
-    await this.props.loadUrl(this.props.getScreenState().url);
-    if (params.preloadScreen) {
-      this.props.removeElement?.(params.preloadScreen);
-    }
-    if (params.behaviorElementId) {
-      this.props.removeElement?.(params.behaviorElementId);
-    }
-  };
-
-  /**
    * Renders the XML doc into React components. Shows blank screen until the XML doc is available.
    */
   render() {

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -36,6 +36,5 @@ export type Props = Omit<
   url?: string;
   getLocalDoc: () => Document | null;
   getScreenState: () => ScreenState;
-  setNeedsLoadCallback: (callback: () => void) => void;
   setScreenState: (state: ScreenState) => void;
 };

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -38,5 +38,4 @@ export type Props = Omit<
   getScreenState: () => ScreenState;
   setNeedsLoadCallback: (callback: () => void) => void;
   setScreenState: (state: ScreenState) => void;
-  loadUrl: (url?: string) => void;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -419,9 +419,9 @@ export type OnUpdateCallbacks = {
   getNavigation: () => NavigationProvider;
   getOnUpdate: () => HvComponentOnUpdate;
   getDoc: () => Document | null;
-  setNeedsLoad: () => void;
   getState: () => ScreenState;
   setState: (state: ScreenState) => void;
+  updateUrl: (url: string) => void;
 };
 
 export type ScreenState = {


### PR DESCRIPTION
Remove legacy load triggers from hv-route and hv-screen and internalize into hv-doc.
- Removed use of "needsLoad"
- Removed unnecessary lifecycle functions
- Verified current functionality including load, reload, append, modals, etc.

See commits for breakdown

[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1209875001265866?focus=true)