### PR TITLE
chore(hv-doc): restore full url

### DIFF
--- a/src/core/components/hv-doc/index.tsx
+++ b/src/core/components/hv-doc/index.tsx
@@ -131,7 +131,7 @@ const HvDoc = (props: Props) => {
             : doc;
 
           localDoc.current = document;
-          localUrl.current = targetUrl;
+          localUrl.current = fullUrl;
           const stylesheets = Stylesheets.createStylesheets(doc);
           setState(prev => ({
             ...prev,
@@ -140,7 +140,7 @@ const HvDoc = (props: Props) => {
             loadingUrl: null,
             staleHeaderType,
             styles: stylesheets,
-            url: targetUrl,
+            url: fullUrl,
           }));
         } else {
           // Invalid document


### PR DESCRIPTION
In an attempt to clean up the url monitoring, I was storing just the partial url into state. There's a part of hv-root's `fetchElement` which currently requires the state's url to provide the prefix.