### PR TITLE
chore(section-list): use FlatList for SectionList

### DIFF
--- a/demo/backend/advanced/case-studies/basic-forms/index.xml.njk
+++ b/demo/backend/advanced/case-studies/basic-forms/index.xml.njk
@@ -22,6 +22,7 @@ hv_button_behavior: "back"
       />
     </view>
     <text
+      id="basic-forms-submit"
       action="replace"
       delay="500"
       href="/hyperview/public/advanced/case-studies/basic-forms/submit.xml"

--- a/demo/backend/advanced/case-studies/scroll-to-input/_styles.xml.njk
+++ b/demo/backend/advanced/case-studies/scroll-to-input/_styles.xml.njk
@@ -1,0 +1,54 @@
+<style
+  id="form-group"
+  flex="1"
+  marginLeft="24"
+  marginRight="24"
+  marginTop="24"
+/>
+<style
+  id="input"
+  borderBottomColor="#E1E1E1"
+  borderBottomWidth="1"
+  borderColor="#4E4D4D"
+  flex="1"
+  fontSize="16"
+  fontWeight="normal"
+  paddingBottom="8"
+  paddingTop="8"
+>
+  <modifier focused="true">
+  <style borderBottomColor="#4778FF" />
+  </modifier>
+</style>
+<style id="input-error" borderBottomColor="#FF4847" color="#FF4847">
+  <modifier focused="true">
+  <style borderBottomColor="#FF4847" />
+  </modifier>
+</style>
+<style
+  id="label"
+  borderColor="#4E4D4D"
+  fontSize="16"
+  fontWeight="bold"
+  lineHeight="24"
+  marginBottom="8"
+/>
+<style
+  id="help"
+  borderColor="#FF4847"
+  fontSize="16"
+  fontWeight="normal"
+  lineHeight="24"
+  marginTop="16"
+/>
+<style id="help-error" color="#FF4847" />
+<style
+  id="submit"
+  color="#4778FF"
+  fontSize="16"
+  fontWeight="bold"
+  lineHeight="24"
+  marginLeft="24"
+  marginTop="16"
+/>
+<style id="spacer" height="200" />

--- a/demo/backend/advanced/case-studies/scroll-to-input/index.xml.njk
+++ b/demo/backend/advanced/case-studies/scroll-to-input/index.xml.njk
@@ -1,0 +1,44 @@
+---
+permalink: "/advanced/case-studies/scroll-to-input/index.xml"
+tags: "Advanced/Case Studies"
+hv_title: "Scroll to Input Offset"
+hv_button_behavior: "back"
+---
+{% extends 'templates/base.xml.njk' %}
+{% from 'macros/description/index.xml.njk' import description %}
+
+{% block styles %}
+  {% include './_styles.xml.njk' %}
+{% endblock %}
+
+{% block container %}
+  <form id="myScrollForm" scroll="true" scroll-to-input-offset="450">
+    {{ description('Scroll to input offset is a property that can be used to scroll to an input field when it is focused.') }}
+    <view style="spacer" />
+    <view style="spacer" />
+    <view style="form-group">
+      <text style="label">Label line</text>
+      <text-field
+        name="data"
+        placeholder="Placeholder"
+        placeholderTextColor="#8D9494"
+        style="input"
+      />
+    </view>
+    <text
+      action="replace"
+      href="/hyperview/public/advanced/case-studies/scroll-to-input/submit.xml"
+      show-during-load="mySpinner"
+      style="submit"
+      target="myScrollForm"
+    >
+      Submit
+    </text>
+    <view style="spacer" />
+    <view style="spacer" />
+    <view style="spacer" />
+    <view style="spacer" />
+    {{ description('Bottom of the form') }}
+  </form>
+  <spinner id="mySpinner" hide="true" />
+{% endblock %}

--- a/demo/backend/advanced/case-studies/scroll-to-input/submit.xml
+++ b/demo/backend/advanced/case-studies/scroll-to-input/submit.xml
@@ -1,0 +1,18 @@
+<form
+  id="myScrollForm"
+  scroll="true"
+  xmlns="https://hyperview.org/hyperview"
+  scroll-to-input-offset="512"
+>
+  <view style="form-group">
+    <text style="label">Label line</text>
+    <text-field
+      name="data"
+      placeholder="Placeholder"
+      placeholderTextColor="#8D9494"
+      style="input"
+      value=""
+    />
+  </view>
+  <text style="submit">Saved!</text>
+</form>

--- a/demo/backend/ui/ui-elements/forms/text-field/index.xml.njk
+++ b/demo/backend/ui/ui-elements/forms/text-field/index.xml.njk
@@ -23,6 +23,6 @@ hv_button_behavior: "back"
 {% endblock %}
 
 {% block content %}
-  {{ about('Text field are used in forms to collect textual data') }}
+  {{ about('Text fields are used in forms to collect textual data') }}
   {% include './_form.xml.njk' %}
 {% endblock %}

--- a/demo/src/Behaviors/AddStyles/AddStyles.ts
+++ b/demo/src/Behaviors/AddStyles/AddStyles.ts
@@ -11,6 +11,44 @@ import {
 } from 'hyperview/src/services';
 
 /**
+ * Checks if a style element has changed by comparing its attributes and children
+ */
+const hasStyleChanged = (oldStyle: Element, newStyle: Element): boolean => {
+  // Compare attributes
+  const oldAttrs = oldStyle.attributes ? Array.from(oldStyle.attributes) : [];
+  const newAttrs = newStyle.attributes ? Array.from(newStyle.attributes) : [];
+
+  if (oldAttrs.length !== newAttrs.length) {
+    return true;
+  }
+
+  // Check if any attribute values differ
+  const hasAttrChanged = newAttrs.some(
+    newAttr => oldStyle.getAttribute(newAttr.name) !== newAttr.value,
+  );
+  if (hasAttrChanged) {
+    return true;
+  }
+
+  // Compare children recursively
+  const oldChildren = oldStyle.childNodes
+    ? Array.from(oldStyle.childNodes)
+    : [];
+  const newChildren = newStyle.childNodes
+    ? Array.from(newStyle.childNodes)
+    : [];
+
+  if (oldChildren.length !== newChildren.length) {
+    return true;
+  }
+
+  // Check if any child elements differ
+  return newChildren.some((newChild, index) =>
+    hasStyleChanged(oldChildren[index] as Element, newChild as Element),
+  );
+};
+
+/**
  * This behavior allows injecting styles into the screen's styles element.
  * It is useful when loading partial Hyperview documents that need their own styles.
  * Usage:
@@ -33,17 +71,41 @@ export const AddStyles: HvBehavior = {
       if (newStyles) {
         const screen = getAncestorByTagName(element, 'screen');
         if (screen) {
-          const styles = Dom.getFirstTag(screen, 'styles');
-          const styleElements = newStyles.getElementsByTagName('style');
+          const styles: Element | null | undefined = Dom.getFirstTag(
+            screen,
+            'styles',
+          );
+          const styleElements = Array.from(
+            newStyles.getElementsByTagName('style'),
+          ).filter(e => !!e.getAttribute('id'));
           if (styles && styleElements) {
-            Array.from(styleElements).forEach(style => {
-              styles.appendChild(style);
+            const existingStyles = Array.from(
+              styles.getElementsByTagName('style') || [],
+            );
+            let hasChanges = false;
+            styleElements.forEach(style => {
+              const styleId = style.getAttribute('id');
+              const existingStyle = existingStyles.find(
+                e => e.getAttribute('id') === styleId,
+              );
+              if (!existingStyle) {
+                styles.appendChild(style);
+                hasChanges = true;
+              } else if (style && hasStyleChanged(existingStyle, style)) {
+                styles.replaceChild(style, existingStyle);
+                hasChanges = true;
+              }
             });
-            const newRoot = shallowCloneToRoot(styles);
-            updateRoot(newRoot, true);
+
+            if (hasChanges) {
+              // Only perform cloning if styles have changed
+              const newRoot: Document = shallowCloneToRoot(styles);
+              updateRoot(newRoot, true);
+            }
           }
         }
       }
+
       const ranOnce = element.getAttribute('ran-once');
       const once = element.getAttribute('once');
       if (once === 'true') {

--- a/docs/reference_view.md
+++ b/docs/reference_view.md
@@ -111,9 +111,9 @@ An attribute indicating the direction in which the view will scroll.
 
 #### `scroll-to-input-offset`
 
-| Type   | Required                |
-| ------ | ----------------------- |
-| number | No (defauls to **120**) |
+| Type   | Required                 |
+| ------ | ------------------------ |
+| number | No (defaults to **120**) |
 
 An attribute defining an additional scroll offset to be applied to the view, when a `<text-field>` is focused. Only valid in combination with attribute `scroll` set to `"true"`.
 

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -456,6 +456,7 @@
     <xs:attribute name="safe-area" type="xs:boolean" />
     <xs:attribute name="value" type="xs:string" />
     <xs:attribute name="sticky" type="xs:boolean" />
+    <xs:attribute name="scroll-to-input-offset" type="xs:nonNegativeInteger" />
     <xs:attributeGroup ref="hv:behaviorAttributes" />
     <xs:attributeGroup ref="hv:scrollAttributes" />
   </xs:attributeGroup>

--- a/src/components/hv-section-list/index.tsx
+++ b/src/components/hv-section-list/index.tsx
@@ -36,6 +36,10 @@ export default class HvSectionList extends PureComponent<
 
   parser: DOMParser = new DOMParser();
 
+  startTime: number = Date.now();
+
+  renderCount: number = 0;
+
   ref: ElementRef<typeof FlatList> | null = null;
 
   state: State = {
@@ -201,6 +205,7 @@ export default class HvSectionList extends PureComponent<
   };
 
   render() {
+    this.renderCount += 1;
     const styleAttr = this.props.element.getAttribute('style');
     const style = styleAttr
       ? styleAttr.split(' ').map(s => this.props.stylesheets.regular[s])
@@ -252,6 +257,13 @@ export default class HvSectionList extends PureComponent<
         : undefined;
 
     const { testID, accessibilityLabel } = createTestProps(this.props.element);
+
+    console.log(
+      '>> SectionList render time:',
+      Date.now() - this.startTime,
+      'render count:',
+      this.renderCount,
+    );
 
     return (
       <Contexts.RefreshControlComponentContext.Consumer>

--- a/src/components/hv-section-list/index.tsx
+++ b/src/components/hv-section-list/index.tsx
@@ -284,7 +284,11 @@ export default class HvSectionList extends PureComponent<
               removeClippedSubviews={false}
               renderItem={this.renderListItem}
               scrollIndicatorInsets={scrollIndicatorInsets}
-              stickyHeaderIndices={headerIndeces}
+              stickyHeaderIndices={
+                this.getStickySectionHeadersEnabled()
+                  ? headerIndeces
+                  : undefined
+              }
               style={style}
               testID={testID}
             />

--- a/src/components/hv-section-list/types.ts
+++ b/src/components/hv-section-list/types.ts
@@ -6,7 +6,6 @@ export type State = {
 export type ScrollParams = {
   animated?: boolean | undefined;
   index: number;
-  sectionIndex: number;
   viewOffset?: number;
   viewPosition?: number;
 };

--- a/src/components/hv-section-list/types.ts
+++ b/src/components/hv-section-list/types.ts
@@ -5,7 +5,7 @@ export type State = {
 // https://reactnative.dev/docs/sectionlist#scrolltolocation
 export type ScrollParams = {
   animated?: boolean | undefined;
-  itemIndex: number;
+  index: number;
   sectionIndex: number;
   viewOffset?: number;
   viewPosition?: number;

--- a/src/components/hv-view/index.tsx
+++ b/src/components/hv-view/index.tsx
@@ -137,7 +137,7 @@ export default class HvView extends PureComponent<HvComponentProps> {
     const offsetStr = this.attributes[ATTRIBUTES.SCROLL_TO_INPUT_OFFSET];
     if (offsetStr) {
       const offset = parseInt(offsetStr, 10);
-      return Number.isNaN(offset) ? 0 : defaultOffset;
+      return Number.isNaN(offset) ? defaultOffset : offset;
     }
     return defaultOffset;
   };

--- a/src/core/components/hv-root/index.tsx
+++ b/src/core/components/hv-root/index.tsx
@@ -27,6 +27,7 @@ import {
 import React, { PureComponent } from 'react';
 import HvRoute from 'hyperview/src/core/components/hv-route';
 import { Linking } from 'react-native';
+import { XMLSerializer } from '@instawork/xmldom';
 import { XNetworkRetryAction } from 'hyperview/src/services/dom/types';
 
 /**
@@ -488,8 +489,19 @@ export default class Hyperview extends PureComponent<Types.Props> {
         onUpdateCallbacks.getDoc(),
         behaviorElement,
       );
+
       if (targetElement) {
         Services.setTimeoutId(targetElement, timeoutId.toString());
+      } else {
+        // Warn developers if the behavior element is not found
+        Logging.error(
+          `Cannot find a behavior element to perform "${action}". It may be missing an id.`,
+          Logging.deferredToString(() => {
+            return new XMLSerializer().serializeToString(
+              behaviorElement as Element,
+            );
+          }),
+        );
       }
     } else {
       // If there's no delay, fetch immediately and update the doc when done.


### PR DESCRIPTION
Example of using a react-native `FlatList` in place of `SectionList` for our `hv-section-list` component.

All functionality is retained. Code was able to be simplified especially around the scrolling behaviors.

>This PR isn't necessarily for merging, just an example of what is possible with FlatList.

| Section List | Flat List |
| -- | -- |
| ![s-l-sticky](https://github.com/user-attachments/assets/dcce9a34-a454-40bc-8b57-f0828a71fc50) | ![f-l-sticky](https://github.com/user-attachments/assets/32e700e4-f2fe-4468-a467-71cdc2349d17) |
| ![s-l-scroll](https://github.com/user-attachments/assets/72abc980-20b2-44d0-acf2-850edba13184) | ![f-l-scroll](https://github.com/user-attachments/assets/ce71a3b2-6d0a-4813-b19a-bda871aed4fe) |


[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1210525847101749?focus=true)