### PR TITLE
chore(test-helpers): remove export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import * as Events from 'hyperview/src/services/events';
 import * as Logging from 'hyperview/src/services/logging';
 import * as Namespaces from 'hyperview/src/services/namespaces';
-import * as TestHelpers from 'hyperview/test/helpers';
 
 /**
  * Root component for Hyperview.
@@ -42,7 +41,7 @@ export { createEventHandler } from 'hyperview/src/core/utils';
 /**
  * Services
  */
-export { Events, Logging, Namespaces, TestHelpers };
+export { Events, Logging, Namespaces };
 export {
   createProps,
   createStyleProp,


### PR DESCRIPTION
Exporting the `TestHelpers` from Hyperview causes an issue in the mobile codebase around the use of `import fs from 'fs';` in `test/helpers/file.ts`. The export is removed and the mobile app will continue to reach into Hyperview to access the `parse` function.