### PR TITLE
chore(exports): provide legacy types

### DIFF
--- a/src/core/components/navigator-stack/helpers.ts
+++ b/src/core/components/navigator-stack/helpers.ts
@@ -1,8 +1,19 @@
 import * as NavigatorHelpers from 'hyperview/src/services/navigator/helpers';
 import { ID_CARD, ID_MODAL } from 'hyperview/src/services/navigator/types';
-import { LOCAL_NAME, RouteProps } from 'hyperview/src/types';
+import { LOCAL_NAME } from 'hyperview/src/types';
 import type { ParamListBase } from '@react-navigation/routers';
 import { StackNavigationState } from '@react-navigation/native';
+
+// TODO: Legacy export
+// Delete
+export type LegacyRoute = {
+  key: string;
+  name: string;
+  params?: {
+    id?: string;
+    url?: string;
+  };
+};
 
 export const buildRoutesFromDom = (
   doc: Document | undefined,
@@ -10,7 +21,7 @@ export const buildRoutesFromDom = (
   navigatorId: string,
   routeParamList: Record<string, object | undefined>,
   entrypointUrl: string | undefined,
-): RouteProps[] => {
+): LegacyRoute[] => {
   const element = doc
     ? NavigatorHelpers.getNavigatorById(doc, navigatorId)
     : null;
@@ -20,9 +31,11 @@ export const buildRoutesFromDom = (
       )
     : [];
 
-  const routes: RouteProps[] = [];
-  const routeIds = state.routes.map((r: RouteProps) => r.params?.id);
-  const routeHrefs = state.routes.map((r: RouteProps) => {
+  // TODO: Legacy export
+  // Replace with RouteProps[]
+  const routes: LegacyRoute[] = [];
+  const routeIds = state.routes.map((r: LegacyRoute) => r.params?.id);
+  const routeHrefs = state.routes.map((r: LegacyRoute) => {
     return r.params?.url
       ? NavigatorHelpers.getUrlFromHref(r.params.url, entrypointUrl)
       : undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,3 +59,7 @@ export { HvBaseError } from 'hyperview/src/services/error';
 export { renderChildren, renderElement } from 'hyperview/src/services/render';
 export { createStylesheets } from 'hyperview/src/services/stylesheets';
 export { getUrlFromHref } from 'hyperview/src/services/url';
+
+// TODO: Legacy export
+// Remove and replace with RouteProps
+export type { RouteProps as Route } from 'hyperview/src/types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ export { Events, Logging, Namespaces };
 export {
   createProps,
   createStyleProp,
+  createTestProps,
   getAncestorByTagName,
   shallowCloneToRoot,
 } from 'hyperview/src/services';

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -17,3 +17,7 @@ export {
   updateRouteUrlFromState,
 } from './helpers';
 export { ANCHOR_ID_SEPARATOR, ID_CARD, ID_MODAL, KEY_MODAL } from './types';
+
+// TODO: Legacy export
+// Remove and import from 'hyperview'
+export type { NavigationComponents } from 'hyperview/src/types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -276,7 +276,9 @@ export type RouteParams = {
   url?: DOMString;
 };
 
-export type RouteProps = NavigatorRoute<string, RouteParams | undefined>;
+// TODO: Legacy export
+// Replace second param with RouteParams | undefined
+export type RouteProps = NavigatorRoute<string, RouteParams>;
 
 export type Fetch = (
   input: RequestInfo | URL,


### PR DESCRIPTION
To enable mobile code to remain unchanged, these exports are temporarily being restored. Once HV is released, these can be removed and the mobile apps can be updated to use the new signatures.

Revert [this commit](https://github.com/Instawork/hyperview/commit/161a595b1a2c7fb4c0952cd278b6e9b1fe7602f4) post-release.