### PR TITLE
chore(hv-screen): remove loading features

### DIFF
--- a/src/elements/hv-doc/hv-doc.tsx
+++ b/src/elements/hv-doc/hv-doc.tsx
@@ -203,8 +203,22 @@ export default (props: Props) => {
     ) {
       loadUrl(props.url);
     }
+
+    // Update the element cache
+    const newBehaviorElementId = props.route?.params?.behaviorElementId;
+    const newPreloadScreen = props.route?.params?.preloadScreen;
+    const oldBehaviorElementId =
+      currentProps.current?.route?.params?.behaviorElementId;
+    const oldPreloadScreen = currentProps.current?.route?.params?.preloadScreen;
+    if (oldBehaviorElementId && newBehaviorElementId !== oldBehaviorElementId) {
+      removeElement?.(oldBehaviorElementId);
+    }
+    if (oldPreloadScreen && newPreloadScreen !== oldPreloadScreen) {
+      removeElement?.(oldPreloadScreen);
+    }
+
     currentProps.current = props;
-  }, [loadUrl, props]);
+  }, [loadUrl, props, removeElement]);
 
   const getScreenState = useCallback(
     () => ({ ...state, url: localUrl.current }),

--- a/src/elements/hv-route/hv-route.tsx
+++ b/src/elements/hv-route/hv-route.tsx
@@ -2,7 +2,6 @@ import * as Helpers from 'hyperview/src/services/dom/helpers';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as NavigatorService from 'hyperview/src/services/navigator';
 import * as Types from './types';
-import * as UrlService from 'hyperview/src/services/url';
 import {
   BackBehaviorProvider,
   useBackBehaviorContext,
@@ -14,7 +13,6 @@ import HvDoc, {
 import type {
   ListenerEvent,
   NavigationProps,
-  RouteProps,
   ScreenState,
 } from 'hyperview/src/types';
 import React, { PureComponent, useContext, useMemo } from 'react';
@@ -76,36 +74,14 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
    * Build the <HvScreen> component with injected props
    */
   Screen = (): React.ReactElement => {
-    const url = UrlService.getUrlFromHref(
-      this.props.url || this.props.entrypointUrl,
-      this.props.entrypointUrl,
-    );
-
-    // Inject the corrected url into the params and cast as correct type
-    const route: RouteProps = {
-      ...this.props.route,
-      key: this.props.route?.key || 'hv-screen',
-      name: this.props.route?.name || 'hv-screen',
-      params: {
-        ...this.props.route?.params,
-        url: url || undefined,
-      },
-    };
-
     return (
       <HvScreen
         componentRegistry={this.props.componentRegistry}
         elementErrorComponent={this.props.elementErrorComponent}
-        entrypointUrl={this.props.entrypointUrl}
-        getDoc={this.props.getDoc}
-        getElement={this.props.getElement}
         getScreenState={this.props.getScreenState}
-        navigation={this.props.navigator}
         onUpdate={this.props.onUpdate}
         onUpdateCallbacks={this.props.onUpdateCallbacks}
         reload={this.props.reload}
-        removeElement={this.props.removeElement}
-        route={route}
         setScreenState={this.props.setScreenState}
       />
     );
@@ -204,7 +180,7 @@ function HvRouteFC(props: Types.Props) {
     onRouteFocus,
     experimentalFeatures,
   } = useHyperview();
-  const { getElement, removeElement, setElement } = useElementCache();
+  const { setElement } = useElementCache();
   const { get, onUpdate } = useBackBehaviorContext();
   const { getDoc, setDoc } = useUnsafeHvDocContext() || {};
 
@@ -370,18 +346,13 @@ function HvRouteFC(props: Types.Props) {
         }) => (
           <HvRouteInner
             componentRegistry={componentRegistry}
-            doc={localGetDoc() || undefined}
             element={element}
             elementErrorComponent={elementErrorComponent}
-            entrypointUrl={entrypointUrl}
             getDoc={localGetDoc}
-            getElement={getElement}
             getScreenState={getScreenState}
-            navigator={navigator}
             onUpdate={stateOnUpdate}
             onUpdateCallbacks={onUpdateCallbacks}
             reload={reload}
-            removeElement={removeElement}
             route={props.route}
             setScreenState={setScreenState}
             url={url}

--- a/src/elements/hv-route/types.ts
+++ b/src/elements/hv-route/types.ts
@@ -1,5 +1,4 @@
 import * as Components from 'hyperview/src/services/components';
-import * as NavigatorService from 'hyperview/src/services/navigator';
 import {
   HvComponentOnUpdate,
   NavigationProps,
@@ -14,22 +13,17 @@ import type { Props as ErrorProps } from 'hyperview/src/core/components/load-err
  * The props used by inner components of hv-route
  */
 export type InnerRouteProps = {
-  url?: string;
-  navigator: NavigatorService.Navigator;
-  route?: RouteProps;
-  entrypointUrl: string;
-  onUpdate: HvComponentOnUpdate;
-  elementErrorComponent?: ComponentType<ErrorProps>;
-  getElement: (key: number) => Element | undefined;
-  removeElement: (key: number) => void;
   componentRegistry: Components.Registry;
   element?: Element;
-  doc: Document | undefined;
+  elementErrorComponent?: ComponentType<ErrorProps>;
   getDoc: () => Document | undefined;
-  setScreenState: (state: ScreenState) => void;
   getScreenState: () => ScreenState;
+  onUpdate: HvComponentOnUpdate;
   onUpdateCallbacks: OnUpdateCallbacks;
   reload: (url?: string | null) => void;
+  route?: RouteProps;
+  setScreenState: (state: ScreenState) => void;
+  url?: string;
 };
 
 /**

--- a/src/elements/hv-screen/index.js
+++ b/src/elements/hv-screen/index.js
@@ -19,19 +19,6 @@ export default class HvScreen extends React.Component {
 
   static renderElement = Render.renderElement;
 
-  getRoute = props => {
-    // The prop route is available in React Navigation v5 and above
-    if (props.route) {
-      return props.route;
-    }
-
-    // Fallback for older versions of React Navigation
-    if (props.navigation) {
-      return props.navigation.state;
-    }
-    return { params: {} };
-  };
-
   /**
    * Renders the XML doc into React components. Shows blank screen until the XML doc is available.
    */

--- a/src/elements/hv-screen/index.js
+++ b/src/elements/hv-screen/index.js
@@ -3,7 +3,6 @@ import * as Events from 'hyperview/src/services/events';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import * as Render from 'hyperview/src/services/render';
 import * as Scroll from 'hyperview/src/core/components/scroll';
-import * as Stylesheets from 'hyperview/src/services/stylesheets';
 import { createProps, createStyleProp } from 'hyperview/src/services';
 import HvElement from 'hyperview/src/core/components/hv-element';
 import { HvScreenRenderError } from './errors';
@@ -32,92 +31,6 @@ export default class HvScreen extends React.Component {
     }
     return { params: {} };
   };
-
-  componentDidMount() {
-    const { params } = this.getRoute(this.props);
-    // The screen may be rendering via a navigation from another HyperScreen.
-    // In this case, the url to load in the screen will be passed via navigation props.
-    // Otherwise, use the entrypoint URL provided as a prop to the first HyperScreen.
-    const url = params.url || this.props.entrypointUrl || null;
-
-    const preloadScreen = params.preloadScreen
-      ? this.props.getElement(params.preloadScreen)
-      : null;
-    const preloadStyles = preloadScreen
-      ? Stylesheets.createStylesheets(preloadScreen)
-      : {};
-
-    if (preloadScreen && !this.props.getScreenState().doc) {
-      this.props.setScreenState({
-        doc: preloadScreen,
-        elementError: null,
-        error: null,
-        styles: preloadStyles,
-        url,
-      });
-    } else {
-      this.props.setScreenState({
-        elementError: null,
-        error: null,
-        url,
-      });
-    }
-  }
-
-  /**
-   * Potentially updates state when navigating back to the mounted screen.
-   * If the navigation params have a different URL than the screen's URL, Update the
-   * preload screen and URL to load.
-   */
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillReceiveProps = nextProps => {
-    const oldNavigationState = this.getRoute(this.props);
-    const newNavigationState = this.getRoute(nextProps);
-
-    const newUrl = newNavigationState.params.url;
-    const oldUrl = oldNavigationState.params.url;
-    const newPreloadScreen = newNavigationState.params.preloadScreen;
-    const oldPreloadScreen = oldNavigationState.params.preloadScreen;
-    const newElementId = newNavigationState.params.behaviorElementId;
-    const oldElementId = oldNavigationState.params.behaviorElementId;
-
-    if (newPreloadScreen !== oldPreloadScreen && oldPreloadScreen) {
-      this.props.removeElement?.(oldPreloadScreen);
-    }
-
-    if (newElementId !== oldElementId && oldElementId) {
-      this.props.removeElement?.(oldElementId);
-    }
-
-    if (newUrl && newUrl !== oldUrl) {
-      const preloadScreen = newPreloadScreen
-        ? this.props.getElement(newPreloadScreen)
-        : null;
-
-      const doc = preloadScreen || this.props.getLocalDoc();
-      const styles = preloadScreen
-        ? Stylesheets.createStylesheets(preloadScreen)
-        : // eslint-disable-next-line react/no-access-state-in-setstate
-          this.props.getScreenState().styles;
-
-      this.props.setScreenState({ doc, styles, url: newUrl });
-    }
-  };
-
-  /**
-   * Clear out the preload screen associated with this screen.
-   */
-  componentWillUnmount() {
-    const { params } = this.getRoute(this.props);
-    const { behaviorElementId, preloadScreen } = params;
-
-    if (preloadScreen) {
-      this.props.removeElement?.(preloadScreen);
-    }
-    if (behaviorElementId) {
-      this.props.removeElement?.(behaviorElementId);
-    }
-  }
 
   /**
    * Renders the XML doc into React components. Shows blank screen until the XML doc is available.

--- a/src/elements/hv-screen/types.ts
+++ b/src/elements/hv-screen/types.ts
@@ -1,42 +1,21 @@
 import * as Components from 'hyperview/src/services/components';
 import type {
   HvComponentOnUpdate,
-  NavigationProvider,
   OnUpdateCallbacks,
-  RouteProps,
   ScreenState,
 } from 'hyperview/src/types';
-import { Props as HvProps } from 'hyperview/src/types';
+import { ComponentType } from 'react';
+import type { Props as ErrorProps } from 'hyperview/src/core/components/load-error';
 
 /**
  * All of the props used by hv-screen
  */
-export type Props = Omit<
-  HvProps,
-  | 'formatDate'
-  | 'refreshControl'
-  | 'navigationComponents'
-  | 'onRouteBlur'
-  | 'onRouteFocus'
-  | 'loadingScreen'
-  | 'logger'
-  | 'errorScreen'
-  | 'fetch'
-  | 'onError'
-  | 'onParseAfter'
-  | 'onParseBefore'
-  | 'url'
-> & {
-  getElement?: (id: number) => Element | undefined;
-  navigation: NavigationProvider;
+export type Props = {
   componentRegistry: Components.Registry;
+  elementErrorComponent?: ComponentType<ErrorProps>;
+  getScreenState: () => ScreenState;
   onUpdate: HvComponentOnUpdate;
   onUpdateCallbacks: OnUpdateCallbacks;
   reload: (url?: string | null) => void;
-  removeElement?: (id: number) => void;
-  route?: RouteProps;
-  url?: string;
-  getDoc: () => Document | undefined;
-  getScreenState: () => ScreenState;
   setScreenState: (state: ScreenState) => void;
 };


### PR DESCRIPTION
`hv-screen` is no longer responsible for performing loading and therefore does not need to handle the preloadScreen functionality or cache maintenance. These functions are performed by `hv-doc`. Removing all of these greatly simplifies the `hv-screen` implementation and reduces the number of props that need to be passed in.

[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1209875001265863?focus=true)