### PR TITLE
chore(section-list): revert FC conversion

### DIFF
--- a/src/elements/hv-section-list/index.tsx
+++ b/src/elements/hv-section-list/index.tsx
@@ -4,6 +4,7 @@ import * as Logging from 'hyperview/src/services/logging';
 import * as Namespaces from 'hyperview/src/services/namespaces';
 import type {
   DOMString,
+  HvComponentOnUpdate,
   HvComponentOptions,
   HvComponentProps,
 } from 'hyperview/src/types';
@@ -12,14 +13,15 @@ import {
   Platform,
 } from 'react-native';
 import { LOCAL_NAME, NODE_TYPE } from 'hyperview/src/types';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { PureComponent } from 'react';
+import type { ScrollParams, State } from './types';
 import { createTestProps, getAncestorByTagName } from 'hyperview/src/services';
+import { DOMParser } from '@instawork/xmldom';
+import { Context as DocContext } from 'hyperview/src/elements/hv-doc/context';
 import type { ElementRef } from 'react';
 import HvElement from 'hyperview/src/core/components/hv-element';
 import { HyperviewContext } from 'hyperview/src/contexts/hyperview';
-import type { ScrollParams } from './types';
 import { SectionList } from 'hyperview/src/core/components/scroll';
-import { useHvDocContext } from 'hyperview/src/elements/hv-doc';
 
 const getSectionIndex = (
   sectionTitle: Element,
@@ -57,174 +59,188 @@ const getPreviousSectionTitle = (
   return getPreviousSectionTitle(previousSibling as Element, itemIndex);
 };
 
-const HvSectionList = (props: HvComponentProps) => {
-  // eslint-disable-next-line react/destructuring-assignment
-  const { element, onUpdate, options, stylesheets } = props;
-  const ref = useRef<ElementRef<typeof SectionList> | null>(null);
-  const [refreshing, setRefreshing] = useState(false);
-  const { getDoc } = useHvDocContext();
+export default class HvSectionList extends PureComponent<
+  HvComponentProps,
+  State
+> {
+  static namespaceURI = Namespaces.HYPERVIEW;
 
-  const handleScrollBehavior = useCallback(
-    (behaviorElement: Element) => {
-      const targetId:
-        | DOMString
-        | null
-        | undefined = behaviorElement?.getAttribute('target');
-      if (!targetId) {
-        Logging.warn('[behaviors/scroll]: missing "target" attribute');
-        return;
-      }
-      const doc: Document | undefined = getDoc?.();
-      const targetElement: Element | null | undefined = Dom.getElementById(
-        doc,
-        targetId,
-      );
-      if (!targetElement) {
-        return;
-      }
+  static localName = LOCAL_NAME.SECTION_LIST;
 
-      const targetElementParentList = getAncestorByTagName(
-        targetElement,
-        LOCAL_NAME.SECTION_LIST,
-      );
-      if (targetElementParentList !== element) {
-        return;
-      }
+  // TODO: Replace with "const { getDoc } = useHvDocContext();"
+  context: React.ContextType<typeof DocContext> | undefined = undefined;
 
-      // Target can either be an <item> or a child of an <item>
-      const targetListItem =
-        targetElement.localName === LOCAL_NAME.ITEM
-          ? targetElement
-          : getAncestorByTagName(targetElement, LOCAL_NAME.ITEM);
+  static contextType = DocContext;
 
-      const animated: boolean =
+  parser: DOMParser = new DOMParser();
+
+  ref: ElementRef<typeof SectionList> | null = null;
+
+  state: State = {
+    refreshing: false,
+  };
+
+  onRef = (ref: ElementRef<typeof SectionList> | null) => {
+    this.ref = ref;
+  };
+
+  onUpdate: HvComponentOnUpdate = (
+    href: DOMString | null | undefined,
+    action: DOMString | null | undefined,
+    element: Element,
+    options: HvComponentOptions,
+  ) => {
+    if (action === 'scroll' && options.behaviorElement) {
+      this.handleScrollBehavior(options.behaviorElement);
+      return;
+    }
+    this.props.onUpdate(href, action, element, options);
+  };
+
+  handleScrollBehavior = (behaviorElement: Element) => {
+    const targetId:
+      | DOMString
+      | null
+      | undefined = behaviorElement?.getAttribute('target');
+    if (!targetId) {
+      Logging.warn('[behaviors/scroll]: missing "target" attribute');
+      return;
+    }
+    const doc: Document | undefined = this.context?.getDoc();
+    const targetElement: Element | null | undefined = Dom.getElementById(
+      doc,
+      targetId,
+    );
+    if (!targetElement) {
+      return;
+    }
+
+    const targetElementParentList = getAncestorByTagName(
+      targetElement,
+      LOCAL_NAME.SECTION_LIST,
+    );
+    if (targetElementParentList !== this.props.element) {
+      return;
+    }
+
+    // Target can either be an <item> or a child of an <item>
+    const targetListItem =
+      targetElement.localName === LOCAL_NAME.ITEM
+        ? targetElement
+        : getAncestorByTagName(targetElement, LOCAL_NAME.ITEM);
+
+    const animated: boolean =
+      behaviorElement?.getAttributeNS(
+        Namespaces.HYPERVIEW_SCROLL,
+        'animated',
+      ) === 'true';
+
+    const viewOffset: number | null | undefined =
+      parseInt(
         behaviorElement?.getAttributeNS(
           Namespaces.HYPERVIEW_SCROLL,
-          'animated',
-        ) === 'true';
+          'offset',
+        ) || '',
+        10,
+      ) || undefined;
 
-      const viewOffset: number | null | undefined =
-        parseInt(
-          behaviorElement?.getAttributeNS(
-            Namespaces.HYPERVIEW_SCROLL,
-            'offset',
-          ) || '',
-          10,
-        ) || undefined;
+    const viewPosition: number | null | undefined =
+      parseFloat(
+        behaviorElement?.getAttributeNS(
+          Namespaces.HYPERVIEW_SCROLL,
+          'position',
+        ) || '',
+      ) || undefined;
 
-      const viewPosition: number | null | undefined =
-        parseFloat(
-          behaviorElement?.getAttributeNS(
-            Namespaces.HYPERVIEW_SCROLL,
-            'position',
-          ) || '',
-        ) || undefined;
+    if (!targetListItem) {
+      return;
+    }
 
-      if (!targetListItem) {
-        return;
-      }
-
-      // find index of target in section-list
-      // first, check legacy section-list format, where items are nested under a <section>
-      const targetElementParentSection = getAncestorByTagName(
-        targetElement,
+    // find index of target in section-list
+    // first, check legacy section-list format, where items are nested under a <section>
+    const targetElementParentSection = getAncestorByTagName(
+      targetElement,
+      LOCAL_NAME.SECTION,
+    );
+    if (targetElementParentSection) {
+      const sections = this.props.element.getElementsByTagNameNS(
+        Namespaces.HYPERVIEW,
         LOCAL_NAME.SECTION,
       );
-      if (targetElementParentSection) {
-        const sections = element.getElementsByTagNameNS(
-          Namespaces.HYPERVIEW,
-          LOCAL_NAME.SECTION,
-        );
-        const sectionIndex = Array.from(sections).indexOf(
-          targetElementParentSection,
-        );
-        if (sectionIndex === -1) {
-          return;
-        }
-        const itemsInSection = Array.from(
-          targetElementParentSection.getElementsByTagNameNS(
-            Namespaces.HYPERVIEW,
-            LOCAL_NAME.ITEM,
-          ),
-        );
-        const itemIndex = itemsInSection.indexOf(targetListItem);
-        if (itemIndex === -1) {
-          return;
-        }
-
-        const params: ScrollParams = {
-          animated,
-          itemIndex: itemIndex + 1,
-          sectionIndex,
-        };
-        if (typeof viewOffset === 'number') {
-          params.viewOffset = viewOffset;
-        }
-
-        if (typeof viewPosition === 'number') {
-          params.viewPosition = viewPosition;
-        }
-
-        ref.current?.scrollToLocation(params);
-      } else {
-        // eslint-disable-next-line max-len
-        // No parent section? Check new section-list format, where items are nested under the section-list
-        const items = element.getElementsByTagNameNS(
-          Namespaces.HYPERVIEW,
-          LOCAL_NAME.ITEM,
-        );
-        if (Array.from(items).indexOf(targetListItem) === -1) {
-          return;
-        }
-        const [sectionTitle, itemIndex] = getPreviousSectionTitle(
-          targetListItem,
-          1, // 1 instead of 0 as it appears itemIndex is 1-based
-        );
-        const sectionTitles = element.getElementsByTagNameNS(
-          Namespaces.HYPERVIEW,
-          LOCAL_NAME.SECTION_TITLE,
-        );
-        const sectionIndex = sectionTitle
-          ? getSectionIndex(sectionTitle, sectionTitles)
-          : 0;
-        if (sectionIndex === -1) {
-          return;
-        }
-        const params: ScrollParams = {
-          animated,
-          itemIndex,
-          sectionIndex,
-        };
-        if (viewOffset) {
-          params.viewOffset = viewOffset;
-        }
-        if (viewPosition) {
-          params.viewPosition = viewPosition;
-        }
-        ref.current?.scrollToLocation(params);
-      }
-    },
-    [element, getDoc],
-  );
-
-  const onListUpdate = useCallback(
-    (
-      href: DOMString | null | undefined,
-      action: DOMString | null | undefined,
-      el: Element,
-      opts: HvComponentOptions,
-    ) => {
-      if (action === 'scroll' && opts.behaviorElement) {
-        handleScrollBehavior(opts.behaviorElement);
+      const sectionIndex = Array.from(sections).indexOf(
+        targetElementParentSection,
+      );
+      if (sectionIndex === -1) {
         return;
       }
-      onUpdate(href, action, el, opts);
-    },
-    [handleScrollBehavior, onUpdate],
-  );
+      const itemsInSection = Array.from(
+        targetElementParentSection.getElementsByTagNameNS(
+          Namespaces.HYPERVIEW,
+          LOCAL_NAME.ITEM,
+        ),
+      );
+      const itemIndex = itemsInSection.indexOf(targetListItem);
+      if (itemIndex === -1) {
+        return;
+      }
 
-  const getStickySectionHeadersEnabled = useCallback((): boolean => {
-    const stickySectionTitles = element.getAttribute('sticky-section-titles');
+      const params: ScrollParams = {
+        animated,
+        itemIndex: itemIndex + 1,
+        sectionIndex,
+      };
+      if (typeof viewOffset === 'number') {
+        params.viewOffset = viewOffset;
+      }
+
+      if (typeof viewPosition === 'number') {
+        params.viewPosition = viewPosition;
+      }
+
+      this.ref?.scrollToLocation(params);
+    } else {
+      // eslint-disable-next-line max-len
+      // No parent section? Check new section-list format, where items are nested under the section-list
+      const items = this.props.element.getElementsByTagNameNS(
+        Namespaces.HYPERVIEW,
+        LOCAL_NAME.ITEM,
+      );
+      if (Array.from(items).indexOf(targetListItem) === -1) {
+        return;
+      }
+      const [sectionTitle, itemIndex] = getPreviousSectionTitle(
+        targetListItem,
+        1, // 1 instead of 0 as it appears itemIndex is 1-based
+      );
+      const sectionTitles = this.props.element.getElementsByTagNameNS(
+        Namespaces.HYPERVIEW,
+        LOCAL_NAME.SECTION_TITLE,
+      );
+      const sectionIndex = sectionTitle
+        ? getSectionIndex(sectionTitle, sectionTitles)
+        : 0;
+      if (sectionIndex === -1) {
+        return;
+      }
+      const params: ScrollParams = {
+        animated,
+        itemIndex,
+        sectionIndex,
+      };
+      if (viewOffset) {
+        params.viewOffset = viewOffset;
+      }
+      if (viewPosition) {
+        params.viewPosition = viewPosition;
+      }
+      this.ref?.scrollToLocation(params);
+    }
+  };
+
+  getStickySectionHeadersEnabled = (): boolean => {
+    const stickySectionTitles = this.props.element.getAttribute(
+      'sticky-section-titles',
+    );
     if (stickySectionTitles === 'true') {
       return true;
     }
@@ -239,40 +255,42 @@ const HvSectionList = (props: HvComponentProps) => {
         ios: true,
       }) || false
     );
-  }, [element]);
+  };
 
-  const refresh = useCallback(() => {
-    setRefreshing(true);
-    const path = element.getAttribute('href');
-    const action = element.getAttribute('action') || 'append';
-    const targetId = element.getAttribute('target') || null;
-    const showIndicatorIds = element.getAttribute('show-during-load') || null;
-    const hideIndicatorIds = element.getAttribute('hide-during-load') || null;
-    const delay = element.getAttribute('delay');
-    const once = element.getAttribute('once') || null;
+  refresh = () => {
+    this.setState({ refreshing: true });
+    const path = this.props.element.getAttribute('href');
+    const action = this.props.element.getAttribute('action') || 'append';
+    const targetId = this.props.element.getAttribute('target') || null;
+    const showIndicatorIds =
+      this.props.element.getAttribute('show-during-load') || null;
+    const hideIndicatorIds =
+      this.props.element.getAttribute('hide-during-load') || null;
+    const delay = this.props.element.getAttribute('delay');
+    const once = this.props.element.getAttribute('once') || null;
 
-    onUpdate(path, action, element, {
-      behaviorElement: element,
+    this.props.onUpdate(path, action, this.props.element, {
+      behaviorElement: this.props.element,
       delay,
       hideIndicatorIds,
       once,
       onEnd: () => {
-        setRefreshing(false);
+        this.setState({ refreshing: false });
       },
       showIndicatorIds,
       targetId,
     });
-  }, [element, onUpdate, setRefreshing]);
+  };
 
-  const styleAttr = element.getAttribute('style');
-  const style = styleAttr
-    ? styleAttr.split(' ').map(s => stylesheets.regular[s])
-    : null;
+  render() {
+    const styleAttr = this.props.element.getAttribute('style');
+    const style = styleAttr
+      ? styleAttr.split(' ').map(s => this.props.stylesheets.regular[s])
+      : null;
 
-  const flattened: Element[] = useMemo(() => [], []);
+    const flattened: Element[] = [];
 
-  const addNodes = useCallback(
-    (sectionElement: Element) => {
+    const addNodes = (sectionElement: Element) => {
       if (sectionElement.childNodes) {
         for (let j = 0; j < sectionElement.childNodes.length; j += 1) {
           const node = sectionElement.childNodes[j];
@@ -289,104 +307,104 @@ const HvSectionList = (props: HvComponentProps) => {
           }
         }
       }
-    },
-    [flattened],
-  );
+    };
 
-  addNodes(element);
+    addNodes(this.props.element);
 
-  let items = [];
-  let titleElement = null;
-  const sections: { data: Element[]; title: Element | null }[] = [];
+    let items = [];
+    let titleElement = null;
+    const sections: { data: Element[]; title: Element | null }[] = [];
 
-  for (let j = 0; j < flattened.length; j += 1) {
-    const sectionElement = flattened[j];
-    if (sectionElement) {
-      if (sectionElement.nodeName === LOCAL_NAME.ITEM) {
-        items.push(sectionElement);
-      } else if (sectionElement.nodeName === LOCAL_NAME.SECTION_TITLE) {
-        if (items.length > 0) {
-          sections.push({
-            data: items,
-            title: titleElement,
-          });
-          items = [];
+    for (let j = 0; j < flattened.length; j += 1) {
+      const sectionElement = flattened[j];
+      if (sectionElement) {
+        if (sectionElement.nodeName === LOCAL_NAME.ITEM) {
+          items.push(sectionElement);
+        } else if (sectionElement.nodeName === LOCAL_NAME.SECTION_TITLE) {
+          if (items.length > 0) {
+            sections.push({
+              data: items,
+              title: titleElement,
+            });
+            items = [];
+          }
+          titleElement = sectionElement;
         }
-        titleElement = sectionElement;
       }
     }
+
+    if (items.length > 0) {
+      sections.push({
+        data: items,
+        title: titleElement,
+      });
+    }
+
+    // Fix scrollbar rendering issue in iOS 13+
+    // https://github.com/facebook/react-native/issues/26610#issuecomment-539843444
+    const scrollIndicatorInsets =
+      Platform.OS === 'ios' && parseInt(Platform.Version, 10) >= 13
+        ? { right: 1 }
+        : undefined;
+
+    const { testID, accessibilityLabel } = createTestProps(this.props.element);
+
+    return (
+      <HyperviewContext.Consumer>
+        {hyperview => {
+          const RefreshControl =
+            hyperview?.refreshControl || DefaultRefreshControl;
+          const hasRefreshTrigger =
+            this.props.element.getAttribute('trigger') === 'refresh';
+          return (
+            <SectionList
+              ref={this.onRef}
+              accessibilityLabel={accessibilityLabel}
+              element={this.props.element}
+              keyboardDismissMode={Keyboard.getKeyboardDismissMode(
+                this.props.element,
+              )}
+              keyboardShouldPersistTaps={Keyboard.getKeyboardShouldPersistTaps(
+                this.props.element,
+              )}
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              keyExtractor={(item: any) => item.getAttribute('key')}
+              refreshControl={
+                hasRefreshTrigger ? (
+                  <RefreshControl
+                    onRefresh={this.refresh}
+                    refreshing={this.state.refreshing}
+                  />
+                ) : undefined
+              }
+              removeClippedSubviews={false}
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              renderItem={({ item }: any): any => (
+                <HvElement
+                  element={item as Element}
+                  onUpdate={this.onUpdate}
+                  options={this.props.options}
+                  stylesheets={this.props.stylesheets}
+                />
+              )}
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              renderSectionHeader={({ section: { title } }: any): any => (
+                <HvElement
+                  element={title as Element}
+                  onUpdate={this.onUpdate}
+                  options={this.props.options}
+                  stylesheets={this.props.stylesheets}
+                />
+              )}
+              scrollIndicatorInsets={scrollIndicatorInsets}
+              sections={sections}
+              stickySectionHeadersEnabled={this.getStickySectionHeadersEnabled()}
+              style={style}
+              testID={testID}
+            />
+          );
+        }}
+      </HyperviewContext.Consumer>
+    );
   }
-
-  if (items.length > 0) {
-    sections.push({
-      data: items,
-      title: titleElement,
-    });
-  }
-
-  // Fix scrollbar rendering issue in iOS 13+
-  // https://github.com/facebook/react-native/issues/26610#issuecomment-539843444
-  const scrollIndicatorInsets =
-    Platform.OS === 'ios' && parseInt(Platform.Version, 10) >= 13
-      ? { right: 1 }
-      : undefined;
-
-  const { testID, accessibilityLabel } = createTestProps(element);
-
-  return (
-    <HyperviewContext.Consumer>
-      {hyperview => {
-        const RefreshControl =
-          hyperview?.refreshControl || DefaultRefreshControl;
-        const hasRefreshTrigger = element.getAttribute('trigger') === 'refresh';
-        return (
-          <SectionList
-            ref={ref}
-            accessibilityLabel={accessibilityLabel}
-            element={element}
-            keyboardDismissMode={Keyboard.getKeyboardDismissMode(element)}
-            keyboardShouldPersistTaps={Keyboard.getKeyboardShouldPersistTaps(
-              element,
-            )}
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            keyExtractor={(item: any) => item.getAttribute('key')}
-            refreshControl={
-              hasRefreshTrigger ? (
-                <RefreshControl onRefresh={refresh} refreshing={refreshing} />
-              ) : undefined
-            }
-            removeClippedSubviews={false}
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            renderItem={({ item }: any): any => (
-              <HvElement
-                element={item as Element}
-                onUpdate={onListUpdate}
-                options={options}
-                stylesheets={stylesheets}
-              />
-            )}
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            renderSectionHeader={({ section: { title } }: any): any => (
-              <HvElement
-                element={title as Element}
-                onUpdate={onListUpdate}
-                options={options}
-                stylesheets={stylesheets}
-              />
-            )}
-            scrollIndicatorInsets={scrollIndicatorInsets}
-            sections={sections}
-            stickySectionHeadersEnabled={getStickySectionHeadersEnabled()}
-            style={style}
-            testID={testID}
-          />
-        );
-      }}
-    </HyperviewContext.Consumer>
-  );
-};
-
-HvSectionList.namespaceURI = Namespaces.HYPERVIEW;
-HvSectionList.localName = LOCAL_NAME.SECTION_LIST;
-
-export default HvSectionList;
+}

--- a/src/elements/hv-section-list/types.ts
+++ b/src/elements/hv-section-list/types.ts
@@ -1,3 +1,7 @@
+export type State = {
+  refreshing: boolean;
+};
+
 // https://reactnative.dev/docs/sectionlist#scrolltolocation
 export type ScrollParams = {
   animated?: boolean | undefined;


### PR DESCRIPTION
While the section-list as Functional Component works well in the demo and in many places in the mobile apps, it is failing in the profile section. After spending some time trying to debug the problem, it seemed better to postpone this FC migration for now. The other optimizations including the new context hierarchy remain.