### PR TITLE
chore(render): revert view changes

### DIFF
--- a/src/components/hv-option/index.tsx
+++ b/src/components/hv-option/index.tsx
@@ -1,8 +1,8 @@
 import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Namespaces from 'hyperview/src/services/namespaces';
+import * as Render from 'hyperview/src/services/render';
 import React, { PureComponent } from 'react';
 import { TouchableWithoutFeedback, View } from 'react-native';
-import HvChildren from 'hyperview/src/core/components/hv-children';
 import type { HvComponentProps } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import type { State } from './types';
@@ -53,7 +53,6 @@ export default class HvOption extends PureComponent<HvComponentProps, State> {
       this.props.stylesheets,
       newOptions,
     );
-    const { key, ...otherProps } = props;
 
     // Option renders as an outer TouchableWithoutFeedback view and inner view.
     // The outer view handles presses, the inner view handles styling.
@@ -80,24 +79,20 @@ export default class HvOption extends PureComponent<HvComponentProps, State> {
       outerProps.style = { flex: props.style.flex };
     }
 
-    return (
-      <TouchableWithoutFeedback
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...outerProps}
-      >
-        <View
-          key={key}
-          // eslint-disable-next-line react/jsx-props-no-spreading
-          {...otherProps}
-        >
-          <HvChildren
-            element={this.props.element}
-            onUpdate={this.props.onUpdate}
-            options={newOptions}
-            stylesheets={this.props.stylesheets}
-          />
-        </View>
-      </TouchableWithoutFeedback>
+    // TODO: Replace with <HvChildren>
+    return React.createElement(
+      TouchableWithoutFeedback,
+      outerProps,
+      React.createElement(
+        View,
+        props,
+        ...Render.buildChildArray(
+          this.props.element,
+          this.props.onUpdate,
+          newOptions,
+          this.props.stylesheets,
+        ),
+      ),
     );
   }
 }

--- a/src/components/hv-select-single/index.tsx
+++ b/src/components/hv-select-single/index.tsx
@@ -1,7 +1,7 @@
 import * as Namespaces from 'hyperview/src/services/namespaces';
+import * as Render from 'hyperview/src/services/render';
 import type { DOMString, HvComponentProps } from 'hyperview/src/types';
 import React, { PureComponent } from 'react';
-import HvChildren from 'hyperview/src/core/components/hv-children';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import { View } from 'react-native';
 import { createProps } from 'hyperview/src/services';
@@ -89,23 +89,20 @@ export default class HvSelectSingle extends PureComponent<HvComponentProps> {
     const props = createProps(this.props.element, this.props.stylesheets, {
       ...this.props.options,
     });
-    const { key, ...otherProps } = props;
-    return (
-      <View
-        key={key}
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...otherProps}
-      >
-        <HvChildren
-          element={this.props.element}
-          onUpdate={this.props.onUpdate}
-          options={{
-            ...this.props.options,
-            onSelect: this.onSelect,
-          }}
-          stylesheets={this.props.stylesheets}
-        />
-      </View>
+
+    // TODO: Replace with <HvChildren>
+    return React.createElement(
+      View,
+      props,
+      ...Render.buildChildArray(
+        this.props.element,
+        this.props.onUpdate,
+        {
+          ...this.props.options,
+          onSelect: this.onSelect,
+        },
+        this.props.stylesheets,
+      ),
     );
   }
 }

--- a/src/components/hv-text/index.tsx
+++ b/src/components/hv-text/index.tsx
@@ -1,10 +1,10 @@
 import * as Namespaces from 'hyperview/src/services/namespaces';
+import * as Render from 'hyperview/src/services/render';
 import type {
   HvComponentOnUpdate,
   HvComponentProps,
 } from 'hyperview/src/types';
 import React, { PureComponent } from 'react';
-import HvChildren from 'hyperview/src/core/components/hv-children';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import { Text } from 'react-native';
 import { addHref } from 'hyperview/src/core/hyper-ref';
@@ -21,24 +21,21 @@ export default class HvText extends PureComponent<HvComponentProps> {
       this.props.stylesheets,
       this.props.options,
     );
-    const { key, ...otherProps } = props;
-    return (
-      <Text
-        key={key}
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...otherProps}
-      >
-        <HvChildren
-          element={this.props.element}
-          onUpdate={this.props.onUpdate}
-          options={{
-            ...this.props.options,
-            preformatted:
-              this.props.element.getAttribute('preformatted') === 'true',
-          }}
-          stylesheets={this.props.stylesheets}
-        />
-      </Text>
+
+    // TODO: Replace with <HvChildren>
+    return React.createElement(
+      Text,
+      props,
+      ...Render.buildChildArray(
+        this.props.element,
+        this.props.onUpdate,
+        {
+          ...this.props.options,
+          preformatted:
+            this.props.element.getAttribute('preformatted') === 'true',
+        },
+        this.props.stylesheets,
+      ),
     );
   };
 

--- a/src/components/hv-view/index.tsx
+++ b/src/components/hv-view/index.tsx
@@ -194,45 +194,50 @@ export default class HvView extends PureComponent<HvComponentProps> {
     /* eslint-disable react/jsx-props-no-spreading */
     if (scrollable) {
       if (hasInputFields) {
-        return (
-          <KeyboardAwareScrollView
-            element={this.props.element}
-            {...this.getCommonProps()}
-            {...this.getScrollViewProps(children)}
-            {...this.getKeyboardAwareScrollViewProps(inputFieldRefs)}
-          >
-            {children}
-          </KeyboardAwareScrollView>
+        // TODO: Replace with <HvChildren>
+        return React.createElement(
+          KeyboardAwareScrollView,
+          {
+            element: this.props.element,
+            ...this.getCommonProps(),
+            ...this.getScrollViewProps(children),
+            ...this.getKeyboardAwareScrollViewProps(inputFieldRefs),
+          },
+          ...children,
         );
       }
-      return (
-        <ScrollView
-          element={this.props.element}
-          {...this.getCommonProps()}
-          {...this.getScrollViewProps(children)}
-        >
-          {children}
-        </ScrollView>
+      // TODO: Replace with <HvChildren>
+      return React.createElement(
+        ScrollView,
+        {
+          element: this.props.element,
+          ...this.getCommonProps(),
+          ...this.getScrollViewProps(children),
+        },
+        ...children,
       );
     }
     if (!keyboardAvoiding && safeArea) {
-      return <SafeAreaView {...this.getCommonProps()}>{children}</SafeAreaView>;
-    }
-    if (keyboardAvoiding) {
-      return (
-        <KeyboardAvoidingView {...this.getCommonProps()} behavior="position">
-          {children}
-        </KeyboardAvoidingView>
+      // TODO: Replace with <HvChildren>
+      return React.createElement(
+        SafeAreaView,
+        this.getCommonProps(),
+        ...children,
       );
     }
-    return (
-      <View
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...this.getCommonProps()}
-      >
-        {children}
-      </View>
-    );
+    if (keyboardAvoiding) {
+      // TODO: Replace with <HvChildren>
+      return React.createElement(
+        KeyboardAvoidingView,
+        {
+          ...this.getCommonProps(),
+          behavior: 'position',
+        },
+        ...children,
+      );
+    }
+    // TODO: Replace with <HvChildren>
+    return React.createElement(View, this.getCommonProps(), ...children);
     /* eslint-enable react/jsx-props-no-spreading */
   };
 

--- a/src/services/render/index.tsx
+++ b/src/services/render/index.tsx
@@ -33,6 +33,18 @@ export const renderElement = (
     return null;
   }
 
+  const key = element.getAttribute?.('key');
+  if (key && key !== '') {
+    return (
+      <HvElement
+        key={key}
+        element={element}
+        onUpdate={onUpdate}
+        options={options}
+        stylesheets={stylesheets}
+      />
+    );
+  }
   return (
     <HvElement
       element={element}
@@ -96,12 +108,27 @@ export const buildChildArray = (
   if (!element || !element.childNodes) {
     return [];
   }
-  return Array.from(element.childNodes).map(node => (
-    <HvElement
-      element={node as Element}
-      onUpdate={onUpdate}
-      options={options}
-      stylesheets={stylesheets}
-    />
-  ));
+  return Array.from(element.childNodes).map(node => {
+    const nodeElement = node as Element;
+    const key = nodeElement?.getAttribute?.('key');
+    if (key && key !== '') {
+      return (
+        <HvElement
+          key={key}
+          element={nodeElement}
+          onUpdate={onUpdate}
+          options={options}
+          stylesheets={stylesheets}
+        />
+      );
+    }
+    return (
+      <HvElement
+        element={nodeElement}
+        onUpdate={onUpdate}
+        options={options}
+        stylesheets={stylesheets}
+      />
+    );
+  });
 };


### PR DESCRIPTION
The updated code was causing an increase in "Each child in a list should have a unique key prop" warnings. It was determined that the legacy code used spreading over the child array which causes React to not issue the warning. [See documentation](https://react.dev/reference/react/createElement#:~:text=You%20should%20only,they%20never%20reorder.).

This code temporarily reverts the various components which were throwing the warnings in the Hyperview demo. They should be restored at a later time to restore the intended functionality.

- [Added a key to the \<HvElement\>](https://github.com/Instawork/hyperview/pull/1176/commits/a6406bc66411b55125102888987c6be44dc31a03)
- [Reverted use of declarative syntax where needed](https://github.com/Instawork/hyperview/pull/1176/commits/ec8e044dfb9bdf8054fe305d347c791d5f1530c6)

Relates to [Asana](https://app.asana.com/1/47184964732898/project/1205761271270033/task/1210424257505845?focus=true)