### PR TITLE
chore(hv-doc): consolidate hv-doc state

### DIFF
--- a/src/core/components/hv-doc/index.tsx
+++ b/src/core/components/hv-doc/index.tsx
@@ -43,11 +43,14 @@ const HvDoc = (props: Props) => {
   const localUrl = useRef<string | null | undefined>(null);
   // </HACK>
 
-  const [state, setState] = useState<DocState>(() => {
-    return {
-      doc: undefined,
-      error: undefined,
-    };
+  const [state, setState] = useState<DocState>({
+    doc: null,
+    elementError: null,
+    error: null,
+    loadingUrl: null,
+    staleHeaderType: null,
+    styles: null,
+    url: null,
   });
 
   const navigationContext: NavigationContext.NavigationContextProps | null = useContext(
@@ -131,7 +134,7 @@ const HvDoc = (props: Props) => {
           setState(prev => ({
             ...prev,
             doc: document,
-            error: undefined,
+            error: null,
             loadingUrl: null,
             staleHeaderType,
             styles: stylesheets,
@@ -166,19 +169,18 @@ const HvDoc = (props: Props) => {
 
   // Monitor url changes
   useEffect(() => {
-    if (
+    if (state.loadingUrl) {
+      // Handle force reload
+      loadUrl(state.loadingUrl);
+    } else if (
       props.url &&
+      !state.url &&
       props.url !== state.url &&
       !props.element &&
       !props.route?.params.needsSubStack
     ) {
+      // Handle initial load
       loadUrl(props.url);
-    } else if (
-      props.url &&
-      state.loadingUrl &&
-      props.url !== state.loadingUrl
-    ) {
-      loadUrl(state.loadingUrl);
     }
   }, [
     loadUrl,

--- a/src/core/components/hv-doc/index.tsx
+++ b/src/core/components/hv-doc/index.tsx
@@ -129,7 +129,7 @@ const HvDoc = (props: Props) => {
             : doc;
 
           localDoc.current = document;
-          localUrl.current = fullUrl;
+          localUrl.current = targetUrl;
           const stylesheets = Stylesheets.createStylesheets(doc);
           setState(prev => ({
             ...prev,

--- a/src/core/components/hv-doc/index.tsx
+++ b/src/core/components/hv-doc/index.tsx
@@ -44,18 +44,6 @@ const HvDoc = (props: Props) => {
   // </HACK>
 
   const [state, setState] = useState<DocState>(() => {
-    // Initial state may receive a doc from the props
-    if (props.doc) {
-      localDoc.current = props.doc;
-      return {
-        doc: props.doc,
-        error: undefined,
-        staleHeaderType: undefined,
-        styles: props.doc
-          ? Stylesheets.createStylesheets(props.doc)
-          : undefined,
-      };
-    }
     return {
       doc: undefined,
       error: undefined,
@@ -181,7 +169,6 @@ const HvDoc = (props: Props) => {
     if (
       props.url &&
       props.url !== state.url &&
-      !props.doc &&
       !props.element &&
       !props.route?.params.needsSubStack
     ) {
@@ -195,7 +182,6 @@ const HvDoc = (props: Props) => {
     }
   }, [
     loadUrl,
-    props.doc,
     props.element,
     props.route?.params.needsSubStack,
     props.url,

--- a/src/core/components/hv-doc/types.ts
+++ b/src/core/components/hv-doc/types.ts
@@ -9,7 +9,6 @@ import {
 
 export type Props = {
   children?: React.ReactNode;
-  doc?: Document;
   element?: Element;
   navigationProvider: NavigationProvider;
   route?: NavigatorService.Route<

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -154,51 +154,28 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
       },
     };
 
-    const propsLocalDoc = this.props.getLocalDoc();
-    const localDoc = useMemo(() => {
-      return propsLocalDoc?.cloneNode(true) as Document;
-    }, [propsLocalDoc]);
-
     return (
-      <HvDoc
-        doc={localDoc}
-        navigationProvider={this.props.navigator}
-        route={route}
-        url={url}
-      >
-        <StateContext.Consumer>
-          {({
-            getLocalDoc,
-            getScreenState,
-            onUpdate,
-            onUpdateCallbacks,
-            reload,
-            setScreenState,
-          }) => (
-            <Contexts.DateFormatContext.Consumer>
-              {formatter => (
-                <HvScreen
-                  behaviors={this.props.behaviors}
-                  components={this.props.components}
-                  elementErrorComponent={this.props.elementErrorComponent}
-                  entrypointUrl={this.props.entrypointUrl}
-                  formatDate={formatter}
-                  getElement={this.props.getElement}
-                  getLocalDoc={getLocalDoc}
-                  getScreenState={getScreenState}
-                  navigation={this.props.navigator}
-                  onUpdate={onUpdate}
-                  onUpdateCallbacks={onUpdateCallbacks}
-                  reload={reload}
-                  removeElement={this.props.removeElement}
-                  route={route}
-                  setScreenState={setScreenState}
-                />
-              )}
-            </Contexts.DateFormatContext.Consumer>
-          )}
-        </StateContext.Consumer>
-      </HvDoc>
+      <Contexts.DateFormatContext.Consumer>
+        {formatter => (
+          <HvScreen
+            behaviors={this.props.behaviors}
+            components={this.props.components}
+            elementErrorComponent={this.props.elementErrorComponent}
+            entrypointUrl={this.props.entrypointUrl}
+            formatDate={formatter}
+            getElement={this.props.getElement}
+            getLocalDoc={this.props.getLocalDoc}
+            getScreenState={this.props.getScreenState}
+            navigation={this.props.navigator}
+            onUpdate={this.props.onUpdate}
+            onUpdateCallbacks={this.props.onUpdateCallbacks}
+            reload={this.props.reload}
+            removeElement={this.props.removeElement}
+            route={route}
+            setScreenState={this.props.setScreenState}
+          />
+        )}
+      </Contexts.DateFormatContext.Consumer>
     );
   };
 
@@ -489,7 +466,14 @@ function HvRouteFC(props: Types.Props) {
       url={url}
     >
       <StateContext.Consumer>
-        {({ getLocalDoc, onUpdate, setScreenState }) => (
+        {({
+          getLocalDoc,
+          getScreenState,
+          onUpdate,
+          onUpdateCallbacks,
+          reload,
+          setScreenState,
+        }) => (
           <HvRouteInner
             behaviors={navigationContext.behaviors}
             components={navigationContext.components}
@@ -499,9 +483,12 @@ function HvRouteFC(props: Types.Props) {
             entrypointUrl={navigationContext.entrypointUrl}
             getElement={elemenCacheContext.getElement}
             getLocalDoc={getLocalDoc}
+            getScreenState={getScreenState}
             handleBack={navigationContext.handleBack}
             navigator={navigator}
             onUpdate={onUpdate}
+            onUpdateCallbacks={onUpdateCallbacks}
+            reload={reload}
             removeElement={elemenCacheContext.removeElement}
             route={props.route}
             setScreenState={setScreenState}

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -6,6 +6,7 @@ import {
   HvBehavior,
   HvComponent,
   HvComponentOnUpdate,
+  OnUpdateCallbacks,
   Reload,
   Route,
   RouteParams,
@@ -58,6 +59,9 @@ export type InnerRouteProps = {
   doc: Document | undefined;
   getLocalDoc: () => Document | null;
   setScreenState: (state: ScreenState) => void;
+  getScreenState: () => ScreenState;
+  onUpdateCallbacks: OnUpdateCallbacks;
+  reload: (url?: string | null) => void;
 };
 
 /**


### PR DESCRIPTION
Merging the hv-doc implementation to use a single instance across both `hv-route` and `hv-screen`. This has the benefit of reducing individual state management, load tracking, and removes the need to pass a clone of the loaded doc into `hv-screen`. This also includes setting the initial state to use `null` values instead of `undefined` to reduce the effect of state updates causing re-renders.

This has been tested within HV Demo including features which force a screen to reload.

[Asana](https://app.asana.com/1/47184964732898/project/1205761271270033/task/1209875001265872?focus=true)
