### PR TITLE
chore(render): memoize create styles

### DIFF
--- a/src/components/hv-date-field/field/index.tsx
+++ b/src/components/hv-date-field/field/index.tsx
@@ -1,5 +1,5 @@
 import * as Contexts from 'hyperview/src/contexts';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { StyleSheet, TouchableWithoutFeedback, View } from 'react-native';
 import { createProps, createStyleProp } from 'hyperview/src/services';
 import FieldLabel from '../field-label';
@@ -22,13 +22,17 @@ export default (props: Props) => {
     styleAttr: 'field-style',
   });
 
-  const labelStyle: StyleSheetType = StyleSheet.flatten(
-    createStyleProp(props.element, props.stylesheets, {
-      ...props.options,
-      focused: props.focused,
-      pressed,
-      styleAttr: 'field-text-style',
-    }),
+  const labelStyle: StyleSheetType = useMemo(
+    () =>
+      StyleSheet.flatten(
+        createStyleProp(props.element, props.stylesheets, {
+          ...props.options,
+          focused: props.focused,
+          pressed,
+          styleAttr: 'field-text-style',
+        }),
+      ),
+    [props.element, props.stylesheets, props.options, props.focused, pressed],
   );
 
   return (

--- a/src/components/hv-picker-field/field-label/index.tsx
+++ b/src/components/hv-picker-field/field-label/index.tsx
@@ -1,7 +1,7 @@
 import * as FontScale from 'hyperview/src/services/font-scale';
+import React, { useMemo } from 'react';
 import { StyleSheet, Text } from 'react-native';
 import type { Props } from './types';
-import React from 'react';
 import type { StyleSheet as StyleSheetType } from 'hyperview/src/types';
 import { createStyleProp } from 'hyperview/src/services';
 
@@ -14,13 +14,23 @@ export default (props: Props) => {
   const placeholderTextColor = props.element.getAttribute(
     'placeholderTextColor',
   );
-  const style: StyleSheetType = StyleSheet.flatten(
-    createStyleProp(props.element, props.stylesheets, {
-      ...props.options,
-      focused: props.focused,
-      pressed: props.pressed,
-      styleAttr: 'field-text-style',
-    }),
+  const style: StyleSheetType = useMemo(
+    () =>
+      StyleSheet.flatten(
+        createStyleProp(props.element, props.stylesheets, {
+          ...props.options,
+          focused: props.focused,
+          pressed: props.pressed,
+          styleAttr: 'field-text-style',
+        }),
+      ),
+    [
+      props.element,
+      props.stylesheets,
+      props.options,
+      props.focused,
+      props.pressed,
+    ],
   );
 
   const labelStyles: Array<StyleSheetType> = [style];

--- a/src/components/hv-picker-field/index.ios.tsx
+++ b/src/components/hv-picker-field/index.ios.tsx
@@ -5,7 +5,6 @@ import type {
   HvComponentProps,
   StyleSheet,
 } from 'hyperview/src/types';
-import React, { PureComponent } from 'react';
 import {
   createStyleProp,
   createTestProps,
@@ -15,6 +14,7 @@ import Field from './field';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import Modal from 'hyperview/src/core/components/modal';
 import Picker from 'hyperview/src/core/components/picker';
+import React from 'react';
 import { View } from 'react-native';
 
 /**
@@ -23,18 +23,10 @@ import { View } from 'react-native';
  * - On Android, the system picker is rendered inline on the screen. Pressing the picker
  *   opens a system dialog.
  */
-export default class HvPickerField extends PureComponent<HvComponentProps> {
-  static namespaceURI = Namespaces.HYPERVIEW;
-
-  static localName = LOCAL_NAME.PICKER_FIELD;
-
-  static getFormInputValues = (element: Element): Array<[string, string]> => {
-    return getNameValueFormInputValues(element);
-  };
-
-  getPickerInitialValue = (): string => {
-    const value = this.getValue();
-    const pickerItems: Element[] = this.getPickerItems();
+const HvPickerField = (props: HvComponentProps) => {
+  const getPickerInitialValue = (): string => {
+    const value = getValue();
+    const pickerItems: Element[] = getPickerItems();
     const valueExists = pickerItems.some(
       item => item.getAttribute('value') === value,
     );
@@ -49,14 +41,14 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
   /**
    * Returns a string representing the value in the field.
    */
-  getValue = (): string => this.props.element.getAttribute('value') || '';
+  const getValue = (): string => props.element.getAttribute('value') || '';
 
   /**
    * Gets the label from the picker items for the given value.
    * If the value doesn't have a picker item, returns null.
    */
-  getLabelForValue = (value: DOMString): string | null | undefined => {
-    const pickerItemElements: HTMLCollectionOf<Element> = this.props.element.getElementsByTagNameNS(
+  const getLabelForValue = (value: DOMString): string | null | undefined => {
+    const pickerItemElements: HTMLCollectionOf<Element> = props.element.getElementsByTagNameNS(
       Namespaces.HYPERVIEW,
       LOCAL_NAME.PICKER_ITEM,
     );
@@ -81,12 +73,12 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
   /**
    * Returns a string representing the value in the picker.
    */
-  getPickerValue = (): string =>
-    this.props.element.getAttribute('picker-value') || '';
+  const getPickerValue = (): string =>
+    props.element.getAttribute('picker-value') || '';
 
-  getPickerItems = (): Element[] =>
+  const getPickerItems = (): Element[] =>
     Array.from(
-      this.props.element.getElementsByTagNameNS(
+      props.element.getElementsByTagNameNS(
         Namespaces.HYPERVIEW,
         LOCAL_NAME.PICKER_ITEM,
       ),
@@ -96,125 +88,129 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
    * Shows the picker, defaulting to the field's value.
    * If the field is not set, use the first value in the picker.
    */
-  onFieldPress = () => {
-    const newElement = this.props.element.cloneNode(true) as Element;
+  const onFieldPress = () => {
+    const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'true');
-    newElement.setAttribute('picker-value', this.getPickerInitialValue());
-    this.props.onUpdate(null, 'swap', this.props.element, { newElement });
-    Behaviors.trigger('focus', newElement, this.props.onUpdate);
+    newElement.setAttribute('picker-value', getPickerInitialValue());
+    props.onUpdate(null, 'swap', props.element, { newElement });
+    Behaviors.trigger('focus', newElement, props.onUpdate);
   };
 
   /**
    * Hides the picker without applying the chosen value.
    */
-  onCancel = () => {
-    const newElement = this.props.element.cloneNode(true) as Element;
+  const onCancel = () => {
+    const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'false');
     newElement.removeAttribute('picker-value');
-    this.props.onUpdate(null, 'swap', this.props.element, { newElement });
-    Behaviors.trigger('blur', newElement, this.props.onUpdate);
+    props.onUpdate(null, 'swap', props.element, { newElement });
+    Behaviors.trigger('blur', newElement, props.onUpdate);
   };
 
   /**
    * Hides the picker and applies the chosen value to the field.
    */
-  onDone = () => {
-    const pickerValue = this.getPickerValue();
-    const value = this.getValue();
-    const newElement = this.props.element.cloneNode(true) as Element;
+  const onDone = () => {
+    const pickerValue = getPickerValue();
+    const value = getValue();
+    const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('value', pickerValue);
     newElement.removeAttribute('picker-value');
     newElement.setAttribute('focused', 'false');
-    this.props.onUpdate(null, 'swap', this.props.element, { newElement });
+    props.onUpdate(null, 'swap', props.element, { newElement });
     const hasChanged = value !== pickerValue;
     if (hasChanged) {
-      Behaviors.trigger('change', newElement, this.props.onUpdate);
+      Behaviors.trigger('change', newElement, props.onUpdate);
     }
-    Behaviors.trigger('blur', newElement, this.props.onUpdate);
+    Behaviors.trigger('blur', newElement, props.onUpdate);
   };
 
   /**
    * Updates the picker value while keeping the picker open.
    */
-  setPickerValue = (value: string) => {
-    const newElement = this.props.element.cloneNode(true) as Element;
+  const setPickerValue = (value: string) => {
+    const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('picker-value', value);
-    this.props.onUpdate(null, 'swap', this.props.element, { newElement });
+    props.onUpdate(null, 'swap', props.element, { newElement });
   };
 
   /**
    * Returns true if the field is focused (and picker is showing).
    */
-  isFocused = (): boolean =>
-    this.props.element.getAttribute('focused') === 'true';
+  const isFocused = (): boolean =>
+    props.element.getAttribute('focused') === 'true';
 
-  render() {
-    const style: Array<StyleSheet> = createStyleProp(
-      this.props.element,
-      this.props.stylesheets,
-      {
-        ...this.props.options,
-        styleAttr: 'field-text-style',
-      },
-    );
-    const { testID, accessibilityLabel } = createTestProps(this.props.element);
-    const value: DOMString | null | undefined = this.props.element.getAttribute(
-      'value',
-    );
-    const placeholderTextColor:
-      | DOMString
-      | null
-      | undefined = this.props.element.getAttribute('placeholderTextColor');
-    if ([undefined, null, ''].includes(value) && placeholderTextColor) {
-      style.push({ color: placeholderTextColor });
-    }
-
-    // Gets all of the <picker-item> elements. All picker item elements
-    // with a value and label are turned into options for the picker.
-    const children = this.getPickerItems()
-      .filter(Boolean)
-      .map((item: Element) => {
-        const l: DOMString | null | undefined = item.getAttribute('label');
-        const v: DOMString | null | undefined = item.getAttribute('value');
-        if (!l || typeof v !== 'string') {
-          return null;
-        }
-        return <Picker.Item key={l + v} label={l} value={v} />;
-      });
-
-    const focused = this.props.element.getAttribute('focused') === 'true';
-
-    return (
-      <Field
-        element={this.props.element}
-        focused={focused}
-        onPress={this.onFieldPress}
-        options={this.props.options}
-        stylesheets={this.props.stylesheets}
-        value={this.getLabelForValue(this.getValue())}
-      >
-        {focused ? (
-          <Modal
-            element={this.props.element}
-            focused={focused}
-            onModalCancel={this.onCancel}
-            onModalDone={this.onDone}
-            onUpdate={this.props.onUpdate}
-            options={this.props.options}
-            stylesheets={this.props.stylesheets}
-          >
-            <View accessibilityLabel={accessibilityLabel} testID={testID}>
-              <Picker
-                onValueChange={this.setPickerValue}
-                selectedValue={this.getPickerValue()}
-                style={style}
-              >
-                {children}
-              </Picker>
-            </View>
-          </Modal>
-        ) : null}
-      </Field>
-    );
+  const style: Array<StyleSheet> = createStyleProp(
+    props.element,
+    props.stylesheets,
+    {
+      ...props.options,
+      styleAttr: 'field-text-style',
+    },
+  );
+  const { testID, accessibilityLabel } = createTestProps(props.element);
+  const value: DOMString | null | undefined = props.element.getAttribute(
+    'value',
+  );
+  const placeholderTextColor:
+    | DOMString
+    | null
+    | undefined = props.element.getAttribute('placeholderTextColor');
+  if ([undefined, null, ''].includes(value) && placeholderTextColor) {
+    style.push({ color: placeholderTextColor });
   }
-}
+
+  // Gets all of the <picker-item> elements. All picker item elements
+  // with a value and label are turned into options for the picker.
+  const children = getPickerItems()
+    .filter(Boolean)
+    .map((item: Element) => {
+      const l: DOMString | null | undefined = item.getAttribute('label');
+      const v: DOMString | null | undefined = item.getAttribute('value');
+      if (!l || typeof v !== 'string') {
+        return null;
+      }
+      return <Picker.Item key={l + v} label={l} value={v} />;
+    });
+
+  const focused = isFocused();
+
+  return (
+    <Field
+      element={props.element}
+      focused={focused}
+      onPress={onFieldPress}
+      options={props.options}
+      stylesheets={props.stylesheets}
+      value={getLabelForValue(getValue())}
+    >
+      {focused ? (
+        <Modal
+          element={props.element}
+          focused={focused}
+          onModalCancel={onCancel}
+          onModalDone={onDone}
+          onUpdate={props.onUpdate}
+          options={props.options}
+          stylesheets={props.stylesheets}
+        >
+          <View accessibilityLabel={accessibilityLabel} testID={testID}>
+            <Picker
+              onValueChange={setPickerValue}
+              selectedValue={getPickerValue()}
+              style={style}
+            >
+              {children}
+            </Picker>
+          </View>
+        </Modal>
+      ) : null}
+    </Field>
+  );
+};
+
+HvPickerField.namespaceURI = Namespaces.HYPERVIEW;
+HvPickerField.localName = LOCAL_NAME.PICKER_FIELD;
+HvPickerField.getFormInputValues = getNameValueFormInputValues;
+
+export default HvPickerField;

--- a/src/components/hv-picker-field/index.ios.tsx
+++ b/src/components/hv-picker-field/index.ios.tsx
@@ -5,6 +5,7 @@ import type {
   HvComponentProps,
   StyleSheet,
 } from 'hyperview/src/types';
+import React, { useMemo } from 'react';
 import {
   createStyleProp,
   createTestProps,
@@ -14,7 +15,6 @@ import Field from './field';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import Modal from 'hyperview/src/core/components/modal';
 import Picker from 'hyperview/src/core/components/picker';
-import React from 'react';
 import { View } from 'react-native';
 
 /**
@@ -140,13 +140,13 @@ const HvPickerField = (props: HvComponentProps) => {
   const isFocused = (): boolean =>
     props.element.getAttribute('focused') === 'true';
 
-  const style: Array<StyleSheet> = createStyleProp(
-    props.element,
-    props.stylesheets,
-    {
-      ...props.options,
-      styleAttr: 'field-text-style',
-    },
+  const style: Array<StyleSheet> = useMemo(
+    () =>
+      createStyleProp(props.element, props.stylesheets, {
+        ...props.options,
+        styleAttr: 'field-text-style',
+      }),
+    [props.element, props.stylesheets, props.options],
   );
   const { testID, accessibilityLabel } = createTestProps(props.element);
   const value: DOMString | null | undefined = props.element.getAttribute(

--- a/src/components/hv-picker-field/index.tsx
+++ b/src/components/hv-picker-field/index.tsx
@@ -5,7 +5,6 @@ import type {
   HvComponentProps,
   StyleSheet,
 } from 'hyperview/src/types';
-import React, { PureComponent } from 'react';
 import {
   createStyleProp,
   createTestProps,
@@ -13,6 +12,7 @@ import {
 } from 'hyperview/src/services';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import Picker from 'hyperview/src/core/components/picker';
+import React from 'react';
 import { View } from 'react-native';
 
 /**
@@ -21,168 +21,164 @@ import { View } from 'react-native';
  * - On Android, the system picker is rendered inline on the screen. Pressing the picker
  *   opens a system dialog.
  */
-export default class HvPickerField extends PureComponent<HvComponentProps> {
-  static namespaceURI = Namespaces.HYPERVIEW;
-
-  static localName = LOCAL_NAME.PICKER_FIELD;
-
-  static getFormInputValues = (element: Element): Array<[string, string]> => {
-    return getNameValueFormInputValues(element);
-  };
-
+const HvPickerField = (props: HvComponentProps) => {
   /**
    * Returns a string representing the value in the field.
    */
-  getValue = (): string => this.props.element.getAttribute('value') || '';
+  const getValue = (): string => props.element.getAttribute('value') || '';
 
   /**
    * Returns a string representing the value in the picker.
    */
-  getPickerValue = (): string => this.props.element.getAttribute('value') || '';
+  const getPickerValue = (): string =>
+    props.element.getAttribute('value') || '';
 
-  getPickerItems = (): Element[] =>
+  const getPickerItems = (): Element[] =>
     Array.from(
-      this.props.element.getElementsByTagNameNS(
+      props.element.getElementsByTagNameNS(
         Namespaces.HYPERVIEW,
         LOCAL_NAME.PICKER_ITEM,
       ),
     );
 
-  onFocus = () => {
-    const newElement = this.props.element.cloneNode(true) as Element;
+  const onFocus = () => {
+    const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'true');
-    this.props.onUpdate(null, 'swap', this.props.element, { newElement });
-    Behaviors.trigger('focus', newElement, this.props.onUpdate);
+    props.onUpdate(null, 'swap', props.element, { newElement });
+    Behaviors.trigger('focus', newElement, props.onUpdate);
   };
 
-  onBlur = () => {
-    const newElement = this.props.element.cloneNode(true) as Element;
+  const onBlur = () => {
+    const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'false');
-    this.props.onUpdate(null, 'swap', this.props.element, { newElement });
-    Behaviors.trigger('blur', newElement, this.props.onUpdate);
+    props.onUpdate(null, 'swap', props.element, { newElement });
+    Behaviors.trigger('blur', newElement, props.onUpdate);
   };
 
   /**
    * Hides the picker without applying the chosen value.
    */
-  onCancel = () => {
-    const newElement = this.props.element.cloneNode(true) as Element;
+  const onCancel = () => {
+    const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'false');
     newElement.removeAttribute('picker-value');
-    this.props.onUpdate(null, 'swap', this.props.element, { newElement });
+    props.onUpdate(null, 'swap', props.element, { newElement });
   };
 
   /**
    * Hides the picker and applies the chosen value to the field.
    */
-  onDone = (newValue?: string) => {
-    const pickerValue =
-      newValue !== undefined ? newValue : this.getPickerValue();
-    const value = this.getValue();
-    const newElement = this.props.element.cloneNode(true) as Element;
+  const onDone = (newValue?: string) => {
+    const pickerValue = newValue !== undefined ? newValue : getPickerValue();
+    const value = getValue();
+    const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('value', pickerValue);
     newElement.removeAttribute('picker-value');
     newElement.setAttribute('focused', 'false');
-    this.props.onUpdate(null, 'swap', this.props.element, { newElement });
+    props.onUpdate(null, 'swap', props.element, { newElement });
 
     const hasChanged = value !== pickerValue;
     if (hasChanged) {
-      Behaviors.trigger('change', newElement, this.props.onUpdate);
+      Behaviors.trigger('change', newElement, props.onUpdate);
     }
   };
 
-  render() {
-    const onChange = (value: string | null | undefined) => {
-      if (value === undefined) {
-        this.onCancel();
-      } else {
-        this.onDone(value || '');
-      }
-    };
-
-    const style: Array<StyleSheet> = createStyleProp(
-      this.props.element,
-      this.props.stylesheets,
-      {
-        ...this.props.options,
-        styleAttr: 'field-text-style',
-      },
-    );
-    const { testID, accessibilityLabel } = createTestProps(this.props.element);
-    const value: DOMString | null | undefined = this.props.element.getAttribute(
-      'value',
-    );
-    const placeholderTextColor:
-      | DOMString
-      | null
-      | undefined = this.props.element.getAttribute('placeholderTextColor');
-    if ([undefined, null, ''].includes(value) && placeholderTextColor) {
-      style.push({ color: placeholderTextColor });
+  const onChange = (value: string | null | undefined) => {
+    if (value === undefined) {
+      onCancel();
+    } else {
+      onDone(value || '');
     }
+  };
 
-    const fieldStyle: Array<StyleSheet> = createStyleProp(
-      this.props.element,
-      this.props.stylesheets,
-      {
-        ...this.props.options,
-        styleAttr: 'field-style',
-      },
-    );
+  const style: Array<StyleSheet> = createStyleProp(
+    props.element,
+    props.stylesheets,
+    {
+      ...props.options,
+      styleAttr: 'field-text-style',
+    },
+  );
+  const { testID, accessibilityLabel } = createTestProps(props.element);
+  const value: DOMString | null | undefined = props.element.getAttribute(
+    'value',
+  );
+  const placeholderTextColor:
+    | DOMString
+    | null
+    | undefined = props.element.getAttribute('placeholderTextColor');
+  if ([undefined, null, ''].includes(value) && placeholderTextColor) {
+    style.push({ color: placeholderTextColor });
+  }
 
-    // Gets all of the <picker-item> elements. All picker item elements
-    // with a value and label are turned into options for the picker.
-    const items = this.getPickerItems();
-    const children = items.filter(Boolean).map((item: Element) => {
-      const l: DOMString | null | undefined = item.getAttribute('label');
-      const v: DOMString | null | undefined = item.getAttribute('value');
-      if (!l || typeof v !== 'string') {
-        return null;
-      }
-      const enabled = ['', 'true', null].includes(item.getAttribute('enabled'));
-      return (
-        <Picker.Item
-          key={l + v}
-          enabled={enabled}
-          label={l}
-          style={{ fontSize: 16 }}
-          value={v}
-        />
-      );
-    });
+  const fieldStyle: Array<StyleSheet> = createStyleProp(
+    props.element,
+    props.stylesheets,
+    {
+      ...props.options,
+      styleAttr: 'field-style',
+    },
+  );
 
-    // If there are no items, or the first item has a value,
-    // we need to add an empty option that acts as a placeholder.
-    if (items.length > 0 && items[0].getAttribute('value') !== '') {
-      children.unshift(
-        <Picker.Item
-          key="empty"
-          // eslint-disable-next-line max-len
-          // `enabled` needs to be true when the field is not focused, otherwise the the field will not be selectable
-          // fix inspired by https://github.com/react-native-picker/picker/issues/95#issuecomment-935718568
-          enabled={this.props.element.getAttribute('focused') !== 'true'}
-          label={this.props.element.getAttribute('placeholder') || undefined}
-          style={{ fontSize: 16 }}
-          value=""
-        />,
-      );
+  // Gets all of the <picker-item> elements. All picker item elements
+  // with a value and label are turned into options for the picker.
+  const items = getPickerItems();
+  const children = items.filter(Boolean).map((item: Element) => {
+    const l: DOMString | null | undefined = item.getAttribute('label');
+    const v: DOMString | null | undefined = item.getAttribute('value');
+    if (!l || typeof v !== 'string') {
+      return null;
     }
-
+    const enabled = ['', 'true', null].includes(item.getAttribute('enabled'));
     return (
-      <View
-        accessibilityLabel={accessibilityLabel}
-        style={fieldStyle}
-        testID={testID}
-      >
-        <Picker
-          onBlur={this.onBlur}
-          onFocus={this.onFocus}
-          onValueChange={onChange}
-          selectedValue={this.getPickerValue()}
-          style={style}
-        >
-          {children}
-        </Picker>
-      </View>
+      <Picker.Item
+        key={l + v}
+        enabled={enabled}
+        label={l}
+        style={{ fontSize: 16 }}
+        value={v}
+      />
+    );
+  });
+
+  // If there are no items, or the first item has a value,
+  // we need to add an empty option that acts as a placeholder.
+  if (items.length > 0 && items[0].getAttribute('value') !== '') {
+    children.unshift(
+      <Picker.Item
+        key="empty"
+        // eslint-disable-next-line max-len
+        // `enabled` needs to be true when the field is not focused, otherwise the the field will not be selectable
+        // fix inspired by https://github.com/react-native-picker/picker/issues/95#issuecomment-935718568
+        enabled={props.element.getAttribute('focused') !== 'true'}
+        label={props.element.getAttribute('placeholder') || undefined}
+        style={{ fontSize: 16 }}
+        value=""
+      />,
     );
   }
-}
+
+  return (
+    <View
+      accessibilityLabel={accessibilityLabel}
+      style={fieldStyle}
+      testID={testID}
+    >
+      <Picker
+        onBlur={onBlur}
+        onFocus={onFocus}
+        onValueChange={onChange}
+        selectedValue={getPickerValue()}
+        style={style}
+      >
+        {children}
+      </Picker>
+    </View>
+  );
+};
+
+HvPickerField.namespaceURI = Namespaces.HYPERVIEW;
+HvPickerField.localName = LOCAL_NAME.PICKER_FIELD;
+HvPickerField.getFormInputValues = getNameValueFormInputValues;
+
+export default HvPickerField;

--- a/src/components/hv-picker-field/index.tsx
+++ b/src/components/hv-picker-field/index.tsx
@@ -5,6 +5,7 @@ import type {
   HvComponentProps,
   StyleSheet,
 } from 'hyperview/src/types';
+import React, { useMemo } from 'react';
 import {
   createStyleProp,
   createTestProps,
@@ -12,7 +13,6 @@ import {
 } from 'hyperview/src/services';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import Picker from 'hyperview/src/core/components/picker';
-import React from 'react';
 import { View } from 'react-native';
 
 /**
@@ -91,13 +91,13 @@ const HvPickerField = (props: HvComponentProps) => {
     }
   };
 
-  const style: Array<StyleSheet> = createStyleProp(
-    props.element,
-    props.stylesheets,
-    {
-      ...props.options,
-      styleAttr: 'field-text-style',
-    },
+  const style: Array<StyleSheet> = useMemo(
+    () =>
+      createStyleProp(props.element, props.stylesheets, {
+        ...props.options,
+        styleAttr: 'field-text-style',
+      }),
+    [props.element, props.stylesheets, props.options],
   );
   const { testID, accessibilityLabel } = createTestProps(props.element);
   const value: DOMString | null | undefined = props.element.getAttribute(
@@ -111,13 +111,13 @@ const HvPickerField = (props: HvComponentProps) => {
     style.push({ color: placeholderTextColor });
   }
 
-  const fieldStyle: Array<StyleSheet> = createStyleProp(
-    props.element,
-    props.stylesheets,
-    {
-      ...props.options,
-      styleAttr: 'field-style',
-    },
+  const fieldStyle: Array<StyleSheet> = useMemo(
+    () =>
+      createStyleProp(props.element, props.stylesheets, {
+        ...props.options,
+        styleAttr: 'field-style',
+      }),
+    [props.element, props.stylesheets, props.options],
   );
 
   // Gets all of the <picker-item> elements. All picker item elements

--- a/src/components/hv-switch/index.ts
+++ b/src/components/hv-switch/index.ts
@@ -1,7 +1,6 @@
 import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import { Platform, StyleSheet, Switch } from 'react-native';
-import React, { PureComponent } from 'react';
 import {
   createStyleProp,
   getNameValueFormInputValues,
@@ -9,6 +8,7 @@ import {
 import type { ColorValue } from './style-sheet';
 import type { HvComponentProps } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
+import React from 'react';
 import normalizeColor from './style-sheet';
 
 /* eslint no-bitwise: ["error", { "allow": [">>", "&"] }] */
@@ -31,72 +31,62 @@ function darkenColor(color: ColorValue, percent: number): ColorValue {
   return `#${newRgb}${A}`;
 }
 
-export default class HvSwitch extends PureComponent<HvComponentProps> {
-  static namespaceURI = Namespaces.HYPERVIEW;
+const HvSwitch = (props: HvComponentProps) => {
+  if (props.element.getAttribute('hide') === 'true') {
+    return null;
+  }
 
-  static localName = LOCAL_NAME.SWITCH;
+  const unselectedStyle = StyleSheet.flatten(
+    createStyleProp(props.element, props.stylesheets, {
+      selected: false,
+    }),
+  );
+  const selectedStyle = StyleSheet.flatten(
+    createStyleProp(props.element, props.stylesheets, {
+      selected: true,
+    }),
+  );
 
-  static getFormInputValues = (element: Element): Array<[string, string]> => {
-    return getNameValueFormInputValues(element);
+  const p = {
+    ios_backgroundColor: unselectedStyle
+      ? unselectedStyle.backgroundColor
+      : null,
+    onChange: () => {
+      const newElement = props.element.cloneNode(true) as Element;
+      Behaviors.trigger('change', newElement, props.onUpdate);
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onValueChange: (value: any) => {
+      const newElement = props.element.cloneNode(true) as Element;
+      newElement.setAttribute('value', value ? 'on' : 'off');
+      props.onUpdate(null, 'swap', props.element, { newElement });
+    },
+    // iOS thumbColor default
+    thumbColor: unselectedStyle?.color || selectedStyle?.color,
+    trackColor: {
+      false: unselectedStyle ? unselectedStyle.backgroundColor : null,
+      true: selectedStyle ? selectedStyle.backgroundColor : null,
+    },
+    value: props.element.getAttribute('value') === 'on',
   };
 
-  render() {
-    if (this.props.element.getAttribute('hide') === 'true') {
-      return null;
-    }
-
-    const unselectedStyle = StyleSheet.flatten(
-      createStyleProp(this.props.element, this.props.stylesheets, {
-        selected: false,
-      }),
-    );
-    const selectedStyle = StyleSheet.flatten(
-      createStyleProp(this.props.element, this.props.stylesheets, {
-        selected: true,
-      }),
-    );
-
-    const props = {
-      ios_backgroundColor: unselectedStyle
-        ? unselectedStyle.backgroundColor
-        : null,
-      onChange: () => {
-        const newElement = this.props.element.cloneNode(true) as Element;
-        Behaviors.trigger('change', newElement, this.props.onUpdate);
-      },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      onValueChange: (value: any) => {
-        const newElement = this.props.element.cloneNode(true) as Element;
-        newElement.setAttribute('value', value ? 'on' : 'off');
-        this.props.onUpdate(null, 'swap', this.props.element, { newElement });
-      },
-      // iOS thumbColor default
-      thumbColor: unselectedStyle?.color || selectedStyle?.color,
-      trackColor: {
-        false: unselectedStyle ? unselectedStyle.backgroundColor : null,
-        true: selectedStyle ? selectedStyle.backgroundColor : null,
-      },
-      value: this.props.element.getAttribute('value') === 'on',
-    };
-
-    // android thumbColor default
-    if (
-      Platform.OS === 'android' &&
-      !props.thumbColor &&
-      props.trackColor.true
-    ) {
-      props.thumbColor = props.value
-        ? darkenColor(props.trackColor.true, 0.3)
-        : '#FFFFFF';
-    }
-
-    // if thumbColors are explicitly specified, override defaults
-    if (props.value && selectedStyle?.color) {
-      props.thumbColor = selectedStyle.color;
-    } else if (!props.value && unselectedStyle?.color) {
-      props.thumbColor = unselectedStyle.color;
-    }
-
-    return React.createElement(Switch, props);
+  // android thumbColor default
+  if (Platform.OS === 'android' && !p.thumbColor && p.trackColor.true) {
+    p.thumbColor = p.value ? darkenColor(p.trackColor.true, 0.3) : '#FFFFFF';
   }
-}
+
+  // if thumbColors are explicitly specified, override defaults
+  if (p.value && selectedStyle?.color) {
+    p.thumbColor = selectedStyle.color;
+  } else if (!p.value && unselectedStyle?.color) {
+    p.thumbColor = unselectedStyle.color;
+  }
+
+  return React.createElement(Switch, p);
+};
+
+HvSwitch.namespaceURI = Namespaces.HYPERVIEW;
+HvSwitch.localName = LOCAL_NAME.SWITCH;
+HvSwitch.getFormInputValues = getNameValueFormInputValues;
+
+export default HvSwitch;

--- a/src/components/hv-switch/index.ts
+++ b/src/components/hv-switch/index.ts
@@ -1,6 +1,7 @@
 import * as Behaviors from 'hyperview/src/services/behaviors';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import { Platform, StyleSheet, Switch } from 'react-native';
+import React, { useMemo } from 'react';
 import {
   createStyleProp,
   getNameValueFormInputValues,
@@ -8,7 +9,6 @@ import {
 import type { ColorValue } from './style-sheet';
 import type { HvComponentProps } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
-import React from 'react';
 import normalizeColor from './style-sheet';
 
 /* eslint no-bitwise: ["error", { "allow": [">>", "&"] }] */
@@ -32,20 +32,28 @@ function darkenColor(color: ColorValue, percent: number): ColorValue {
 }
 
 const HvSwitch = (props: HvComponentProps) => {
+  const unselectedStyle = useMemo(
+    () =>
+      StyleSheet.flatten(
+        createStyleProp(props.element, props.stylesheets, {
+          selected: false,
+        }),
+      ),
+    [props.element, props.stylesheets],
+  );
+  const selectedStyle = useMemo(
+    () =>
+      StyleSheet.flatten(
+        createStyleProp(props.element, props.stylesheets, {
+          selected: true,
+        }),
+      ),
+    [props.element, props.stylesheets],
+  );
+
   if (props.element.getAttribute('hide') === 'true') {
     return null;
   }
-
-  const unselectedStyle = StyleSheet.flatten(
-    createStyleProp(props.element, props.stylesheets, {
-      selected: false,
-    }),
-  );
-  const selectedStyle = StyleSheet.flatten(
-    createStyleProp(props.element, props.stylesheets, {
-      selected: true,
-    }),
-  );
 
   const p = {
     ios_backgroundColor: unselectedStyle

--- a/src/components/hv-view/index.tsx
+++ b/src/components/hv-view/index.tsx
@@ -41,6 +41,29 @@ const HvView = (props: HvComponentProps) => {
     );
   }, [props.element]);
 
+  // TODO: fix type
+  // createStyleProp returns an array of StyleSheet,
+  // but it appears something wants a ViewStyle, which is not
+  // not an array type. Does a type need to get fixed elsewhere?
+  const style = useMemo(
+    () =>
+      (createStyleProp(
+        props.element,
+        props.stylesheets,
+        props.options,
+      ) as unknown) as ViewStyle,
+    [props.element, props.stylesheets, props.options],
+  );
+
+  const containerStyle = useMemo(
+    () =>
+      createStyleProp(props.element, props.stylesheets, {
+        ...props.options,
+        styleAttr: ATTRIBUTES.CONTENT_CONTAINER_STYLE,
+      }),
+    [props.element, props.stylesheets, props.options],
+  );
+
   const checkHasInputFields = (): boolean => {
     const textFields = props.element.getElementsByTagNameNS(
       Namespaces.HYPERVIEW,
@@ -51,15 +74,6 @@ const HvView = (props: HvComponentProps) => {
   };
 
   const getCommonProps = (): CommonProps => {
-    // TODO: fix type
-    // createStyleProp returns an array of StyleSheet,
-    // but it appears something wants a ViewStyle, which is not
-    // not an array type. Does a type need to get fixed elsewhere?
-    const style = (createStyleProp(
-      props.element,
-      props.stylesheets,
-      props.options,
-    ) as unknown) as ViewStyle;
     const id = props.element.getAttribute('id');
     if (!id) {
       return { style };
@@ -79,10 +93,7 @@ const HvView = (props: HvComponentProps) => {
       attributes[ATTRIBUTES.SHOWS_SCROLL_INDICATOR] !== 'false';
 
     const contentContainerStyle = attributes[ATTRIBUTES.CONTENT_CONTAINER_STYLE]
-      ? createStyleProp(props.element, props.stylesheets, {
-          ...props.options,
-          styleAttr: ATTRIBUTES.CONTENT_CONTAINER_STYLE,
-        })
+      ? containerStyle
       : undefined;
 
     // Fix scrollbar rendering issue in iOS 13+

--- a/src/core/components/modal/index.tsx
+++ b/src/core/components/modal/index.tsx
@@ -5,7 +5,7 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import ModalButton from './modal-button';
 import Overlay from './overlay';
 import type { Props } from './types';
@@ -30,24 +30,28 @@ export default (props: Props): JSX.Element => {
   const overlayOpacity = useRef(new Animated.Value(0)).current;
   const contentOpacity = useRef(new Animated.Value(0)).current;
 
-  const style: Array<StyleSheetType> = createStyleProp(
-    props.element,
-    props.stylesheets,
-    {
-      ...props.options,
-      styleAttr: 'modal-style',
-    },
+  const style: Array<StyleSheetType> = useMemo(
+    () =>
+      createStyleProp(props.element, props.stylesheets, {
+        ...props.options,
+        styleAttr: 'modal-style',
+      }),
+    [props.element, props.stylesheets, props.options],
   );
 
   const cancelLabel: string =
     props.element.getAttribute('cancel-label') || 'Cancel';
   const doneLabel: string = props.element.getAttribute('done-label') || 'Done';
 
-  const overlayStyle = StyleSheet.flatten(
-    createStyleProp(props.element, props.stylesheets, {
-      ...props.options,
-      styleAttr: 'modal-overlay-style',
-    }),
+  const overlayStyle = useMemo(
+    () =>
+      StyleSheet.flatten(
+        createStyleProp(props.element, props.stylesheets, {
+          ...props.options,
+          styleAttr: 'modal-overlay-style',
+        }),
+      ),
+    [props.element, props.stylesheets, props.options],
   );
 
   const onLayout = (event: LayoutChangeEvent) => {

--- a/src/core/components/modal/modal-button/index.tsx
+++ b/src/core/components/modal/modal-button/index.tsx
@@ -1,5 +1,5 @@
 import * as FontScale from 'hyperview/src/services/font-scale';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Text, TouchableWithoutFeedback, View } from 'react-native';
 import type { Props } from './types';
 import type { StyleSheet } from 'hyperview/src/types';
@@ -11,14 +11,14 @@ import { createStyleProp } from 'hyperview/src/services';
 export default (props: Props) => {
   const [pressed, setPressed] = useState(false);
 
-  const style: Array<StyleSheet> = createStyleProp(
-    props.element,
-    props.stylesheets,
-    {
-      ...props.options,
-      pressed,
-      styleAttr: 'modal-text-style',
-    },
+  const style: Array<StyleSheet> = useMemo(
+    () =>
+      createStyleProp(props.element, props.stylesheets, {
+        ...props.options,
+        pressed,
+        styleAttr: 'modal-text-style',
+      }),
+    [props.element, props.stylesheets, props.options, pressed],
   );
 
   return (


### PR DESCRIPTION
To improve performance and reduce re-renders, memoize the styles created by ``. This required converting several class components to functional.

- [Migrate from class to functional components](https://github.com/Instawork/hyperview/commit/71e9dc0bf7674dbdb5b5ceb6bd60206922e9162f)
- [Memoize style creation](https://github.com/Instawork/hyperview/commit/0469bc4a0a0b482cc54790b7ab44e5c08921d3ca)

[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1210344460236267?focus=true)