### PR TITLE
chore: type clean up

### DIFF
--- a/src/behaviors/hv-hide/index.ts
+++ b/src/behaviors/hv-hide/index.ts
@@ -36,7 +36,7 @@ export default {
     );
 
     const hideElement = () => {
-      const doc: Document | null = getRoot();
+      const doc: Document | undefined = getRoot();
       const targetElement: Element | null | undefined = Dom.getElementById(
         doc,
         targetId,
@@ -67,7 +67,7 @@ export default {
       hideElement();
     } else {
       // If there's a delay, first trigger the indicators before the hide
-      const doc: Document | null = getRoot();
+      const doc: Document | undefined = getRoot();
       if (doc) {
         const newRoot = Behaviors.setIndicatorsBeforeLoad(
           showIndicatorIds,

--- a/src/behaviors/hv-select-all/index.ts
+++ b/src/behaviors/hv-select-all/index.ts
@@ -39,7 +39,7 @@ export default {
     );
 
     const selectAll = () => {
-      const doc: Document | null = getRoot();
+      const doc: Document | undefined = getRoot();
       const targetElement: Element | null | undefined = Dom.getElementById(
         doc,
         targetId,
@@ -69,7 +69,7 @@ export default {
       selectAll();
     } else {
       // If there's a delay, first trigger the indicators before the select-all.
-      const doc: Document | null = getRoot();
+      const doc: Document | undefined = getRoot();
       if (doc) {
         const newRoot = Behaviors.setIndicatorsBeforeLoad(
           showIndicatorIds,

--- a/src/behaviors/hv-set-value/index.ts
+++ b/src/behaviors/hv-set-value/index.ts
@@ -40,7 +40,7 @@ export default {
     );
 
     const setValue = () => {
-      const doc: Document | null = getRoot();
+      const doc: Document | undefined = getRoot();
       const targetElement: Element | null | undefined = Dom.getElementById(
         doc,
         targetId,
@@ -71,7 +71,7 @@ export default {
       setValue();
     } else {
       // If there's a delay, first trigger the indicators before the show.
-      const doc: Document | null = getRoot();
+      const doc: Document | undefined = getRoot();
       if (doc) {
         const newRoot = Behaviors.setIndicatorsBeforeLoad(
           showIndicatorIds,

--- a/src/behaviors/hv-show/index.ts
+++ b/src/behaviors/hv-show/index.ts
@@ -36,7 +36,7 @@ export default {
     );
 
     const showElement = () => {
-      const doc: Document | null = getRoot();
+      const doc: Document | undefined = getRoot();
       const targetElement: Element | null | undefined = Dom.getElementById(
         doc,
         targetId,
@@ -67,7 +67,7 @@ export default {
       showElement();
     } else {
       // If there's a delay, first trigger the indicators before the show.
-      const doc: Document | null = getRoot();
+      const doc: Document | undefined = getRoot();
       if (doc) {
         const newRoot = Behaviors.setIndicatorsBeforeLoad(
           showIndicatorIds,

--- a/src/behaviors/hv-toggle/index.ts
+++ b/src/behaviors/hv-toggle/index.ts
@@ -36,7 +36,7 @@ export default {
     );
 
     const toggleElement = () => {
-      const doc: Document | null = getRoot();
+      const doc: Document | undefined = getRoot();
       const targetElement: Element | null | undefined = Dom.getElementById(
         doc,
         targetId,
@@ -70,7 +70,7 @@ export default {
       toggleElement();
     } else {
       // If there's a delay, first trigger the indicators before the toggle.
-      const doc: Document | null = getRoot();
+      const doc: Document | undefined = getRoot();
       if (doc) {
         const newRoot = Behaviors.setIndicatorsBeforeLoad(
           showIndicatorIds,

--- a/src/behaviors/hv-unselect-all/index.ts
+++ b/src/behaviors/hv-unselect-all/index.ts
@@ -39,7 +39,7 @@ export default {
     );
 
     const unselectAll = () => {
-      const doc: Document | null = getRoot();
+      const doc: Document | undefined = getRoot();
       const targetElement: Element | null | undefined = Dom.getElementById(
         doc,
         targetId,
@@ -69,7 +69,7 @@ export default {
       unselectAll();
     } else {
       // If there's a delay, first trigger the indicators before the unselect-all.
-      const doc: Document | null = getRoot();
+      const doc: Document | undefined = getRoot();
       if (doc) {
         const newRoot = Behaviors.setIndicatorsBeforeLoad(
           showIndicatorIds,

--- a/src/elements/hv-doc/context.ts
+++ b/src/elements/hv-doc/context.ts
@@ -1,9 +1,9 @@
-import { StateContextProps } from './types';
+import { StateProps } from './types';
 import { createContext } from 'react';
 
 const callbacks = {
   clearElementError: () => undefined,
-  getDoc: () => null,
+  getDoc: () => undefined,
   getNavigation: () => ({
     backAction: () => undefined,
     navigate: () => undefined,
@@ -15,8 +15,8 @@ const callbacks = {
   updateUrl: () => null,
 };
 
-export const StateContext = createContext<StateContextProps>({
-  getLocalDoc: () => null,
+export const Context = createContext<StateProps>({
+  getDoc: () => undefined,
   getScreenState: () => ({}),
   onUpdate: () => undefined,
   onUpdateCallbacks: callbacks,

--- a/src/elements/hv-doc/hv-doc.tsx
+++ b/src/elements/hv-doc/hv-doc.tsx
@@ -19,9 +19,9 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { Context } from './context';
 import { HvDocError } from './errors';
 import LoadError from 'hyperview/src/core/components/load-error';
-import { StateContext } from './context';
 import { later } from 'hyperview/src/services';
 import { useElementCache } from 'hyperview/src/contexts/element-cache';
 import { useHyperview } from 'hyperview/src/contexts/hyperview';
@@ -35,7 +35,7 @@ export default (props: Props) => {
   // available (see details here: https://reactjs.org/docs/react-component.html#setstate)
   // Whenever we need to access the document for reasons other than rendering, we should use
   // `localDoc`. When rendering, we should use `document`.
-  const localDoc = useRef<Document | null | undefined>(null);
+  const localDoc = useRef<Document | undefined>(undefined);
 
   // This is a temporary solution to ensure the url is available immediately while
   // external components are still triggering the loadUrl callback
@@ -45,7 +45,7 @@ export default (props: Props) => {
   const currentProps = useRef(props);
 
   const [state, setState] = useState<DocState>({
-    doc: null,
+    doc: undefined,
     elementError: null,
     error: null,
     loadingUrl: null,
@@ -203,7 +203,7 @@ export default (props: Props) => {
     () => ({ ...state, url: localUrl.current }),
     [state],
   );
-  const getDoc = useCallback(() => localDoc.current ?? null, [localDoc]);
+  const getDoc = useCallback(() => localDoc.current ?? undefined, [localDoc]);
   const getNavigation = useCallback(() => props.navigationProvider, [
     props.navigationProvider,
   ]);
@@ -219,7 +219,7 @@ export default (props: Props) => {
       setState(prev => ({
         ...prev,
         ...newState,
-        doc: hasElement ? null : newState.doc ?? prev.doc,
+        doc: hasElement ? undefined : newState.doc ?? prev.doc,
       }));
     },
     [hasElement],
@@ -277,7 +277,7 @@ export default (props: Props) => {
     };
 
     return {
-      getLocalDoc: getDoc,
+      getDoc,
       getScreenState,
       onUpdate: onDocUpdate,
       onUpdateCallbacks: onUpdateCallbacksRef.current,
@@ -318,7 +318,7 @@ export default (props: Props) => {
   };
 
   return (
-    <StateContext.Provider value={contextValue}>
+    <Context.Provider value={contextValue}>
       {state.error ? (
         //  Render the state error
         <Err
@@ -329,6 +329,6 @@ export default (props: Props) => {
       ) : (
         props.children
       )}
-    </StateContext.Provider>
+    </Context.Provider>
   );
 };

--- a/src/elements/hv-doc/index.ts
+++ b/src/elements/hv-doc/index.ts
@@ -1,2 +1,2 @@
 export { default } from './hv-doc';
-export { StateContext } from './context';
+export { Context as StateContext } from './context';

--- a/src/elements/hv-doc/types.ts
+++ b/src/elements/hv-doc/types.ts
@@ -14,8 +14,8 @@ export type Props = {
   url: string;
 };
 
-export type StateContextProps = {
-  getLocalDoc: () => Document | null;
+export type StateProps = {
+  getDoc: () => Document | undefined;
   getScreenState: () => ScreenState;
   onUpdate: HvComponentOnUpdate;
   onUpdateCallbacks: OnUpdateCallbacks;

--- a/src/elements/hv-list/index.tsx
+++ b/src/elements/hv-list/index.tsx
@@ -66,7 +66,7 @@ export default class HvList extends PureComponent<HvComponentProps, State> {
       Logging.warn('[behaviors/scroll]: missing "target" attribute');
       return;
     }
-    const doc: Document | null | undefined = this.context?.getDoc();
+    const doc: Document | undefined = this.context?.getDoc();
     const targetElement: Element | null | undefined = Dom.getElementById(
       doc,
       targetId,

--- a/src/elements/hv-navigator/index.tsx
+++ b/src/elements/hv-navigator/index.tsx
@@ -8,10 +8,12 @@ import * as NavigatorService from 'hyperview/src/services/navigator';
 import {
   BEHAVIOR_ATTRIBUTES,
   LOCAL_NAME,
+  NAVIGATOR_TYPE,
   RouteParams,
   TRIGGERS,
 } from 'hyperview/src/types';
 import type {
+  NavigatorProps,
   ParamTypes,
   Props,
   ScreenParams,
@@ -197,7 +199,7 @@ export default class HvNavigator extends PureComponent<Props> {
     const initialParams = NavigatorService.isDynamicRoute(id)
       ? {}
       : { id, isModal, needsSubStack, routeId, url: href };
-    if (type === NavigatorService.NAVIGATOR_TYPE.TAB) {
+    if (type === NAVIGATOR_TYPE.TAB) {
       return (
         <BottomTab.Screen
           key={id}
@@ -207,7 +209,7 @@ export default class HvNavigator extends PureComponent<Props> {
         />
       );
     }
-    if (type === NavigatorService.NAVIGATOR_TYPE.STACK) {
+    if (type === NAVIGATOR_TYPE.STACK) {
       const gestureEnabled = Platform.OS === 'ios' ? !needsSubStack : false;
       return (
         <Stack.Screen
@@ -243,7 +245,7 @@ export default class HvNavigator extends PureComponent<Props> {
     screens.push(
       this.buildScreen(
         NavigatorService.ID_CARD,
-        NavigatorService.NAVIGATOR_TYPE.STACK,
+        NAVIGATOR_TYPE.STACK,
         undefined,
         false,
       ),
@@ -252,7 +254,7 @@ export default class HvNavigator extends PureComponent<Props> {
     screens.push(
       this.buildScreen(
         NavigatorService.ID_MODAL,
-        NavigatorService.NAVIGATOR_TYPE.STACK,
+        NAVIGATOR_TYPE.STACK,
         undefined,
         true,
       ),
@@ -317,7 +319,7 @@ export default class HvNavigator extends PureComponent<Props> {
     });
 
     // Add the dynamic stack screens
-    if (type === NavigatorService.NAVIGATOR_TYPE.STACK) {
+    if (type === NAVIGATOR_TYPE.STACK) {
       screens.push(...this.buildDynamicScreens());
     }
     return screens;
@@ -355,7 +357,7 @@ export default class HvNavigator extends PureComponent<Props> {
     const { BottomTabBar } = navigationComponents || {};
 
     switch (type) {
-      case NavigatorService.NAVIGATOR_TYPE.STACK:
+      case NAVIGATOR_TYPE.STACK:
         return (
           <Stack.Navigator
             id={id}
@@ -364,7 +366,7 @@ export default class HvNavigator extends PureComponent<Props> {
             {this.buildScreens(type, this.props.element)}
           </Stack.Navigator>
         );
-      case NavigatorService.NAVIGATOR_TYPE.TAB:
+      case NAVIGATOR_TYPE.TAB:
         return (
           <BottomTab.Navigator
             backBehavior="none"
@@ -397,9 +399,7 @@ export default class HvNavigator extends PureComponent<Props> {
   /**
    * Build a stack navigator for a modal
    */
-  ModalNavigator = (
-    props: NavigatorService.NavigatorProps,
-  ): React.ReactElement => {
+  ModalNavigator = (props: NavigatorProps): React.ReactElement => {
     if (!this.props.params) {
       throw new NavigatorService.HvNavigatorError(
         'No params found for modal screen',
@@ -420,7 +420,7 @@ export default class HvNavigator extends PureComponent<Props> {
     screens.push(
       this.buildScreen(
         screenId,
-        NavigatorService.NAVIGATOR_TYPE.STACK,
+        NAVIGATOR_TYPE.STACK,
         this.props.params?.url || undefined,
         false,
         false,

--- a/src/elements/hv-navigator/types.ts
+++ b/src/elements/hv-navigator/types.ts
@@ -18,6 +18,11 @@ export type Props = {
   routeComponent: FC<HvRouteProps>;
 };
 
+/* List of props available to navigators */
+export type NavigatorProps = {
+  doc: Document | undefined;
+};
+
 /**
  * Options used for a stack navigator's screenOptions
  */

--- a/src/elements/hv-route/hv-route.tsx
+++ b/src/elements/hv-route/hv-route.tsx
@@ -46,13 +46,13 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
     if (this.props.element) {
       return this.props.element;
     }
-    if (!this.props.getLocalDoc()) {
+    if (!this.props.getDoc()) {
       throw new NavigatorService.HvRenderError('No document found');
     }
 
     // Get the <doc> element
     const root: Element | null = Helpers.getFirstChildTag(
-      this.props.getLocalDoc() as Document,
+      this.props.getDoc() as Document,
       LOCAL_NAME.DOC,
     );
     if (!root) {
@@ -164,7 +164,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
         elementErrorComponent={this.props.elementErrorComponent}
         entrypointUrl={this.props.entrypointUrl}
         getElement={this.props.getElement}
-        getLocalDoc={this.props.getLocalDoc}
+        getDoc={this.props.getDoc}
         getScreenState={this.props.getScreenState}
         navigation={this.props.navigator}
         onUpdate={this.props.onUpdate}
@@ -204,21 +204,21 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
         if (!this.props.url) {
           throw new NavigatorService.HvRouteError('No url received');
         }
-        if (!this.props.getLocalDoc()) {
+        if (!this.props.getDoc()) {
           throw new NavigatorService.HvRouteError('No document received');
         }
       }
     }
 
     if (needsSubStack || renderElement?.localName === LOCAL_NAME.NAVIGATOR) {
-      if (this.props.getLocalDoc()) {
+      if (this.props.getDoc()) {
         // The <DocContext> provides doc access to nested navigators
         // The <UpdateContext> provides access to the onUpdate method for this route
         // only pass it when the doc is available and is not being overridden by an element
         return (
           <Contexts.DocContext.Provider
             value={{
-              getDoc: () => this.props.getLocalDoc() || undefined,
+              getDoc: () => this.props.getDoc() || undefined,
               setDoc: (doc: Document) => this.props.setScreenState({ doc }),
             }}
           >
@@ -264,7 +264,7 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
 
     if (
       this.props.element ||
-      this.props.getLocalDoc() ||
+      this.props.getDoc() ||
       this.props.route?.params?.needsSubStack
     ) {
       return <Route />;
@@ -466,7 +466,7 @@ function HvRouteFC(props: Types.Props) {
     >
       <StateContext.Consumer>
         {({
-          getLocalDoc,
+          getDoc,
           getScreenState,
           onUpdate,
           onUpdateCallbacks,
@@ -476,12 +476,12 @@ function HvRouteFC(props: Types.Props) {
           <HvRouteInner
             behaviors={behaviors}
             components={components}
-            doc={getLocalDoc() || undefined}
+            doc={getDoc() || undefined}
             element={element}
             elementErrorComponent={elementErrorComponent}
             entrypointUrl={entrypointUrl}
+            getDoc={getDoc}
             getElement={getElement}
-            getLocalDoc={getLocalDoc}
             getScreenState={getScreenState}
             navigator={navigator}
             onUpdate={onUpdate}

--- a/src/elements/hv-route/types.ts
+++ b/src/elements/hv-route/types.ts
@@ -27,7 +27,7 @@ export type InnerRouteProps = {
   removeElement: (key: number) => void;
   element?: Element;
   doc: Document | undefined;
-  getLocalDoc: () => Document | null;
+  getDoc: () => Document | undefined;
   setScreenState: (state: ScreenState) => void;
   getScreenState: () => ScreenState;
   onUpdateCallbacks: OnUpdateCallbacks;

--- a/src/elements/hv-screen/types.ts
+++ b/src/elements/hv-screen/types.ts
@@ -34,7 +34,7 @@ export type Props = Omit<
   removeElement?: (id: number) => void;
   route?: RouteProps;
   url?: string;
-  getLocalDoc: () => Document | null;
+  getDoc: () => Document | undefined;
   getScreenState: () => ScreenState;
   setScreenState: (state: ScreenState) => void;
 };

--- a/src/elements/hv-section-list/index.tsx
+++ b/src/elements/hv-section-list/index.tsx
@@ -105,7 +105,7 @@ export default class HvSectionList extends PureComponent<
       Logging.warn('[behaviors/scroll]: missing "target" attribute');
       return;
     }
-    const doc: Document | null | undefined = this.context?.getDoc();
+    const doc: Document | undefined = this.context?.getDoc();
     const targetElement: Element | null | undefined = Dom.getElementById(
       doc,
       targetId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export type {
   HvComponentOptions,
   HvGetRoot,
   HvUpdateRoot,
+  NavigationComponents,
   RouteParams,
   RouteProps,
   StyleSheet,
@@ -54,7 +55,6 @@ export {
   getFirstTag,
 } from 'hyperview/src/services/dom';
 export { HvBaseError } from 'hyperview/src/services/error';
-export type { NavigationComponents } from 'hyperview/src/services/navigator';
 export { renderChildren, renderElement } from 'hyperview/src/services/render';
 export { createStylesheets } from 'hyperview/src/services/stylesheets';
 export { getUrlFromHref } from 'hyperview/src/services/url';

--- a/src/services/dom/helpers.ts
+++ b/src/services/dom/helpers.ts
@@ -91,7 +91,7 @@ export const preorder = (
  * Handle cases where an element is passed in instead of a document
  */
 export const getElementById = (
-  doc: Document | null | undefined,
+  doc: Document | undefined,
   id: string,
 ): Element | null | undefined => {
   if (!doc) {
@@ -141,7 +141,7 @@ export const processDocument = (doc: Document): Document => {
  * is no longer a direct child of the view
  */
 export const findTargetByBehavior = (
-  doc: Document | null,
+  doc: Document | undefined,
   behaviorElement: Element | null | undefined,
 ): Element | null => {
   if (!doc || !behaviorElement) {

--- a/src/services/navigator/helpers.test.ts
+++ b/src/services/navigator/helpers.test.ts
@@ -424,13 +424,13 @@ describe('findPath', () => {
 // - build navigator hierarchy
 
 function isNavigateParam(
-  p: RouteParams | Types.NavigationNavigateParams | undefined,
-): p is Types.NavigationNavigateParams {
-  return (p as Types.NavigationNavigateParams).screen !== undefined;
+  p: RouteParams | Types.NavigateParams | undefined,
+): p is Types.NavigateParams {
+  return (p as Types.NavigateParams).screen !== undefined;
 }
 
 function isRouteParam(
-  p: RouteParams | Types.NavigationNavigateParams | undefined,
+  p: RouteParams | Types.NavigateParams | undefined,
 ): p is RouteParams {
   return (p as RouteParams).url !== undefined;
 }

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -3,7 +3,12 @@ import * as Helpers from 'hyperview/src/services/dom/helpers';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Types from './types';
 import * as UrlService from 'hyperview/src/services/url';
-import { LOCAL_NAME, NAV_ACTIONS, NODE_TYPE } from 'hyperview/src/types';
+import {
+  LOCAL_NAME,
+  NAVIGATOR_TYPE,
+  NAV_ACTIONS,
+  NODE_TYPE,
+} from 'hyperview/src/types';
 import type {
   NavAction,
   NavigationProps,
@@ -180,7 +185,7 @@ export const buildParams = (
   path: string[],
   routeParams: RouteParams,
   index = 0,
-): Types.NavigationNavigateParams | RouteParams => {
+): Types.NavigateParams | RouteParams => {
   if (path.length && index < path.length) {
     const screen = path[index];
 
@@ -300,14 +305,14 @@ const buildCloseRequest = (
   NavAction,
   NavigationProps | undefined,
   string,
-  Types.NavigationNavigateParams | RouteParams | undefined,
+  Types.NavigateParams | RouteParams | undefined,
 ] => {
   if (!navigation) {
     return [NAV_ACTIONS.CLOSE, navigation, '', routeParams];
   }
 
   const state = navigation.getState();
-  if (state.type === Types.NAVIGATOR_TYPE.STACK) {
+  if (state.type === NAVIGATOR_TYPE.STACK) {
     // Check if current route is modal
     if (isRouteModal(state, state.index)) {
       return [NAV_ACTIONS.CLOSE, navigation, '', routeParams];
@@ -354,7 +359,7 @@ export const buildRequest = (
   NavAction,
   NavigationProps | undefined,
   string,
-  Types.NavigationNavigateParams | RouteParams | undefined,
+  Types.NavigateParams | RouteParams | undefined,
 ] => {
   const navAction: NavAction = getNavAction(action, routeParams);
 
@@ -407,7 +412,7 @@ export const buildRequest = (
   //  { screen: 'shifts', params:
   //    { screen: 'my-shifts', params: { url: 'someurl.xml' } } })
   const lastPathId = path.shift();
-  const params: Types.NavigationNavigateParams | RouteParams = buildParams(
+  const params: Types.NavigateParams | RouteParams = buildParams(
     routeId,
     path,
     cleanedParams,
@@ -560,7 +565,7 @@ export const setSelected = (
   if (route && route.parentNode) {
     const parentNode = route.parentNode as Element;
     const type = parentNode.getAttribute(Types.KEY_TYPE);
-    if (type !== Types.NAVIGATOR_TYPE.TAB) {
+    if (type !== NAVIGATOR_TYPE.TAB) {
       return;
     }
 
@@ -600,7 +605,7 @@ export const removeStackRoute = (
   if (route && route.parentNode) {
     const parentNode = route.parentNode as Element;
     const type = parentNode.getAttribute(Types.KEY_TYPE);
-    if (type === Types.NAVIGATOR_TYPE.STACK) {
+    if (type === NAVIGATOR_TYPE.STACK) {
       if (getChildElements(parentNode).length > 1) {
         parentNode.removeChild(route);
 
@@ -640,7 +645,7 @@ export const addStackRoute = (
   if (siblingElement && siblingElement.parentNode) {
     const parentElement = siblingElement.parentNode as Element;
     const type = parentElement.getAttribute(Types.KEY_TYPE);
-    if (type === Types.NAVIGATOR_TYPE.STACK) {
+    if (type === NAVIGATOR_TYPE.STACK) {
       const element = doc.createElementNS(
         Namespaces.HYPERVIEW,
         LOCAL_NAME.NAV_ROUTE,

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -1,6 +1,5 @@
 export { Navigator } from './navigator';
 
-export type { NavigationComponents, NavigatorProps } from './types';
 export { HvRouteError, HvNavigatorError, HvRenderError } from './errors';
 export {
   addStackRoute,
@@ -17,10 +16,4 @@ export {
   setSelected,
   updateRouteUrlFromState,
 } from './helpers';
-export {
-  ANCHOR_ID_SEPARATOR,
-  ID_CARD,
-  ID_MODAL,
-  KEY_MODAL,
-  NAVIGATOR_TYPE,
-} from './types';
+export { ANCHOR_ID_SEPARATOR, ID_CARD, ID_MODAL, KEY_MODAL } from './types';

--- a/src/services/navigator/navigator.ts
+++ b/src/services/navigator/navigator.ts
@@ -126,7 +126,7 @@ export class Navigator implements NavigationProvider {
     componentRegistry: Components.Registry,
     opts: BehaviorOptions,
     stateUrl?: string | null,
-    doc?: Document | null,
+    doc?: Document,
   ): void => {
     const { showIndicatorId, delay, targetId } = opts;
     const formData: FormData | null | undefined = componentRegistry.getFormData(

--- a/src/services/navigator/types.ts
+++ b/src/services/navigator/types.ts
@@ -4,7 +4,6 @@ import type {
   RouteProps,
 } from 'hyperview/src/types';
 import { NavigationContainerRefContext } from '@react-navigation/native';
-import type { BottomTabBarProps as RNBottomTabBarProps } from '@react-navigation/bottom-tabs';
 
 export const ANCHOR_ID_SEPARATOR = '#';
 export const ID_CARD = 'card';
@@ -15,14 +14,6 @@ export const KEY_MODAL = 'modal';
 export const KEY_ID = 'id';
 export const KEY_TYPE = 'type';
 export const KEY_HREF = 'href';
-
-/**
- * Definition of the available navigator types
- */
-export const NAVIGATOR_TYPE = {
-  STACK: 'stack',
-  TAB: 'tab',
-};
 
 export type Props = {
   navigation?: NavigationProps;
@@ -37,24 +28,9 @@ export type Props = {
 /**
  * Mapping of screens and params for navigation
  */
-export type NavigationNavigateParams = {
+export type NavigateParams = {
   screen?: string;
-  params?: NavigationNavigateParams | RouteParams;
-};
-
-type BottomTabBarProps = RNBottomTabBarProps & {
-  id: string;
-};
-
-type BottomTabBarComponent = (props: BottomTabBarProps) => JSX.Element | null;
-
-export type NavigationComponents = {
-  BottomTabBar?: BottomTabBarComponent;
-};
-
-/* List of props available to navigators */
-export type NavigatorProps = NavigationComponents & {
-  doc: Document | undefined;
+  params?: NavigateParams | RouteParams;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,7 +143,7 @@ export type HvComponent = (
 ) &
   HvComponentStatics;
 
-export type HvGetRoot = () => Document | null;
+export type HvGetRoot = () => Document | undefined;
 
 export type HvUpdateRoot = (root: Document, updateStylesheet?: boolean) => void;
 
@@ -299,7 +299,7 @@ export type NavigationProvider = {
     componentRegistry: Components.Registry,
     opts: BehaviorOptions,
     stateUrl?: string | null,
-    doc?: Document | null,
+    doc?: Document,
   ) => void;
   openModalAction: (params: RouteParams) => void;
 };
@@ -308,14 +308,14 @@ export type OnUpdateCallbacks = {
   clearElementError: () => void;
   getNavigation: () => NavigationProvider;
   getOnUpdate: () => HvComponentOnUpdate;
-  getDoc: () => Document | null;
+  getDoc: () => Document | undefined;
   getState: () => ScreenState;
   setState: (state: ScreenState) => void;
   updateUrl: (url: string) => void;
 };
 
 export type ScreenState = {
-  doc?: Document | null;
+  doc?: Document;
   elementError?: Error | null;
   error?: Error | null;
   staleHeaderType?: XResponseStaleReason | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ import type {
 import React, { ComponentType } from 'react';
 import type { Props as ErrorProps } from 'hyperview/src/core/components/load-error';
 import type { Props as LoadingProps } from 'hyperview/src/core/components/loading';
-import type { NavigationComponents } from 'hyperview/src/services/navigator';
+import type { BottomTabBarProps as RNBottomTabBarProps } from '@react-navigation/bottom-tabs';
 import type { RefreshControlProps } from 'react-native';
 import type { XResponseStaleReason } from 'hyperview/src/services/dom';
 
@@ -215,6 +215,14 @@ export const ACTIONS = {
   UNSELECT_ALL: 'unselect-all',
 } as const;
 
+/**
+ * Definition of the available navigator types
+ */
+export const NAVIGATOR_TYPE = {
+  STACK: 'stack',
+  TAB: 'tab',
+};
+
 export const NAV_ACTIONS = {
   BACK: ACTIONS.BACK,
   CLOSE: ACTIONS.CLOSE,
@@ -325,6 +333,16 @@ export type FormatDate = (
   date: Date | null | undefined,
   format: string | undefined,
 ) => string | undefined;
+
+type BottomTabBarProps = RNBottomTabBarProps & {
+  id: string;
+};
+
+type BottomTabBarComponent = (props: BottomTabBarProps) => JSX.Element | null;
+
+export type NavigationComponents = {
+  BottomTabBar?: BottomTabBarComponent;
+};
 
 /**
  * All of the props used by hyperview


### PR DESCRIPTION
Untangling the exports and imports of navigation params to make them more centrally available.

Consolidating the signature of docs to always be `Document | undefined` and also standardizing the method names to all use `getDoc` instead of `getLocalDoc`