### PR TITLE
chore(picker-field): convert to Functional Component

### DIFF
--- a/src/elements/hv-picker-field/index.ios.tsx
+++ b/src/elements/hv-picker-field/index.ios.tsx
@@ -5,7 +5,6 @@ import type {
   HvComponentProps,
   StyleSheet,
 } from 'hyperview/src/types';
-import React, { PureComponent } from 'react';
 import {
   createStyleProp,
   createTestProps,
@@ -15,6 +14,7 @@ import Field from './field';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import Modal from 'hyperview/src/core/components/modal';
 import Picker from 'hyperview/src/core/components/picker';
+import React from 'react';
 import { View } from 'react-native';
 
 /**
@@ -23,18 +23,10 @@ import { View } from 'react-native';
  * - On Android, the system picker is rendered inline on the screen. Pressing the picker
  *   opens a system dialog.
  */
-export default class HvPickerField extends PureComponent<HvComponentProps> {
-  static namespaceURI = Namespaces.HYPERVIEW;
-
-  static localName = LOCAL_NAME.PICKER_FIELD;
-
-  static getFormInputValues = (element: Element): Array<[string, string]> => {
-    return getNameValueFormInputValues(element);
-  };
-
-  getPickerInitialValue = (): string => {
-    const value = this.getValue();
-    const pickerItems: Element[] = this.getPickerItems();
+const HvPickerField = (props: HvComponentProps) => {
+  const getPickerInitialValue = (): string => {
+    const value = getValue();
+    const pickerItems: Element[] = getPickerItems();
     const valueExists = pickerItems.some(
       item => item.getAttribute('value') === value,
     );
@@ -49,14 +41,14 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
   /**
    * Returns a string representing the value in the field.
    */
-  getValue = (): string => this.props.element.getAttribute('value') || '';
+  const getValue = (): string => props.element.getAttribute('value') || '';
 
   /**
    * Gets the label from the picker items for the given value.
    * If the value doesn't have a picker item, returns null.
    */
-  getLabelForValue = (value: DOMString): string | null | undefined => {
-    const pickerItemElements: HTMLCollectionOf<Element> = this.props.element.getElementsByTagNameNS(
+  const getLabelForValue = (value: DOMString): string | null | undefined => {
+    const pickerItemElements: HTMLCollectionOf<Element> = props.element.getElementsByTagNameNS(
       Namespaces.HYPERVIEW,
       LOCAL_NAME.PICKER_ITEM,
     );
@@ -81,12 +73,12 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
   /**
    * Returns a string representing the value in the picker.
    */
-  getPickerValue = (): string =>
-    this.props.element.getAttribute('picker-value') || '';
+  const getPickerValue = (): string =>
+    props.element.getAttribute('picker-value') || '';
 
-  getPickerItems = (): Element[] =>
+  const getPickerItems = (): Element[] =>
     Array.from(
-      this.props.element.getElementsByTagNameNS(
+      props.element.getElementsByTagNameNS(
         Namespaces.HYPERVIEW,
         LOCAL_NAME.PICKER_ITEM,
       ),
@@ -96,125 +88,127 @@ export default class HvPickerField extends PureComponent<HvComponentProps> {
    * Shows the picker, defaulting to the field's value.
    * If the field is not set, use the first value in the picker.
    */
-  onFieldPress = () => {
-    const newElement = this.props.element.cloneNode(true) as Element;
+  const onFieldPress = () => {
+    const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'true');
-    newElement.setAttribute('picker-value', this.getPickerInitialValue());
-    this.props.onUpdate(null, 'swap', this.props.element, { newElement });
-    Behaviors.trigger('focus', newElement, this.props.onUpdate);
+    newElement.setAttribute('picker-value', getPickerInitialValue());
+    props.onUpdate(null, 'swap', props.element, { newElement });
+    Behaviors.trigger('focus', newElement, props.onUpdate);
   };
 
   /**
    * Hides the picker without applying the chosen value.
    */
-  onCancel = () => {
-    const newElement = this.props.element.cloneNode(true) as Element;
+  const onCancel = () => {
+    const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'false');
     newElement.removeAttribute('picker-value');
-    this.props.onUpdate(null, 'swap', this.props.element, { newElement });
-    Behaviors.trigger('blur', newElement, this.props.onUpdate);
+    props.onUpdate(null, 'swap', props.element, { newElement });
+    Behaviors.trigger('blur', newElement, props.onUpdate);
   };
 
   /**
    * Hides the picker and applies the chosen value to the field.
    */
-  onDone = () => {
-    const pickerValue = this.getPickerValue();
-    const value = this.getValue();
-    const newElement = this.props.element.cloneNode(true) as Element;
+  const onDone = () => {
+    const pickerValue = getPickerValue();
+    const value = getValue();
+    const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('value', pickerValue);
     newElement.removeAttribute('picker-value');
     newElement.setAttribute('focused', 'false');
-    this.props.onUpdate(null, 'swap', this.props.element, { newElement });
+    props.onUpdate(null, 'swap', props.element, { newElement });
     const hasChanged = value !== pickerValue;
     if (hasChanged) {
-      Behaviors.trigger('change', newElement, this.props.onUpdate);
+      Behaviors.trigger('change', newElement, props.onUpdate);
     }
-    Behaviors.trigger('blur', newElement, this.props.onUpdate);
+    Behaviors.trigger('blur', newElement, props.onUpdate);
   };
 
   /**
    * Updates the picker value while keeping the picker open.
    */
-  setPickerValue = (value: string) => {
-    const newElement = this.props.element.cloneNode(true) as Element;
+  const setPickerValue = (value: string) => {
+    const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('picker-value', value);
-    this.props.onUpdate(null, 'swap', this.props.element, { newElement });
+    props.onUpdate(null, 'swap', props.element, { newElement });
   };
 
   /**
    * Returns true if the field is focused (and picker is showing).
    */
-  isFocused = (): boolean =>
-    this.props.element.getAttribute('focused') === 'true';
+  const isFocused = (): boolean =>
+    props.element.getAttribute('focused') === 'true';
 
-  render() {
-    const style: Array<StyleSheet> = createStyleProp(
-      this.props.element,
-      this.props.stylesheets,
-      {
-        ...this.props.options,
-        styleAttr: 'field-text-style',
-      },
-    );
-    const { testID, accessibilityLabel } = createTestProps(this.props.element);
-    const value: DOMString | null | undefined = this.props.element.getAttribute(
-      'value',
-    );
-    const placeholderTextColor:
-      | DOMString
-      | null
-      | undefined = this.props.element.getAttribute('placeholderTextColor');
-    if ([undefined, null, ''].includes(value) && placeholderTextColor) {
-      style.push({ color: placeholderTextColor });
-    }
-
-    // Gets all of the <picker-item> elements. All picker item elements
-    // with a value and label are turned into options for the picker.
-    const children = this.getPickerItems()
-      .filter(Boolean)
-      .map((item: Element) => {
-        const l: DOMString | null | undefined = item.getAttribute('label');
-        const v: DOMString | null | undefined = item.getAttribute('value');
-        if (!l || typeof v !== 'string') {
-          return null;
-        }
-        return <Picker.Item key={l + v} label={l} value={v} />;
-      });
-
-    const focused = this.props.element.getAttribute('focused') === 'true';
-
-    return (
-      <Field
-        element={this.props.element}
-        focused={focused}
-        onPress={this.onFieldPress}
-        options={this.props.options}
-        stylesheets={this.props.stylesheets}
-        value={this.getLabelForValue(this.getValue())}
-      >
-        {focused ? (
-          <Modal
-            element={this.props.element}
-            focused={focused}
-            onModalCancel={this.onCancel}
-            onModalDone={this.onDone}
-            onUpdate={this.props.onUpdate}
-            options={this.props.options}
-            stylesheets={this.props.stylesheets}
-          >
-            <View accessibilityLabel={accessibilityLabel} testID={testID}>
-              <Picker
-                onValueChange={this.setPickerValue}
-                selectedValue={this.getPickerValue()}
-                style={style}
-              >
-                {children}
-              </Picker>
-            </View>
-          </Modal>
-        ) : null}
-      </Field>
-    );
+  const style: Array<StyleSheet> = createStyleProp(
+    props.element,
+    props.stylesheets,
+    {
+      ...props.options,
+      styleAttr: 'field-text-style',
+    },
+  );
+  const { testID, accessibilityLabel } = createTestProps(props.element);
+  const value: DOMString | null | undefined = props.element.getAttribute(
+    'value',
+  );
+  const placeholderTextColor:
+    | DOMString
+    | null
+    | undefined = props.element.getAttribute('placeholderTextColor');
+  if ([undefined, null, ''].includes(value) && placeholderTextColor) {
+    style.push({ color: placeholderTextColor });
   }
-}
+
+  // Gets all of the <picker-item> elements. All picker item elements
+  // with a value and label are turned into options for the picker.
+  const children = getPickerItems()
+    .filter(Boolean)
+    .map((item: Element) => {
+      const l: DOMString | null | undefined = item.getAttribute('label');
+      const v: DOMString | null | undefined = item.getAttribute('value');
+      if (!l || typeof v !== 'string') {
+        return null;
+      }
+      return <Picker.Item key={l + v} label={l} value={v} />;
+    });
+
+  return (
+    <Field
+      element={props.element}
+      focused={isFocused()}
+      onPress={onFieldPress}
+      options={props.options}
+      stylesheets={props.stylesheets}
+      value={getLabelForValue(getValue())}
+    >
+      {isFocused() ? (
+        <Modal
+          element={props.element}
+          focused={isFocused()}
+          onModalCancel={onCancel}
+          onModalDone={onDone}
+          onUpdate={props.onUpdate}
+          options={props.options}
+          stylesheets={props.stylesheets}
+        >
+          <View accessibilityLabel={accessibilityLabel} testID={testID}>
+            <Picker
+              onValueChange={setPickerValue}
+              selectedValue={getPickerValue()}
+              style={style}
+            >
+              {children}
+            </Picker>
+          </View>
+        </Modal>
+      ) : null}
+    </Field>
+  );
+};
+
+HvPickerField.namespaceURI = Namespaces.HYPERVIEW;
+HvPickerField.localName = LOCAL_NAME.PICKER_FIELD;
+HvPickerField.getFormInputValues = getNameValueFormInputValues;
+
+export default HvPickerField;

--- a/src/elements/hv-picker-field/index.ios.tsx
+++ b/src/elements/hv-picker-field/index.ios.tsx
@@ -5,6 +5,7 @@ import type {
   HvComponentProps,
   StyleSheet,
 } from 'hyperview/src/types';
+import React, { useCallback } from 'react';
 import {
   createStyleProp,
   createTestProps,
@@ -14,7 +15,6 @@ import Field from './field';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import Modal from 'hyperview/src/core/components/modal';
 import Picker from 'hyperview/src/core/components/picker';
-import React from 'react';
 import { View } from 'react-native';
 
 /**
@@ -24,7 +24,29 @@ import { View } from 'react-native';
  *   opens a system dialog.
  */
 const HvPickerField = (props: HvComponentProps) => {
-  const getPickerInitialValue = (): string => {
+  // eslint-disable-next-line react/destructuring-assignment
+  const { element, onUpdate, options, stylesheets } = props;
+
+  /**
+   * Returns a string representing the value in the field.
+   */
+  const getValue = useCallback(
+    (): string => element.getAttribute('value') || '',
+    [element],
+  );
+
+  const getPickerItems = useCallback(
+    (): Element[] =>
+      Array.from(
+        element.getElementsByTagNameNS(
+          Namespaces.HYPERVIEW,
+          LOCAL_NAME.PICKER_ITEM,
+        ),
+      ),
+    [element],
+  );
+
+  const getPickerInitialValue = useCallback((): string => {
     const value = getValue();
     const pickerItems: Element[] = getPickerItems();
     const valueExists = pickerItems.some(
@@ -36,126 +58,117 @@ const HvPickerField = (props: HvComponentProps) => {
     return pickerItems.length > 0
       ? pickerItems[0].getAttribute('value') || ''
       : '';
-  };
-
-  /**
-   * Returns a string representing the value in the field.
-   */
-  const getValue = (): string => props.element.getAttribute('value') || '';
+  }, [getPickerItems, getValue]);
 
   /**
    * Gets the label from the picker items for the given value.
    * If the value doesn't have a picker item, returns null.
    */
-  const getLabelForValue = (value: DOMString): string | null | undefined => {
-    const pickerItemElements: HTMLCollectionOf<Element> = props.element.getElementsByTagNameNS(
-      Namespaces.HYPERVIEW,
-      LOCAL_NAME.PICKER_ITEM,
-    );
+  const getLabelForValue = useCallback(
+    (value: DOMString): string | null | undefined => {
+      const pickerItemElements: HTMLCollectionOf<Element> = element.getElementsByTagNameNS(
+        Namespaces.HYPERVIEW,
+        LOCAL_NAME.PICKER_ITEM,
+      );
 
-    let item: Element | null | undefined = null;
-    for (let i = 0; i < pickerItemElements.length; i += 1) {
-      const pickerItemElement:
-        | Element
-        | null
-        | undefined = pickerItemElements.item(i);
-      if (
-        pickerItemElement &&
-        pickerItemElement.getAttribute('value') === value
-      ) {
-        item = pickerItemElement;
-        break;
+      let item: Element | null | undefined = null;
+      for (let i = 0; i < pickerItemElements.length; i += 1) {
+        const pickerItemElement:
+          | Element
+          | null
+          | undefined = pickerItemElements.item(i);
+        if (
+          pickerItemElement &&
+          pickerItemElement.getAttribute('value') === value
+        ) {
+          item = pickerItemElement;
+          break;
+        }
       }
-    }
-    return item ? item.getAttribute('label') : null;
-  };
+      return item ? item.getAttribute('label') : null;
+    },
+    [element],
+  );
 
   /**
    * Returns a string representing the value in the picker.
    */
-  const getPickerValue = (): string =>
-    props.element.getAttribute('picker-value') || '';
-
-  const getPickerItems = (): Element[] =>
-    Array.from(
-      props.element.getElementsByTagNameNS(
-        Namespaces.HYPERVIEW,
-        LOCAL_NAME.PICKER_ITEM,
-      ),
-    );
+  const getPickerValue = useCallback(
+    (): string => element.getAttribute('picker-value') || '',
+    [element],
+  );
 
   /**
    * Shows the picker, defaulting to the field's value.
    * If the field is not set, use the first value in the picker.
    */
-  const onFieldPress = () => {
-    const newElement = props.element.cloneNode(true) as Element;
+  const onFieldPress = useCallback(() => {
+    const newElement = element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'true');
     newElement.setAttribute('picker-value', getPickerInitialValue());
-    props.onUpdate(null, 'swap', props.element, { newElement });
-    Behaviors.trigger('focus', newElement, props.onUpdate);
-  };
+    onUpdate(null, 'swap', element, { newElement });
+    Behaviors.trigger('focus', newElement, onUpdate);
+  }, [element, onUpdate, getPickerInitialValue]);
 
   /**
    * Hides the picker without applying the chosen value.
    */
-  const onCancel = () => {
-    const newElement = props.element.cloneNode(true) as Element;
+  const onCancel = useCallback(() => {
+    const newElement = element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'false');
     newElement.removeAttribute('picker-value');
-    props.onUpdate(null, 'swap', props.element, { newElement });
-    Behaviors.trigger('blur', newElement, props.onUpdate);
-  };
+    onUpdate(null, 'swap', element, { newElement });
+    Behaviors.trigger('blur', newElement, onUpdate);
+  }, [element, onUpdate]);
 
   /**
    * Hides the picker and applies the chosen value to the field.
    */
-  const onDone = () => {
+  const onDone = useCallback(() => {
     const pickerValue = getPickerValue();
     const value = getValue();
-    const newElement = props.element.cloneNode(true) as Element;
+    const newElement = element.cloneNode(true) as Element;
     newElement.setAttribute('value', pickerValue);
     newElement.removeAttribute('picker-value');
     newElement.setAttribute('focused', 'false');
-    props.onUpdate(null, 'swap', props.element, { newElement });
+    onUpdate(null, 'swap', element, { newElement });
     const hasChanged = value !== pickerValue;
     if (hasChanged) {
-      Behaviors.trigger('change', newElement, props.onUpdate);
+      Behaviors.trigger('change', newElement, onUpdate);
     }
-    Behaviors.trigger('blur', newElement, props.onUpdate);
-  };
+    Behaviors.trigger('blur', newElement, onUpdate);
+  }, [element, onUpdate, getPickerValue, getValue]);
 
   /**
    * Updates the picker value while keeping the picker open.
    */
-  const setPickerValue = (value: string) => {
-    const newElement = props.element.cloneNode(true) as Element;
-    newElement.setAttribute('picker-value', value);
-    props.onUpdate(null, 'swap', props.element, { newElement });
-  };
+  const setPickerValue = useCallback(
+    (value: string) => {
+      const newElement = element.cloneNode(true) as Element;
+      newElement.setAttribute('picker-value', value);
+      onUpdate(null, 'swap', element, { newElement });
+    },
+    [element, onUpdate],
+  );
 
   /**
    * Returns true if the field is focused (and picker is showing).
    */
-  const isFocused = (): boolean =>
-    props.element.getAttribute('focused') === 'true';
+  const isFocused = useCallback(
+    (): boolean => element.getAttribute('focused') === 'true',
+    [element],
+  );
 
-  const style: Array<StyleSheet> = createStyleProp(
-    props.element,
-    props.stylesheets,
-    {
-      ...props.options,
-      styleAttr: 'field-text-style',
-    },
-  );
-  const { testID, accessibilityLabel } = createTestProps(props.element);
-  const value: DOMString | null | undefined = props.element.getAttribute(
-    'value',
-  );
+  const style: Array<StyleSheet> = createStyleProp(element, stylesheets, {
+    ...options,
+    styleAttr: 'field-text-style',
+  });
+  const { testID, accessibilityLabel } = createTestProps(element);
+  const value: DOMString | null | undefined = element.getAttribute('value');
   const placeholderTextColor:
     | DOMString
     | null
-    | undefined = props.element.getAttribute('placeholderTextColor');
+    | undefined = element.getAttribute('placeholderTextColor');
   if ([undefined, null, ''].includes(value) && placeholderTextColor) {
     style.push({ color: placeholderTextColor });
   }
@@ -175,22 +188,22 @@ const HvPickerField = (props: HvComponentProps) => {
 
   return (
     <Field
-      element={props.element}
+      element={element}
       focused={isFocused()}
       onPress={onFieldPress}
-      options={props.options}
-      stylesheets={props.stylesheets}
+      options={options}
+      stylesheets={stylesheets}
       value={getLabelForValue(getValue())}
     >
       {isFocused() ? (
         <Modal
-          element={props.element}
+          element={element}
           focused={isFocused()}
           onModalCancel={onCancel}
           onModalDone={onDone}
-          onUpdate={props.onUpdate}
-          options={props.options}
-          stylesheets={props.stylesheets}
+          onUpdate={onUpdate}
+          options={options}
+          stylesheets={stylesheets}
         >
           <View accessibilityLabel={accessibilityLabel} testID={testID}>
             <Picker

--- a/src/elements/hv-picker-field/index.tsx
+++ b/src/elements/hv-picker-field/index.tsx
@@ -5,6 +5,7 @@ import type {
   HvComponentProps,
   StyleSheet,
 } from 'hyperview/src/types';
+import React, { useCallback } from 'react';
 import {
   createStyleProp,
   createTestProps,
@@ -12,7 +13,6 @@ import {
 } from 'hyperview/src/services';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import Picker from 'hyperview/src/core/components/picker';
-import React from 'react';
 import { View } from 'react-native';
 
 /**
@@ -22,103 +22,110 @@ import { View } from 'react-native';
  *   opens a system dialog.
  */
 const HvPickerField = (props: HvComponentProps) => {
+  // eslint-disable-next-line react/destructuring-assignment
+  const { element, onUpdate, options, stylesheets } = props;
+
   /**
    * Returns a string representing the value in the field.
    */
-  const getValue = (): string => props.element.getAttribute('value') || '';
+  const getValue = useCallback(
+    (): string => element.getAttribute('value') || '',
+    [element],
+  );
 
   /**
    * Returns a string representing the value in the picker.
    */
-  const getPickerValue = (): string =>
-    props.element.getAttribute('value') || '';
+  const getPickerValue = useCallback(
+    (): string => element.getAttribute('value') || '',
+    [element],
+  );
 
-  const getPickerItems = (): Element[] =>
-    Array.from(
-      props.element.getElementsByTagNameNS(
-        Namespaces.HYPERVIEW,
-        LOCAL_NAME.PICKER_ITEM,
+  const getPickerItems = useCallback(
+    (): Element[] =>
+      Array.from(
+        element.getElementsByTagNameNS(
+          Namespaces.HYPERVIEW,
+          LOCAL_NAME.PICKER_ITEM,
+        ),
       ),
-    );
+    [element],
+  );
 
-  const onFocus = () => {
-    const newElement = props.element.cloneNode(true) as Element;
+  const onFocus = useCallback(() => {
+    const newElement = element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'true');
-    props.onUpdate(null, 'swap', props.element, { newElement });
-    Behaviors.trigger('focus', newElement, props.onUpdate);
-  };
+    onUpdate(null, 'swap', element, { newElement });
+    Behaviors.trigger('focus', newElement, onUpdate);
+  }, [element, onUpdate]);
 
-  const onBlur = () => {
-    const newElement = props.element.cloneNode(true) as Element;
+  const onBlur = useCallback(() => {
+    const newElement = element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'false');
-    props.onUpdate(null, 'swap', props.element, { newElement });
-    Behaviors.trigger('blur', newElement, props.onUpdate);
-  };
+    onUpdate(null, 'swap', element, { newElement });
+    Behaviors.trigger('blur', newElement, onUpdate);
+  }, [element, onUpdate]);
 
   /**
    * Hides the picker without applying the chosen value.
    */
-  const onCancel = () => {
-    const newElement = props.element.cloneNode(true) as Element;
+  const onCancel = useCallback(() => {
+    const newElement = element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'false');
     newElement.removeAttribute('picker-value');
-    props.onUpdate(null, 'swap', props.element, { newElement });
-  };
+    onUpdate(null, 'swap', element, { newElement });
+  }, [element, onUpdate]);
 
   /**
    * Hides the picker and applies the chosen value to the field.
    */
-  const onDone = (newValue?: string) => {
-    const pickerValue = newValue !== undefined ? newValue : getPickerValue();
-    const value = getValue();
-    const newElement = props.element.cloneNode(true) as Element;
-    newElement.setAttribute('value', pickerValue);
-    newElement.removeAttribute('picker-value');
-    newElement.setAttribute('focused', 'false');
-    props.onUpdate(null, 'swap', props.element, { newElement });
+  const onDone = useCallback(
+    (newValue?: string) => {
+      const pickerValue = newValue !== undefined ? newValue : getPickerValue();
+      const value = getValue();
+      const newElement = element.cloneNode(true) as Element;
+      newElement.setAttribute('value', pickerValue);
+      newElement.removeAttribute('picker-value');
+      newElement.setAttribute('focused', 'false');
+      onUpdate(null, 'swap', element, { newElement });
 
-    const hasChanged = value !== pickerValue;
-    if (hasChanged) {
-      Behaviors.trigger('change', newElement, props.onUpdate);
-    }
-  };
-
-  const onChange = (value: string | null | undefined) => {
-    if (value === undefined) {
-      onCancel();
-    } else {
-      onDone(value || '');
-    }
-  };
-
-  const style: Array<StyleSheet> = createStyleProp(
-    props.element,
-    props.stylesheets,
-    {
-      ...props.options,
-      styleAttr: 'field-text-style',
+      const hasChanged = value !== pickerValue;
+      if (hasChanged) {
+        Behaviors.trigger('change', newElement, onUpdate);
+      }
     },
+    [element, getPickerValue, getValue, onUpdate],
   );
-  const { testID, accessibilityLabel } = createTestProps(props.element);
-  const value: DOMString | null | undefined = props.element.getAttribute(
-    'value',
+
+  const onChange = useCallback(
+    (value: string | null | undefined) => {
+      if (value === undefined) {
+        onCancel();
+      } else {
+        onDone(value || '');
+      }
+    },
+    [onCancel, onDone],
   );
+
+  const style: Array<StyleSheet> = createStyleProp(element, stylesheets, {
+    ...options,
+    styleAttr: 'field-text-style',
+  });
+  const { testID, accessibilityLabel } = createTestProps(element);
+  const value: DOMString | null | undefined = element.getAttribute('value');
   const placeholderTextColor:
     | DOMString
     | null
-    | undefined = props.element.getAttribute('placeholderTextColor');
+    | undefined = element.getAttribute('placeholderTextColor');
   if ([undefined, null, ''].includes(value) && placeholderTextColor) {
     style.push({ color: placeholderTextColor });
   }
 
-  const fieldStyle: Array<StyleSheet> = createStyleProp(
-    props.element,
-    props.stylesheets,
-    {
-      ...props.options,
-      styleAttr: 'field-style',
-    },
-  );
+  const fieldStyle: Array<StyleSheet> = createStyleProp(element, stylesheets, {
+    ...options,
+    styleAttr: 'field-style',
+  });
 
   // Gets all of the <picker-item> elements. All picker item elements
   // with a value and label are turned into options for the picker.
@@ -150,8 +157,8 @@ const HvPickerField = (props: HvComponentProps) => {
         // eslint-disable-next-line max-len
         // `enabled` needs to be true when the field is not focused, otherwise the the field will not be selectable
         // fix inspired by https://github.com/react-native-picker/picker/issues/95#issuecomment-935718568
-        enabled={props.element.getAttribute('focused') !== 'true'}
-        label={props.element.getAttribute('placeholder') || undefined}
+        enabled={element.getAttribute('focused') !== 'true'}
+        label={element.getAttribute('placeholder') || undefined}
         style={{ fontSize: 16 }}
         value=""
       />,

--- a/src/elements/hv-picker-field/index.tsx
+++ b/src/elements/hv-picker-field/index.tsx
@@ -5,7 +5,6 @@ import type {
   HvComponentProps,
   StyleSheet,
 } from 'hyperview/src/types';
-import React, { PureComponent } from 'react';
 import {
   createStyleProp,
   createTestProps,
@@ -13,6 +12,7 @@ import {
 } from 'hyperview/src/services';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import Picker from 'hyperview/src/core/components/picker';
+import React from 'react';
 import { View } from 'react-native';
 
 /**
@@ -21,168 +21,164 @@ import { View } from 'react-native';
  * - On Android, the system picker is rendered inline on the screen. Pressing the picker
  *   opens a system dialog.
  */
-export default class HvPickerField extends PureComponent<HvComponentProps> {
-  static namespaceURI = Namespaces.HYPERVIEW;
-
-  static localName = LOCAL_NAME.PICKER_FIELD;
-
-  static getFormInputValues = (element: Element): Array<[string, string]> => {
-    return getNameValueFormInputValues(element);
-  };
-
+const HvPickerField = (props: HvComponentProps) => {
   /**
    * Returns a string representing the value in the field.
    */
-  getValue = (): string => this.props.element.getAttribute('value') || '';
+  const getValue = (): string => props.element.getAttribute('value') || '';
 
   /**
    * Returns a string representing the value in the picker.
    */
-  getPickerValue = (): string => this.props.element.getAttribute('value') || '';
+  const getPickerValue = (): string =>
+    props.element.getAttribute('value') || '';
 
-  getPickerItems = (): Element[] =>
+  const getPickerItems = (): Element[] =>
     Array.from(
-      this.props.element.getElementsByTagNameNS(
+      props.element.getElementsByTagNameNS(
         Namespaces.HYPERVIEW,
         LOCAL_NAME.PICKER_ITEM,
       ),
     );
 
-  onFocus = () => {
-    const newElement = this.props.element.cloneNode(true) as Element;
+  const onFocus = () => {
+    const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'true');
-    this.props.onUpdate(null, 'swap', this.props.element, { newElement });
-    Behaviors.trigger('focus', newElement, this.props.onUpdate);
+    props.onUpdate(null, 'swap', props.element, { newElement });
+    Behaviors.trigger('focus', newElement, props.onUpdate);
   };
 
-  onBlur = () => {
-    const newElement = this.props.element.cloneNode(true) as Element;
+  const onBlur = () => {
+    const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'false');
-    this.props.onUpdate(null, 'swap', this.props.element, { newElement });
-    Behaviors.trigger('blur', newElement, this.props.onUpdate);
+    props.onUpdate(null, 'swap', props.element, { newElement });
+    Behaviors.trigger('blur', newElement, props.onUpdate);
   };
 
   /**
    * Hides the picker without applying the chosen value.
    */
-  onCancel = () => {
-    const newElement = this.props.element.cloneNode(true) as Element;
+  const onCancel = () => {
+    const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('focused', 'false');
     newElement.removeAttribute('picker-value');
-    this.props.onUpdate(null, 'swap', this.props.element, { newElement });
+    props.onUpdate(null, 'swap', props.element, { newElement });
   };
 
   /**
    * Hides the picker and applies the chosen value to the field.
    */
-  onDone = (newValue?: string) => {
-    const pickerValue =
-      newValue !== undefined ? newValue : this.getPickerValue();
-    const value = this.getValue();
-    const newElement = this.props.element.cloneNode(true) as Element;
+  const onDone = (newValue?: string) => {
+    const pickerValue = newValue !== undefined ? newValue : getPickerValue();
+    const value = getValue();
+    const newElement = props.element.cloneNode(true) as Element;
     newElement.setAttribute('value', pickerValue);
     newElement.removeAttribute('picker-value');
     newElement.setAttribute('focused', 'false');
-    this.props.onUpdate(null, 'swap', this.props.element, { newElement });
+    props.onUpdate(null, 'swap', props.element, { newElement });
 
     const hasChanged = value !== pickerValue;
     if (hasChanged) {
-      Behaviors.trigger('change', newElement, this.props.onUpdate);
+      Behaviors.trigger('change', newElement, props.onUpdate);
     }
   };
 
-  render() {
-    const onChange = (value: string | null | undefined) => {
-      if (value === undefined) {
-        this.onCancel();
-      } else {
-        this.onDone(value || '');
-      }
-    };
-
-    const style: Array<StyleSheet> = createStyleProp(
-      this.props.element,
-      this.props.stylesheets,
-      {
-        ...this.props.options,
-        styleAttr: 'field-text-style',
-      },
-    );
-    const { testID, accessibilityLabel } = createTestProps(this.props.element);
-    const value: DOMString | null | undefined = this.props.element.getAttribute(
-      'value',
-    );
-    const placeholderTextColor:
-      | DOMString
-      | null
-      | undefined = this.props.element.getAttribute('placeholderTextColor');
-    if ([undefined, null, ''].includes(value) && placeholderTextColor) {
-      style.push({ color: placeholderTextColor });
+  const onChange = (value: string | null | undefined) => {
+    if (value === undefined) {
+      onCancel();
+    } else {
+      onDone(value || '');
     }
+  };
 
-    const fieldStyle: Array<StyleSheet> = createStyleProp(
-      this.props.element,
-      this.props.stylesheets,
-      {
-        ...this.props.options,
-        styleAttr: 'field-style',
-      },
-    );
+  const style: Array<StyleSheet> = createStyleProp(
+    props.element,
+    props.stylesheets,
+    {
+      ...props.options,
+      styleAttr: 'field-text-style',
+    },
+  );
+  const { testID, accessibilityLabel } = createTestProps(props.element);
+  const value: DOMString | null | undefined = props.element.getAttribute(
+    'value',
+  );
+  const placeholderTextColor:
+    | DOMString
+    | null
+    | undefined = props.element.getAttribute('placeholderTextColor');
+  if ([undefined, null, ''].includes(value) && placeholderTextColor) {
+    style.push({ color: placeholderTextColor });
+  }
 
-    // Gets all of the <picker-item> elements. All picker item elements
-    // with a value and label are turned into options for the picker.
-    const items = this.getPickerItems();
-    const children = items.filter(Boolean).map((item: Element) => {
-      const l: DOMString | null | undefined = item.getAttribute('label');
-      const v: DOMString | null | undefined = item.getAttribute('value');
-      if (!l || typeof v !== 'string') {
-        return null;
-      }
-      const enabled = ['', 'true', null].includes(item.getAttribute('enabled'));
-      return (
-        <Picker.Item
-          key={l + v}
-          enabled={enabled}
-          label={l}
-          style={{ fontSize: 16 }}
-          value={v}
-        />
-      );
-    });
+  const fieldStyle: Array<StyleSheet> = createStyleProp(
+    props.element,
+    props.stylesheets,
+    {
+      ...props.options,
+      styleAttr: 'field-style',
+    },
+  );
 
-    // If there are no items, or the first item has a value,
-    // we need to add an empty option that acts as a placeholder.
-    if (items.length > 0 && items[0].getAttribute('value') !== '') {
-      children.unshift(
-        <Picker.Item
-          key="empty"
-          // eslint-disable-next-line max-len
-          // `enabled` needs to be true when the field is not focused, otherwise the the field will not be selectable
-          // fix inspired by https://github.com/react-native-picker/picker/issues/95#issuecomment-935718568
-          enabled={this.props.element.getAttribute('focused') !== 'true'}
-          label={this.props.element.getAttribute('placeholder') || undefined}
-          style={{ fontSize: 16 }}
-          value=""
-        />,
-      );
+  // Gets all of the <picker-item> elements. All picker item elements
+  // with a value and label are turned into options for the picker.
+  const items = getPickerItems();
+  const children = items.filter(Boolean).map((item: Element) => {
+    const l: DOMString | null | undefined = item.getAttribute('label');
+    const v: DOMString | null | undefined = item.getAttribute('value');
+    if (!l || typeof v !== 'string') {
+      return null;
     }
-
+    const enabled = ['', 'true', null].includes(item.getAttribute('enabled'));
     return (
-      <View
-        accessibilityLabel={accessibilityLabel}
-        style={fieldStyle}
-        testID={testID}
-      >
-        <Picker
-          onBlur={this.onBlur}
-          onFocus={this.onFocus}
-          onValueChange={onChange}
-          selectedValue={this.getPickerValue()}
-          style={style}
-        >
-          {children}
-        </Picker>
-      </View>
+      <Picker.Item
+        key={l + v}
+        enabled={enabled}
+        label={l}
+        style={{ fontSize: 16 }}
+        value={v}
+      />
+    );
+  });
+
+  // If there are no items, or the first item has a value,
+  // we need to add an empty option that acts as a placeholder.
+  if (items.length > 0 && items[0].getAttribute('value') !== '') {
+    children.unshift(
+      <Picker.Item
+        key="empty"
+        // eslint-disable-next-line max-len
+        // `enabled` needs to be true when the field is not focused, otherwise the the field will not be selectable
+        // fix inspired by https://github.com/react-native-picker/picker/issues/95#issuecomment-935718568
+        enabled={props.element.getAttribute('focused') !== 'true'}
+        label={props.element.getAttribute('placeholder') || undefined}
+        style={{ fontSize: 16 }}
+        value=""
+      />,
     );
   }
-}
+
+  return (
+    <View
+      accessibilityLabel={accessibilityLabel}
+      style={fieldStyle}
+      testID={testID}
+    >
+      <Picker
+        onBlur={onBlur}
+        onFocus={onFocus}
+        onValueChange={onChange}
+        selectedValue={getPickerValue()}
+        style={style}
+      >
+        {children}
+      </Picker>
+    </View>
+  );
+};
+
+HvPickerField.namespaceURI = Namespaces.HYPERVIEW;
+HvPickerField.localName = LOCAL_NAME.PICKER_FIELD;
+HvPickerField.getFormInputValues = getNameValueFormInputValues;
+
+export default HvPickerField;


### PR DESCRIPTION
Convert `hv-picker-field` (iOS and Android) to Functional Component. Confirm no degradation in render count.

[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1210601789543016?focus=true)