### PR TITLE
chore(handleBack): remove unused component

### DIFF
--- a/src/contexts/navigation.ts
+++ b/src/contexts/navigation.ts
@@ -7,7 +7,7 @@ import type {
   Reload,
   Route,
 } from 'hyperview/src/types';
-import React, { ComponentType, ReactNode } from 'react';
+import React, { ComponentType } from 'react';
 import type { Props as ErrorProps } from 'hyperview/src/core/components/load-error';
 import type { Props as LoadingProps } from 'hyperview/src/core/components/loading';
 import type { NavigationComponents } from 'hyperview/src/services/navigator';
@@ -28,7 +28,6 @@ export type NavigationContextProps = {
   elementErrorComponent?: ComponentType<ErrorProps>;
   errorScreen?: ComponentType<ErrorProps>;
   loadingScreen?: ComponentType<LoadingProps>;
-  handleBack?: ComponentType<{ children: ReactNode }>;
   navigationComponents?: NavigationComponents;
   experimentalFeatures?: ExperimentalFeatures;
 };

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -577,7 +577,6 @@ export default class Hyperview extends PureComponent<Types.Props> {
               errorScreen: this.props.errorScreen,
               experimentalFeatures: this.props.experimentalFeatures,
               fetch: this.props.fetch,
-              handleBack: this.props.handleBack,
               loadingScreen: this.props.loadingScreen,
               navigationComponents: this.props.navigationComponents,
               onError: this.props.onError,

--- a/src/core/components/hv-root/types.ts
+++ b/src/core/components/hv-root/types.ts
@@ -1,5 +1,4 @@
 import * as Logging from 'hyperview/src/services/logging';
-import { ComponentType, ReactNode } from 'react';
 import type {
   ExperimentalFeatures,
   Fetch,
@@ -7,6 +6,7 @@ import type {
   HvComponent,
   Route,
 } from 'hyperview/src/types';
+import { ComponentType } from 'react';
 import type { Props as ErrorProps } from 'hyperview/src/core/components/load-error';
 import type { Props as LoadingProps } from 'hyperview/src/core/components/loading';
 import type { NavigationComponents } from 'hyperview/src/services/navigator';
@@ -34,7 +34,6 @@ export type Props = {
   elementErrorComponent?: ComponentType<ErrorProps>;
   errorScreen?: ComponentType<ErrorProps>;
   loadingScreen?: ComponentType<LoadingProps>;
-  handleBack?: ComponentType<{ children: ReactNode }>;
   logger?: Logging.Logger;
   experimentalFeatures?: ExperimentalFeatures;
 };

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -255,13 +255,6 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
     }
 
     if (renderElement?.localName === LOCAL_NAME.SCREEN) {
-      if (this.props.handleBack) {
-        return (
-          <this.props.handleBack>
-            <Screen />
-          </this.props.handleBack>
-        );
-      }
       return <Screen />;
     }
 
@@ -484,7 +477,6 @@ function HvRouteFC(props: Types.Props) {
             getElement={elemenCacheContext.getElement}
             getLocalDoc={getLocalDoc}
             getScreenState={getScreenState}
-            handleBack={navigationContext.handleBack}
             navigator={navigator}
             onUpdate={onUpdate}
             onUpdateCallbacks={onUpdateCallbacks}

--- a/src/core/components/hv-route/types.ts
+++ b/src/core/components/hv-route/types.ts
@@ -1,5 +1,4 @@
 import * as NavigatorService from 'hyperview/src/services/navigator';
-import { ComponentType, ReactNode } from 'react';
 import {
   ExperimentalFeatures,
   Fetch,
@@ -12,6 +11,7 @@ import {
   RouteParams,
   ScreenState,
 } from 'hyperview/src/types';
+import { ComponentType } from 'react';
 import type { Props as ErrorProps } from 'hyperview/src/core/components/load-error';
 import type { Props as LoadingProps } from 'hyperview/src/core/components/loading';
 
@@ -30,7 +30,6 @@ export type NavigationContextProps = {
   elementErrorComponent?: ComponentType<ErrorProps>;
   errorScreen?: ComponentType<ErrorProps>;
   loadingScreen?: ComponentType<LoadingProps>;
-  handleBack?: ComponentType<{ children: ReactNode }>;
   reload: Reload;
   experimentalFeatures?: ExperimentalFeatures;
 };
@@ -52,7 +51,6 @@ export type InnerRouteProps = {
   behaviors?: HvBehavior[];
   components?: HvComponent[];
   elementErrorComponent?: ComponentType<ErrorProps>;
-  handleBack?: ComponentType<{ children: ReactNode }>;
   getElement: (key: number) => Element | undefined;
   removeElement: (key: number) => void;
   element?: Element;

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -17,7 +17,6 @@ export type Props = Omit<
   | 'onRouteBlur'
   | 'onRouteFocus'
   | 'loadingScreen'
-  | 'handleBack'
   | 'logger'
   | 'errorScreen'
   | 'fetch'


### PR DESCRIPTION
The `handleBack` component was a remnant of legacy navigation where we needed to handle back requests from Android's back button. Since navigation was internalized and the legacy external navigation has been removed, this property is no longer needed.

[Asana](https://app.asana.com/1/47184964732898/project/1205761271270033/task/1210238602307164?focus=true)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210238602307164