### PR TITLE
chore(date-context): remove redundant contexts

### DIFF
--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -155,27 +155,22 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
     };
 
     return (
-      <Contexts.DateFormatContext.Consumer>
-        {formatter => (
-          <HvScreen
-            behaviors={this.props.behaviors}
-            components={this.props.components}
-            elementErrorComponent={this.props.elementErrorComponent}
-            entrypointUrl={this.props.entrypointUrl}
-            formatDate={formatter}
-            getElement={this.props.getElement}
-            getLocalDoc={this.props.getLocalDoc}
-            getScreenState={this.props.getScreenState}
-            navigation={this.props.navigator}
-            onUpdate={this.props.onUpdate}
-            onUpdateCallbacks={this.props.onUpdateCallbacks}
-            reload={this.props.reload}
-            removeElement={this.props.removeElement}
-            route={route}
-            setScreenState={this.props.setScreenState}
-          />
-        )}
-      </Contexts.DateFormatContext.Consumer>
+      <HvScreen
+        behaviors={this.props.behaviors}
+        components={this.props.components}
+        elementErrorComponent={this.props.elementErrorComponent}
+        entrypointUrl={this.props.entrypointUrl}
+        getElement={this.props.getElement}
+        getLocalDoc={this.props.getLocalDoc}
+        getScreenState={this.props.getScreenState}
+        navigation={this.props.navigator}
+        onUpdate={this.props.onUpdate}
+        onUpdateCallbacks={this.props.onUpdateCallbacks}
+        reload={this.props.reload}
+        removeElement={this.props.removeElement}
+        route={route}
+        setScreenState={this.props.setScreenState}
+      />
     );
   };
 

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -168,17 +168,15 @@ export default class HvScreen extends React.Component {
           getDoc: () => this.props.getLocalDoc(),
         }}
       >
-        <Contexts.DateFormatContext.Provider value={this.props.formatDate}>
-          {elementErrorComponent
-            ? React.createElement(elementErrorComponent, {
-                error: this.props.getScreenState().elementError,
-                onPressClose: () =>
-                  this.props.setScreenState({ elementError: null }),
-                onPressReload: () => this.props.reload(),
-              })
-            : null}
-          <Scroll.Provider>{screenElement}</Scroll.Provider>
-        </Contexts.DateFormatContext.Provider>
+        {elementErrorComponent
+          ? React.createElement(elementErrorComponent, {
+              error: this.props.getScreenState().elementError,
+              onPressClose: () =>
+                this.props.setScreenState({ elementError: null }),
+              onPressReload: () => this.props.reload(),
+            })
+          : null}
+        <Scroll.Provider>{screenElement}</Scroll.Provider>
       </Contexts.DocContext.Provider>
     );
   }

--- a/src/core/components/hv-screen/types.ts
+++ b/src/core/components/hv-screen/types.ts
@@ -12,6 +12,7 @@ import { Props as HvRootProps } from 'hyperview/src/core/components/hv-root/type
  */
 export type Props = Omit<
   HvRootProps,
+  | 'formatDate'
   | 'refreshControl'
   | 'navigationComponents'
   | 'onRouteBlur'


### PR DESCRIPTION
`hv-root` is [already a provider](https://github.com/Instawork/hyperview/blob/0a8ac8f5d264f4ba3fc3d4c87896cb9bf85460d7/src/core/components/hv-root/index.tsx#L567) of `<DateFormatContext>` it is redundant to consume within `hv-route` and provide within `hv-screen`.

[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1210316546014477?focus=true)