### PR TITLE
chore: export required dependencies

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,61 @@
-/* eslint instawork/flow-annotate: 0 */
 import * as Events from 'hyperview/src/services/events';
+import * as Logging from 'hyperview/src/services/logging';
 import * as Namespaces from 'hyperview/src/services/namespaces';
-import Hyperview from './hyperview';
+import * as TestHelpers from 'hyperview/test/helpers';
 
-export * from 'hyperview/src/types';
-export { Events, Namespaces };
+/**
+ * Root component for Hyperview.
+ *
+ * @see https://hyperview.dev/docs/getting-started/installation
+ */
+export { default } from './hyperview';
+
+/**
+ * Types for Hyperview.
+ */
+export type {
+  DOMString,
+  ExperimentalFeatures,
+  HvBehavior,
+  HvComponent,
+  HvComponentProps,
+  HvComponentOnUpdate,
+  HvComponentOptions,
+  HvGetRoot,
+  HvUpdateRoot,
+  RouteParams,
+  RouteProps,
+  StyleSheet,
+  StyleSheets,
+} from 'hyperview/src/types';
+export { ACTIONS, LOCAL_NAME, NODE_TYPE } from 'hyperview/src/types';
+
+/**
+ * Core
+ *
+ * @see https://hyperview.dev/docs/getting-started/installation
+ */
+export { default as HvElement } from 'hyperview/src/core/components/hv-element';
 export { useScrollContext } from 'hyperview/src/core/components/scroll';
-export default Hyperview;
+export { createEventHandler } from 'hyperview/src/core/utils';
+
+/**
+ * Services
+ */
+export { Events, Logging, Namespaces, TestHelpers };
+export {
+  createProps,
+  createStyleProp,
+  getAncestorByTagName,
+  shallowCloneToRoot,
+} from 'hyperview/src/services';
+export {
+  Parser,
+  getBehaviorElements,
+  getFirstTag,
+} from 'hyperview/src/services/dom';
+export { HvBaseError } from 'hyperview/src/services/error';
+export type { NavigationComponents } from 'hyperview/src/services/navigator';
+export { renderChildren, renderElement } from 'hyperview/src/services/render';
+export { createStylesheets } from 'hyperview/src/services/stylesheets';
+export { getUrlFromHref } from 'hyperview/src/services/url';


### PR DESCRIPTION
Exposing the dependencies used by /demo and our mobile apps to avoid requiring reaching into modules.

Evaluated all uses of Hyperview from the demo app and the mobile codebase to check all imports and uses.

The `Events`, `Logging`, `Namespace` and `TestHelpers` are bulk exported to allow using their namespaces as before. Example: `Events.dispatch`. All others are individually exported. Example: ` Dom.getBehaviorElements()` would become `getBehaviorElements()`


[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1210571640157700?focus=true)