### PR TITLE
chore(behaviors): log behaviors only when run

### DIFF
--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -392,53 +392,57 @@ export default class Hyperview extends PureComponent<Types.Props> {
           onUpdateCallbacks,
           networkRetryAction,
           networkRetryEvent,
-        ).then(newElement => {
-          // If a target is specified and exists, use it. Otherwise, the action target defaults
-          // to the element triggering the action.
-          let targetElement = targetId
-            ? Dom.getElementById(onUpdateCallbacks.getDoc(), targetId)
-            : null;
-          if (!targetElement) {
-            // Find the target element by locating the behavior within the current doc
-            targetElement = Helpers.findTargetByBehavior(
-              onUpdateCallbacks.getDoc(),
-              behaviorElement,
-            );
-            // Warn developers if a provided target was not found
-            if (targetId) {
-              Logging.error(
-                'Target element not found. Falling back to current element.',
-                { id: targetId },
+        )
+          .then(newElement => {
+            // If a target is specified and exists, use it. Otherwise, the action target defaults
+            // to the element triggering the action.
+            let targetElement = targetId
+              ? Dom.getElementById(onUpdateCallbacks.getDoc(), targetId)
+              : null;
+            if (!targetElement) {
+              // Find the target element by locating the behavior within the current doc
+              targetElement = Helpers.findTargetByBehavior(
+                onUpdateCallbacks.getDoc(),
+                behaviorElement,
               );
+              // Warn developers if a provided target was not found
+              if (targetId) {
+                Logging.error(
+                  'Target element not found. Falling back to current element.',
+                  { id: targetId },
+                );
+              }
             }
-          }
 
-          if (newElement && targetElement) {
-            newRoot = Behaviors.performUpdate(
-              action,
-              targetElement,
-              newElement as Element,
-            );
-          } else {
-            // When fetch fails, make sure to get the latest version of
-            // the doc to avoid any race conditions
-            newRoot = onUpdateCallbacks.getDoc();
-          }
-          if (newRoot) {
-            newRoot = Behaviors.setIndicatorsAfterLoad(
-              showIndicatorIdList,
-              hideIndicatorIdList,
-              newRoot,
-            );
-            // Re-render the modifications
-            onUpdateCallbacks.setState({
-              doc: newRoot,
-            });
-          }
-          if (typeof onEnd === 'function') {
-            onEnd();
-          }
-        });
+            if (newElement && targetElement) {
+              newRoot = Behaviors.performUpdate(
+                action,
+                targetElement,
+                newElement as Element,
+              );
+            } else {
+              // When fetch fails, make sure to get the latest version of
+              // the doc to avoid any race conditions
+              newRoot = onUpdateCallbacks.getDoc();
+            }
+            if (newRoot) {
+              newRoot = Behaviors.setIndicatorsAfterLoad(
+                showIndicatorIdList,
+                hideIndicatorIdList,
+                newRoot,
+              );
+              // Re-render the modifications
+              onUpdateCallbacks.setState({
+                doc: newRoot,
+              });
+            }
+            if (typeof onEnd === 'function') {
+              onEnd();
+            }
+          })
+          .catch(() => {
+            // TODO
+          });
       }
     };
 

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -243,15 +243,9 @@ export default class Hyperview extends PureComponent<Types.Props> {
       updateAction &&
       Object.values(UPDATE_ACTIONS).includes(updateAction)
     ) {
-      this.onUpdateFragment(
-        href,
-        updateAction,
-        element,
-        options,
-        options.onUpdateCallbacks,
-      );
+      this.onUpdateFragment(href, updateAction, element, options);
     } else if (action === ACTIONS.SWAP) {
-      this.onSwap(element, options.newElement, options.onUpdateCallbacks);
+      this.onSwap(element, options);
     } else if (action === ACTIONS.DISPATCH_EVENT) {
       const { behaviorElement } = options;
       if (!behaviorElement) {
@@ -297,7 +291,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
       }
     } else {
       const { behaviorElement } = options;
-      this.onCustomUpdate(behaviorElement, options.onUpdateCallbacks);
+      this.onCustomUpdate(behaviorElement, options);
     }
   };
 
@@ -329,7 +323,6 @@ export default class Hyperview extends PureComponent<Types.Props> {
     action: UpdateAction,
     element: Element,
     options: HvComponentOptions,
-    onUpdateCallbacks: OnUpdateCallbacks,
   ) => {
     const opts = options || {};
     const {
@@ -341,7 +334,12 @@ export default class Hyperview extends PureComponent<Types.Props> {
       delay,
       once,
       onEnd,
+      onUpdateCallbacks,
     } = opts;
+    if (!onUpdateCallbacks) {
+      Logging.warn('onUpdateFragment requires an onUpdateCallbacks object');
+      return;
+    }
     const networkRetryAction = behaviorElement?.getAttribute(
       'network-retry-action',
     ) as XNetworkRetryAction | null | undefined;
@@ -500,13 +498,10 @@ export default class Hyperview extends PureComponent<Types.Props> {
   /**
    * Used internally to update the state of things like select forms.
    */
-  onSwap = (
-    currentElement: Element,
-    newElement: Element | null | undefined,
-    onUpdateCallbacks: OnUpdateCallbacks,
-  ) => {
+  onSwap = (currentElement: Element, options: HvComponentOptions) => {
+    const { newElement, onUpdateCallbacks } = options;
     const parentElement = currentElement.parentNode as Element;
-    if (!parentElement || !newElement) {
+    if (!parentElement || !newElement || !onUpdateCallbacks) {
       return;
     }
     parentElement.replaceChild(newElement, currentElement);
@@ -521,9 +516,10 @@ export default class Hyperview extends PureComponent<Types.Props> {
    */
   onCustomUpdate = (
     behaviorElement: Element | null | undefined,
-    onUpdateCallbacks: OnUpdateCallbacks,
+    options: HvComponentOptions,
   ) => {
-    if (!behaviorElement) {
+    const { onUpdateCallbacks } = options;
+    if (!behaviorElement || !onUpdateCallbacks) {
       Logging.warn('Custom behavior requires a behaviorElement');
       return;
     }

--- a/src/services/behaviors/index.ts
+++ b/src/services/behaviors/index.ts
@@ -145,16 +145,21 @@ export const trigger = (
     const hideIndicatorIds = behaviorElement.getAttribute('hide-during-load');
     const delay = behaviorElement.getAttribute('delay');
     const once = behaviorElement.getAttribute('once');
+    const onUpdateComplete = (success: boolean) => {
+      if (success) {
+        logBehavior(behaviorElement, action);
+      }
+    };
     onUpdate(href, action, element, {
       behaviorElement,
       delay,
       hideIndicatorIds,
       once,
+      onUpdateComplete,
       showIndicatorIds,
       targetId,
       verb,
     });
-    logBehavior(behaviorElement, action);
   });
 };
 
@@ -193,13 +198,18 @@ export const createActionHandler = (
         BEHAVIOR_ATTRIBUTES.SHOW_DURING_LOAD,
       );
       const delay = behaviorElement.getAttribute(BEHAVIOR_ATTRIBUTES.DELAY);
+      const onUpdateComplete = (success: boolean) => {
+        if (success) {
+          logBehavior(behaviorElement, action);
+        }
+      };
       onUpdate(href, action, element, {
         behaviorElement,
         delay,
+        onUpdateComplete,
         showIndicatorId,
         targetId,
       });
-      logBehavior(behaviorElement, action);
     };
   }
   if (
@@ -218,22 +228,35 @@ export const createActionHandler = (
       );
       const delay = behaviorElement.getAttribute(BEHAVIOR_ATTRIBUTES.DELAY);
       const once = behaviorElement.getAttribute(BEHAVIOR_ATTRIBUTES.ONCE);
+      const onUpdateComplete = (success: boolean) => {
+        if (success) {
+          logBehavior(behaviorElement, action);
+        }
+      };
       onUpdate(href, action, element, {
         behaviorElement,
         delay,
         hideIndicatorIds,
         once,
+        onUpdateComplete,
         showIndicatorIds,
         targetId,
         verb,
       });
-      logBehavior(behaviorElement, action);
     };
   }
   // Custom behavior
   return (element: Element) => {
-    onUpdate(null, action, element, { behaviorElement, custom: true });
-    logBehavior(behaviorElement, action);
+    const onUpdateComplete = (success: boolean) => {
+      if (success) {
+        logBehavior(behaviorElement, action);
+      }
+    };
+    onUpdate(null, action, element, {
+      behaviorElement,
+      custom: true,
+      onUpdateComplete,
+    });
   };
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,6 +189,7 @@ export type HvComponentOptions = {
   newElement?: Element | null | undefined;
   showIndicatorId?: string | null | undefined;
   onUpdateCallbacks?: OnUpdateCallbacks;
+  onUpdateComplete?: (success: boolean) => void;
 };
 
 export type HvComponentOnUpdate = (


### PR DESCRIPTION
Behavior logging in the form of `core/components/hyperview | [behavior] | action: add-styles | <behavior trigger...` is being triggered regardless of whether the behavior was run or was cancelled (example, "once='true'" and already ran). To solve this, a new `onUpdateComplete` callback is added to the `onUpdate` flow. This is called with a "success" value of "true" when the update completed successfully, otherwise a "false" is sent. The behavior service can now wait for this callback and determine whether the log should be emitted.

See commits for breakdown.

[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1205585476216008?focus=true)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209916822029079