### PR TITLE
chore(render): simplify render.renderElement

### DIFF
--- a/demo/src/Components/NavBack/NavBack.tsx
+++ b/demo/src/Components/NavBack/NavBack.tsx
@@ -1,8 +1,8 @@
+import React, { useContext } from 'react';
 import type { HvComponentProps } from 'hyperview';
 import Hyperview from 'hyperview';
 import { NavigationContext } from '@react-navigation/native';
 import { findElements } from '../../Helpers';
-import { useContext } from 'react';
 
 export const namespaceURI = 'https://hyperview.org/navigation';
 
@@ -25,12 +25,15 @@ const NavBack = (props: HvComponentProps) => {
   if (!element) {
     return null;
   }
-  return (Hyperview.renderElement(
-    element,
-    props.stylesheets,
-    props.onUpdate,
-    props.options,
-  ) as unknown) as JSX.Element;
+
+  return (
+    <Hyperview.HvElement
+      element={element}
+      onUpdate={props.onUpdate}
+      options={props.options}
+      stylesheets={props.stylesheets}
+    />
+  );
 };
 
 NavBack.namespaceURI = namespaceURI;

--- a/src/core/components/hv-element/index.tsx
+++ b/src/core/components/hv-element/index.tsx
@@ -4,7 +4,7 @@ import * as Namespaces from 'hyperview/src/services/namespaces';
 import { LOCAL_NAME, NODE_TYPE } from 'hyperview/src/types';
 import React, { useMemo } from 'react';
 import type { HvComponentProps } from 'hyperview/src/types';
-import { isRenderableElement } from '../../utils';
+import { isRenderableElement } from 'hyperview/src/core/utils';
 
 export default (props: HvComponentProps): JSX.Element | null | string => {
   // eslint-disable-next-line react/destructuring-assignment
@@ -34,7 +34,7 @@ export default (props: HvComponentProps): JSX.Element | null | string => {
       },
       stylesheets,
     };
-  }, [formattingContext, options, element, onUpdate, stylesheets]);
+  }, [element, formattingContext, onUpdate, options, stylesheets]);
 
   const Component = useMemo(() => {
     if (nodeType === NODE_TYPE.ELEMENT_NODE && namespaceURI && localName) {

--- a/src/core/components/hv-element/index.tsx
+++ b/src/core/components/hv-element/index.tsx
@@ -50,10 +50,14 @@ export default (props: HvComponentProps): JSX.Element | null | string => {
     return props.element.namespaceURI;
   }, [props.element]);
 
+  const options = useMemo(() => {
+    return props.options;
+  }, [props.options]);
+
   const formattingContext = useMemo(() => {
-    let { inlineFormattingContext } = props.options;
+    let { inlineFormattingContext } = options;
     if (
-      !props.options.preformatted &&
+      !options.preformatted &&
       !inlineFormattingContext &&
       nodeType === NODE_TYPE.ELEMENT_NODE &&
       localName === LOCAL_NAME.TEXT
@@ -61,35 +65,32 @@ export default (props: HvComponentProps): JSX.Element | null | string => {
       inlineFormattingContext = InlineContext.formatter(props.element);
     }
     return inlineFormattingContext;
-  }, [localName, nodeType, props.element, props.options]);
+  }, [localName, nodeType, options, props.element]);
 
   const componentProps = useMemo(() => {
     return {
       element: props.element,
       onUpdate: props.onUpdate,
       options: {
-        ...props.options,
+        ...options,
         inlineFormattingContext: formattingContext,
       },
       stylesheets: props.stylesheets,
     };
   }, [
     formattingContext,
+    options,
     props.element,
     props.onUpdate,
-    props.options,
     props.stylesheets,
   ]);
 
   const Component = useMemo(() => {
     if (nodeType === NODE_TYPE.ELEMENT_NODE && namespaceURI && localName) {
-      return props.options.componentRegistry?.getComponent(
-        namespaceURI,
-        localName,
-      );
+      return options.componentRegistry?.getComponent(namespaceURI, localName);
     }
     return undefined;
-  }, [localName, namespaceURI, nodeType, props.options.componentRegistry]);
+  }, [localName, namespaceURI, nodeType, options.componentRegistry]);
 
   if (nodeType === NODE_TYPE.ELEMENT_NODE) {
     if (!namespaceURI) {
@@ -137,7 +138,7 @@ export default (props: HvComponentProps): JSX.Element | null | string => {
         (props.element.parentNode as Element)?.namespaceURI !==
           Namespaces.HYPERVIEW
       ) {
-        if (props.options.preformatted) {
+        if (options.preformatted) {
           return props.element.nodeValue;
         }
         // When inline formatting context exists, lookup formatted value using node's index.

--- a/src/core/components/hv-element/index.tsx
+++ b/src/core/components/hv-element/index.tsx
@@ -8,19 +8,19 @@ import { isRenderableElement } from '../../utils';
 
 export default (props: HvComponentProps): JSX.Element | null | string => {
   const nodeType = useMemo(() => {
-    return props.element.nodeType;
+    return props.element?.nodeType;
   }, [props.element]);
 
   const localName = useMemo(() => {
-    return props.element.localName;
+    return props.element?.localName;
   }, [props.element]);
 
   const namespaceURI = useMemo(() => {
-    return props.element.namespaceURI;
+    return props.element?.namespaceURI;
   }, [props.element]);
 
   const options = useMemo(() => {
-    return props.options;
+    return props.options || {};
   }, [props.options]);
 
   const formattingContext = useMemo(() => {

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -25,6 +25,7 @@ import {
   UpdateAction,
 } from 'hyperview/src/types';
 import React, { PureComponent } from 'react';
+import HvElement from 'hyperview/src/core/components/hv-element';
 import HvRoute from 'hyperview/src/core/components/hv-route';
 import { Linking } from 'react-native';
 import { XNetworkRetryAction } from 'hyperview/src/services/dom/types';
@@ -42,6 +43,8 @@ export default class Hyperview extends PureComponent<Types.Props> {
   static renderChildNodes = Render.renderChildNodes;
 
   static renderElement = Render.renderElement;
+
+  static HvElement = HvElement;
 
   behaviorRegistry: BehaviorRegistry;
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,3 +1,7 @@
+import * as Logging from 'hyperview/src/services/logging';
+import * as Namespaces from 'hyperview/src/services/namespaces';
+import { HvComponentOptions, LOCAL_NAME, NODE_TYPE } from 'hyperview/src/types';
+
 /**
  * Provides a random UUID string.
  * @returns {string}
@@ -16,4 +20,99 @@ export const uuid = (): string => {
  */
 export const uuidNumber = (): number => {
   return parseInt(uuid().replace(/-/g, ''), 16);
+};
+
+/**
+ * Checks if an element should be rendered based on the element type and options
+ * Logging warnings for unexpected conditions
+ * @param {Element} element
+ * @param {HvComponentOptions} options
+ * @param {InlineContext} inlineFormattingContext
+ * @returns {boolean}
+ */
+export const isRenderableElement = (
+  element: Element,
+  options: HvComponentOptions,
+  inlineFormattingContext: [Node[], string[]] | null | undefined,
+): boolean => {
+  if (!element) {
+    return false;
+  }
+  if (
+    element.nodeType === NODE_TYPE.ELEMENT_NODE &&
+    element.getAttribute('hide') === 'true'
+  ) {
+    // Hidden elements don't get rendered
+    return false;
+  }
+  if (element.nodeType === NODE_TYPE.COMMENT_NODE) {
+    // XML comments don't get rendered.
+    return false;
+  }
+  if (
+    element.nodeType === NODE_TYPE.ELEMENT_NODE &&
+    element.namespaceURI === Namespaces.HYPERVIEW
+  ) {
+    switch (element.localName) {
+      case LOCAL_NAME.BEHAVIOR:
+      case LOCAL_NAME.MODIFIER:
+      case LOCAL_NAME.STYLES:
+      case LOCAL_NAME.STYLE:
+        // Non-UI elements don't get rendered
+        return false;
+      default:
+        break;
+    }
+  }
+
+  if (element.nodeType === NODE_TYPE.ELEMENT_NODE) {
+    if (!element.namespaceURI) {
+      Logging.warn('`namespaceURI` missing for node:', element.toString());
+      return false;
+    }
+    if (!element.localName) {
+      Logging.warn('`localName` missing for node:', element.toString());
+      return false;
+    }
+
+    if (
+      options.componentRegistry?.getComponent(
+        element.namespaceURI,
+        element.localName,
+      )
+    ) {
+      // Has a component registered for the namespace/local name.
+      return true;
+    }
+    // No component registered for the namespace/local name.
+    // Warn in case this was an unintended mistake.
+    Logging.warn(
+      `No component registered for tag <${element.localName}> (namespace: ${element.namespaceURI})`,
+    );
+  }
+
+  if (element.nodeType === NODE_TYPE.TEXT_NODE) {
+    // Render non-empty text nodes, when wrapped inside a <text> element
+    if (element.nodeValue) {
+      if (
+        ((element.parentNode as Element)?.namespaceURI ===
+          Namespaces.HYPERVIEW &&
+          (element.parentNode as Element)?.localName === LOCAL_NAME.TEXT) ||
+        (element.parentNode as Element)?.namespaceURI !== Namespaces.HYPERVIEW
+      ) {
+        if (options.preformatted) {
+          return true;
+        }
+        // When inline formatting context exists, lookup formatted value using node's index.
+        if (inlineFormattingContext) {
+          return true;
+        }
+      }
+    }
+  }
+
+  if (element.nodeType === NODE_TYPE.CDATA_SECTION_NODE) {
+    return true;
+  }
+  return false;
 };

--- a/src/services/render/index.tsx
+++ b/src/services/render/index.tsx
@@ -1,15 +1,14 @@
 import * as InlineContext from 'hyperview/src/services/inline-context';
-import * as Logging from 'hyperview/src/services/logging';
-import * as Namespaces from 'hyperview/src/services/namespaces';
 import type {
-  HvComponent,
   HvComponentOnUpdate,
   HvComponentOptions,
   HvComponentProps,
   StyleSheets,
 } from 'hyperview/src/types';
 import { LOCAL_NAME, NODE_TYPE } from 'hyperview/src/types';
+import HvElement from 'hyperview/src/core/components/hv-element';
 import React from 'react';
+import { isRenderableElement } from 'hyperview/src/core/utils';
 
 export const renderElement = (
   element: Element | null | undefined,
@@ -20,125 +19,28 @@ export const renderElement = (
   if (!element) {
     return null;
   }
-  if (element.nodeType === NODE_TYPE.ELEMENT_NODE) {
-    // Hidden elements don't get rendered
-    if (element.getAttribute('hide') === 'true') {
-      return null;
-    }
-  }
-  if (element.nodeType === NODE_TYPE.COMMENT_NODE) {
-    // XML comments don't get rendered.
-    return null;
-  }
-  if (
-    element.nodeType === NODE_TYPE.ELEMENT_NODE &&
-    element.namespaceURI === Namespaces.HYPERVIEW
-  ) {
-    switch (element.localName) {
-      case LOCAL_NAME.BEHAVIOR:
-      case LOCAL_NAME.MODIFIER:
-      case LOCAL_NAME.STYLES:
-      case LOCAL_NAME.STYLE:
-        // Non-UI elements don't get rendered
-        return null;
-      default:
-        break;
-    }
-  }
 
-  // Initialize inline formatting context for <text> elements when not already defined
-  let { inlineFormattingContext } = options;
-  if (
+  const inlineFormattingContext =
     !options.preformatted &&
-    !inlineFormattingContext &&
+    !options.inlineFormattingContext &&
     element.nodeType === NODE_TYPE.ELEMENT_NODE &&
     element.localName === LOCAL_NAME.TEXT
-  ) {
-    inlineFormattingContext = InlineContext.formatter(element);
+      ? InlineContext.formatter(element)
+      : options.inlineFormattingContext;
+
+  // Check if the element is renderable before rendering the component
+  if (!isRenderableElement(element, options, inlineFormattingContext)) {
+    return null;
   }
 
-  if (element.nodeType === NODE_TYPE.ELEMENT_NODE) {
-    if (!element.namespaceURI) {
-      Logging.warn('`namespaceURI` missing for node:', element.toString());
-      return null;
-    }
-    if (!element.localName) {
-      Logging.warn('`localName` missing for node:', element.toString());
-      return null;
-    }
-
-    const Component:
-      | HvComponent
-      | undefined = options.componentRegistry?.getComponent(
-      element.namespaceURI,
-      element.localName,
-    );
-
-    if (Component) {
-      // Prepare props for the component
-      const props = {
-        element,
-        onUpdate,
-        options: {
-          ...options,
-          inlineFormattingContext,
-        },
-        stylesheets,
-      };
-
-      // Conditionally render the component with a key if it exists, to avoid
-      // warnings with current React versions, when the key attribute is set
-      // using the spread operator.
-      const key = element.getAttribute('key');
-
-      if (key) {
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        return <Component {...props} key={key} />;
-      }
-      return <Component {...props} />; // eslint-disable-line react/jsx-props-no-spreading
-    }
-
-    // No component registered for the namespace/local name.
-    // Warn in case this was an unintended mistake.
-    Logging.warn(
-      `No component registered for tag <${element.localName}> (namespace: ${element.namespaceURI})`,
-    );
-  }
-
-  if (element.nodeType === NODE_TYPE.TEXT_NODE) {
-    // Render non-empty text nodes, when wrapped inside a <text> element
-    if (element.nodeValue) {
-      if (
-        ((element.parentNode as Element)?.namespaceURI ===
-          Namespaces.HYPERVIEW &&
-          (element.parentNode as Element)?.localName === LOCAL_NAME.TEXT) ||
-        (element.parentNode as Element)?.namespaceURI !== Namespaces.HYPERVIEW
-      ) {
-        if (options.preformatted) {
-          return element.nodeValue;
-        }
-        // When inline formatting context exists, lookup formatted value using node's index.
-        if (inlineFormattingContext) {
-          const index = inlineFormattingContext[0].indexOf(element);
-          return inlineFormattingContext[1][index];
-        }
-
-        // Other strings might be whitespaces in non text elements, which we ignore
-        // However we raise a warning when the string isn't just composed of whitespaces.
-        const trimmedValue = element.nodeValue.trim();
-        if (trimmedValue.length > 0) {
-          Logging.warn(
-            `Text string "${trimmedValue}" must be rendered within a <text> element`,
-          );
-        }
-      }
-    }
-  }
-
-  if (element.nodeType === NODE_TYPE.CDATA_SECTION_NODE) {
-    return element.nodeValue;
-  }
-  return null;
+  return (
+    <HvElement
+      element={element}
+      onUpdate={onUpdate}
+      options={options}
+      stylesheets={stylesheets}
+    />
+  );
 };
 
 export const renderChildren = (


### PR DESCRIPTION
Consolidate the logic between `src/services/render` and the new `hv-element` component.
- Created a new utility to abstract the `null` render logic and logging
- Update render service to use logic and then return the component
- Update `hv-element` to use utility for logic and logging
- Export `hv-element` for access outside Hyperview
- Confirmed external use of `Hyperview.renderElement` with new logic still working (using existing nav-back demo)
- Update `nav-back` demo to use component instead of function

[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1210368849843731?focus=true)