### PR TITLE
chore(behavior): warn for invalid update behavior

### DIFF
--- a/demo/backend/advanced/case-studies/basic-forms/index.xml.njk
+++ b/demo/backend/advanced/case-studies/basic-forms/index.xml.njk
@@ -22,6 +22,7 @@ hv_button_behavior: "back"
       />
     </view>
     <text
+      id="basic-forms-submit"
       action="replace"
       delay="500"
       href="/hyperview/public/advanced/case-studies/basic-forms/submit.xml"

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -27,6 +27,7 @@ import {
 import React, { PureComponent } from 'react';
 import HvRoute from 'hyperview/src/core/components/hv-route';
 import { Linking } from 'react-native';
+import { XMLSerializer } from '@instawork/xmldom';
 import { XNetworkRetryAction } from 'hyperview/src/services/dom/types';
 
 /**
@@ -488,8 +489,19 @@ export default class Hyperview extends PureComponent<Types.Props> {
         onUpdateCallbacks.getDoc(),
         behaviorElement,
       );
+
       if (targetElement) {
         Services.setTimeoutId(targetElement, timeoutId.toString());
+      } else {
+        // Warn developers if the behavior element is not found
+        Logging.error(
+          `Cannot find a behavior element to perform "${action}". It may be missing an id.`,
+          Logging.deferredToString(() => {
+            return new XMLSerializer().serializeToString(
+              behaviorElement as Element,
+            );
+          }),
+        );
       }
     } else {
       // If there's no delay, fetch immediately and update the doc when done.


### PR DESCRIPTION
Performing an update action (append, prepend, replace, replace-inner) with a delay requires that the behavior element has an id. The `basic-forms` demo was missing an id so was non functional.

- Added an error to warn developers of this condition
- Fixed the demo by adding an id to the element

| Before | Error | After |
| -- | -- | -- |
| ![before](https://github.com/user-attachments/assets/dfa1fded-0d8d-47a7-846e-def4b7e573fe) | ![error](https://github.com/user-attachments/assets/66e2d97e-64cf-4bae-8c03-02ba9b2700bf) | ![after](https://github.com/user-attachments/assets/c349dacd-ac16-410b-8682-3d1b3e4c02a6) |

[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1210535376481469?focus=true)