### PR TITLE
chore(render): resolve missing view elements

### DIFF
--- a/src/components/hv-view/index.tsx
+++ b/src/components/hv-view/index.tsx
@@ -173,8 +173,9 @@ export default class HvView extends PureComponent<HvComponentProps> {
       }
     }
 
-    const children = Render.buildChildArray(
+    const children = Render.renderChildren(
       this.props.element,
+      this.props.stylesheets,
       this.props.onUpdate,
       {
         ...this.props.options,
@@ -188,7 +189,6 @@ export default class HvView extends PureComponent<HvComponentProps> {
             }
           : {}),
       },
-      this.props.stylesheets,
     );
 
     /* eslint-disable react/jsx-props-no-spreading */


### PR DESCRIPTION
The `buildChildArray` method includes an `hv-element` for each child node regardless of type. The legacy rendering in `hv-view` was having trouble rendering this properly.

Reverting for now.

Relates to https://github.com/Instawork/hyperview/pull/1176
Relates to [Asana](https://app.asana.com/1/47184964732898/project/1205761271270033/task/1210424257505845?focus=true)