### PR TITLE
chore(hv-element): create component for element rendering

### DIFF
--- a/src/components/hv-list/index.tsx
+++ b/src/components/hv-list/index.tsx
@@ -3,7 +3,6 @@ import * as Dom from 'hyperview/src/services/dom';
 import * as Keyboard from 'hyperview/src/services/keyboard';
 import * as Logging from 'hyperview/src/services/logging';
 import * as Namespaces from 'hyperview/src/services/namespaces';
-import * as Render from 'hyperview/src/services/render';
 import type {
   DOMString,
   HvComponentOnUpdate,
@@ -20,6 +19,7 @@ import { createTestProps, getAncestorByTagName } from 'hyperview/src/services';
 import { DOMParser } from '@instawork/xmldom';
 import type { ElementRef } from 'react';
 import { FlatList } from 'hyperview/src/core/components/scroll';
+import HvElement from 'hyperview/src/core/components/hv-element';
 import { LOCAL_NAME } from 'hyperview/src/types';
 
 export default class HvList extends PureComponent<HvComponentProps, State> {
@@ -265,12 +265,13 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
               removeClippedSubviews={false}
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               renderItem={({ item }: any) =>
-                item &&
-                Render.renderElement(
-                  item,
-                  this.props.stylesheets,
-                  this.onUpdate,
-                  this.props.options,
+                item && (
+                  <HvElement
+                    element={item as Element}
+                    onUpdate={this.onUpdate}
+                    options={this.props.options}
+                    stylesheets={this.props.stylesheets}
+                  />
                 )
               }
               scrollIndicatorInsets={scrollIndicatorInsets}

--- a/src/components/hv-section-list/index.tsx
+++ b/src/components/hv-section-list/index.tsx
@@ -3,7 +3,6 @@ import * as Dom from 'hyperview/src/services/dom';
 import * as Keyboard from 'hyperview/src/services/keyboard';
 import * as Logging from 'hyperview/src/services/logging';
 import * as Namespaces from 'hyperview/src/services/namespaces';
-import * as Render from 'hyperview/src/services/render';
 import type {
   DOMString,
   HvComponentOnUpdate,
@@ -20,6 +19,7 @@ import type { ScrollParams, State } from './types';
 import { createTestProps, getAncestorByTagName } from 'hyperview/src/services';
 import { DOMParser } from '@instawork/xmldom';
 import type { ElementRef } from 'react';
+import HvElement from 'hyperview/src/core/components/hv-element';
 import { SectionList } from 'hyperview/src/core/components/scroll';
 
 const getSectionIndex = (
@@ -376,23 +376,23 @@ export default class HvSectionList extends PureComponent<
               }
               removeClippedSubviews={false}
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              renderItem={({ item }: any): any =>
-                Render.renderElement(
-                  item,
-                  this.props.stylesheets,
-                  this.onUpdate,
-                  this.props.options,
-                )
-              }
+              renderItem={({ item }: any): any => (
+                <HvElement
+                  element={item as Element}
+                  onUpdate={this.onUpdate}
+                  options={this.props.options}
+                  stylesheets={this.props.stylesheets}
+                />
+              )}
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              renderSectionHeader={({ section: { title } }: any): any =>
-                Render.renderElement(
-                  title,
-                  this.props.stylesheets,
-                  this.onUpdate,
-                  this.props.options,
-                )
-              }
+              renderSectionHeader={({ section: { title } }: any): any => (
+                <HvElement
+                  element={title as Element}
+                  onUpdate={this.onUpdate}
+                  options={this.props.options}
+                  stylesheets={this.props.stylesheets}
+                />
+              )}
               scrollIndicatorInsets={scrollIndicatorInsets}
               sections={sections}
               stickySectionHeadersEnabled={this.getStickySectionHeadersEnabled()}

--- a/src/core/components/hv-element/index.tsx
+++ b/src/core/components/hv-element/index.tsx
@@ -1,0 +1,157 @@
+import * as InlineContext from 'hyperview/src/services/inline-context';
+import * as Logging from 'hyperview/src/services/logging';
+import * as Namespaces from 'hyperview/src/services/namespaces';
+import { LOCAL_NAME, NODE_TYPE } from 'hyperview/src/types';
+import React, { useMemo } from 'react';
+import type { HvComponentProps } from 'hyperview/src/types';
+
+export default (
+  props: HvComponentProps,
+): React.ReactElement<HvComponentProps> | null | string => {
+  if (!props.element) {
+    return null;
+  }
+
+  if (props.element.nodeType === NODE_TYPE.ELEMENT_NODE) {
+    // Hidden elements don't get rendered
+    if (props.element.getAttribute('hide') === 'true') {
+      return null;
+    }
+  }
+  if (props.element.nodeType === NODE_TYPE.COMMENT_NODE) {
+    // XML comments don't get rendered.
+    return null;
+  }
+  if (
+    props.element.nodeType === NODE_TYPE.ELEMENT_NODE &&
+    props.element.namespaceURI === Namespaces.HYPERVIEW
+  ) {
+    switch (props.element.localName) {
+      case LOCAL_NAME.BEHAVIOR:
+      case LOCAL_NAME.MODIFIER:
+      case LOCAL_NAME.STYLES:
+      case LOCAL_NAME.STYLE:
+        // Non-UI elements don't get rendered
+        return null;
+      default:
+        break;
+    }
+  }
+
+  const formattingContext = useMemo(() => {
+    let { inlineFormattingContext } = props.options;
+    if (
+      !props.options.preformatted &&
+      !inlineFormattingContext &&
+      props.element.nodeType === NODE_TYPE.ELEMENT_NODE &&
+      props.element.localName === LOCAL_NAME.TEXT
+    ) {
+      inlineFormattingContext = InlineContext.formatter(props.element);
+    }
+    return inlineFormattingContext;
+  }, [props.element, props.options]);
+
+  const componentProps = useMemo(() => {
+    return {
+      element: props.element,
+      onUpdate: props.onUpdate,
+      options: {
+        ...props.options,
+        inlineFormattingContext: formattingContext,
+      },
+      stylesheets: props.stylesheets,
+    };
+  }, [
+    props.element,
+    formattingContext,
+    props.onUpdate,
+    props.options,
+    props.stylesheets,
+  ]);
+
+  const Component = useMemo(() => {
+    if (
+      props.element.nodeType === NODE_TYPE.ELEMENT_NODE &&
+      props.element.namespaceURI &&
+      props.element.localName
+    ) {
+      return props.options.componentRegistry?.getComponent(
+        props.element.namespaceURI,
+        props.element.localName,
+      );
+    }
+    return undefined;
+  }, [props.element, props.options.componentRegistry]);
+
+  if (props.element.nodeType === NODE_TYPE.ELEMENT_NODE) {
+    if (!props.element.namespaceURI) {
+      Logging.warn(
+        '`namespaceURI` missing for node:',
+        props.element.toString(),
+      );
+      return null;
+    }
+    if (!props.element.localName) {
+      Logging.warn('`localName` missing for node:', props.element.toString());
+      return null;
+    }
+
+    if (Component) {
+      // Prepare props for the component
+
+      // Conditionally render the component with a key if it exists, to avoid
+      // warnings with current React versions, when the key attribute is set
+      // using the spread operator.
+      const key = props.element.getAttribute('key');
+
+      if (key) {
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        return <Component {...componentProps} key={key} />;
+      }
+      return <Component {...componentProps} />; // eslint-disable-line react/jsx-props-no-spreading
+    }
+
+    // No component registered for the namespace/local name.
+    // Warn in case this was an unintended mistake.
+    Logging.warn(
+      `No component registered for tag <${props.element.localName}> (namespace: ${props.element.namespaceURI})`,
+    );
+  }
+
+  if (props.element.nodeType === NODE_TYPE.TEXT_NODE) {
+    // Render non-empty text nodes, when wrapped inside a <text> element
+    if (props.element.nodeValue) {
+      if (
+        ((props.element.parentNode as Element)?.namespaceURI ===
+          Namespaces.HYPERVIEW &&
+          (props.element.parentNode as Element)?.localName ===
+            LOCAL_NAME.TEXT) ||
+        (props.element.parentNode as Element)?.namespaceURI !==
+          Namespaces.HYPERVIEW
+      ) {
+        if (props.options.preformatted) {
+          return props.element.nodeValue;
+        }
+        // When inline formatting context exists, lookup formatted value using node's index.
+        if (formattingContext) {
+          const index = formattingContext[0].indexOf(props.element);
+          return formattingContext[1][index];
+        }
+
+        // Other strings might be whitespaces in non text elements, which we ignore
+        // However we raise a warning when the string isn't just composed of whitespaces.
+        const trimmedValue = props.element.nodeValue.trim();
+        if (trimmedValue.length > 0) {
+          Logging.warn(
+            `Text string "${trimmedValue}" must be rendered within a <text> element`,
+          );
+        }
+      }
+    }
+  }
+
+  if (props.element.nodeType === NODE_TYPE.CDATA_SECTION_NODE) {
+    return props.element.nodeValue;
+  }
+  return null;
+};

--- a/src/core/components/hv-element/index.tsx
+++ b/src/core/components/hv-element/index.tsx
@@ -5,9 +5,7 @@ import { LOCAL_NAME, NODE_TYPE } from 'hyperview/src/types';
 import React, { useMemo } from 'react';
 import type { HvComponentProps } from 'hyperview/src/types';
 
-export default (
-  props: HvComponentProps,
-): React.ReactElement<HvComponentProps> | null | string => {
+export default (props: HvComponentProps): JSX.Element | null | string => {
   if (!props.element) {
     return null;
   }

--- a/src/core/components/hv-route/index.tsx
+++ b/src/core/components/hv-route/index.tsx
@@ -4,7 +4,6 @@ import * as Helpers from 'hyperview/src/services/dom/helpers';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as NavigationContext from 'hyperview/src/contexts/navigation';
 import * as NavigatorService from 'hyperview/src/services/navigator';
-import * as Render from 'hyperview/src/services/render';
 import * as Stylesheets from 'hyperview/src/services/stylesheets';
 import * as Types from './types';
 import * as UrlService from 'hyperview/src/services/url';
@@ -13,12 +12,8 @@ import {
   BackBehaviorProvider,
 } from 'hyperview/src/contexts/back-behaviors';
 import HvDoc, { StateContext } from 'hyperview/src/core/components/hv-doc';
-import React, {
-  JSXElementConstructor,
-  PureComponent,
-  useContext,
-  useMemo,
-} from 'react';
+import React, { PureComponent, useContext, useMemo } from 'react';
+import HvElement from 'hyperview/src/core/components/hv-element';
 import HvNavigator from 'hyperview/src/core/components/hv-navigator';
 import HvScreen from 'hyperview/src/core/components/hv-screen';
 import { LOCAL_NAME } from 'hyperview/src/types';
@@ -102,12 +97,14 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
         const styleSheet = Stylesheets.createStylesheets(
           (preloadElement as unknown) as Document,
         );
-        const component:
-          | string
-          | React.ReactElement<unknown, string | JSXElementConstructor<unknown>>
-          | null = Render.renderElement(body, styleSheet, () => noop, {
-          componentRegistry: this.componentRegistry,
-        });
+        const component = (
+          <HvElement
+            element={body as Element}
+            onUpdate={noop}
+            options={{ componentRegistry: this.componentRegistry }}
+            stylesheets={styleSheet}
+          />
+        );
         if (component) {
           return (
             <Loading

--- a/src/core/components/hv-screen/index.js
+++ b/src/core/components/hv-screen/index.js
@@ -8,6 +8,7 @@ import * as Render from 'hyperview/src/services/render';
 import * as Scroll from 'hyperview/src/core/components/scroll';
 import * as Stylesheets from 'hyperview/src/services/stylesheets';
 import { createProps, createStyleProp } from 'hyperview/src/services';
+import HvElement from 'hyperview/src/core/components/hv-element';
 import { HvScreenRenderError } from './errors';
 import LoadElementError from '../load-element-error';
 import Loading from 'hyperview/src/core/components/loading';
@@ -146,16 +147,18 @@ export default class HvScreen extends React.Component {
     );
     let screenElement;
     if (body) {
-      screenElement = Render.renderElement(
-        body,
-        this.props.getScreenState().styles,
-        this.props.onUpdate,
-        {
-          componentRegistry: this.componentRegistry,
-          onUpdateCallbacks: this.props.onUpdateCallbacks,
-          screenUrl: this.props.getScreenState().url,
-          staleHeaderType: this.props.getScreenState().staleHeaderType,
-        },
+      screenElement = (
+        <HvElement
+          element={body}
+          onUpdate={this.props.onUpdate}
+          options={{
+            componentRegistry: this.componentRegistry,
+            onUpdateCallbacks: this.props.onUpdateCallbacks,
+            screenUrl: this.props.getScreenState().url,
+            staleHeaderType: this.props.getScreenState().staleHeaderType,
+          }}
+          stylesheets={this.props.getScreenState().styles}
+        />
       );
     }
     if (!screenElement) {

--- a/src/core/hyper-ref/index.tsx
+++ b/src/core/hyper-ref/index.tsx
@@ -22,6 +22,7 @@ import type { PressHandlers, PressPropName, Props, State } from './types';
 import React, { PureComponent } from 'react';
 import { RefreshControl, Text, TouchableOpacity } from 'react-native';
 import { BackBehaviorContext } from 'hyperview/src/contexts/back-behaviors';
+import HvElement from 'hyperview/src/core/components/hv-element';
 import { PRESS_TRIGGERS_PROP_NAMES } from './types';
 import { ScrollView } from 'hyperview/src/core/components/scroll';
 import VisibilityDetectingView from 'hyperview/src/VisibilityDetectingView';
@@ -422,13 +423,18 @@ export default class HyperRef extends PureComponent<Props, State> {
   render() {
     // Render the component based on the XML element. Depending on the applied behaviors,
     // this component will be wrapped with others to provide the necessary interaction.
-    const children = Render.renderElement(
-      this.props.element,
-      this.props.stylesheets,
-      this.props.onUpdate,
-      { ...this.props.options, pressed: this.state.pressed, skipHref: true },
+    const children = (
+      <HvElement
+        element={this.props.element}
+        onUpdate={this.props.onUpdate}
+        options={{
+          ...this.props.options,
+          pressed: this.state.pressed,
+          skipHref: true,
+        }}
+        stylesheets={this.props.stylesheets}
+      />
     );
-
     const { ScrollableView, TouchableView, VisibilityView } = this;
 
     return (


### PR DESCRIPTION
Improving performance by creating a new `hv-element` component as a replacement for Render.renderElement. This allows memoizing the options and props of the component to reduce unneeded re-renders.

[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1210344460236268?focus=true)