### PR TITLE
fix(hv-doc): avoid reloads

### DIFF
--- a/src/core/components/hv-doc/index.tsx
+++ b/src/core/components/hv-doc/index.tsx
@@ -43,7 +43,7 @@ const HvDoc = (props: Props) => {
   const localUrl = useRef<string | null | undefined>(null);
   // </HACK>
 
-  const currentProps = useRef<Props>();
+  const currentUrl = useRef<string | null | undefined>(null);
 
   const [state, setState] = useState<DocState>({
     doc: null,
@@ -176,7 +176,7 @@ const HvDoc = (props: Props) => {
       loadUrl(state.loadingUrl);
     } else if (
       props.url &&
-      !currentProps.current?.url &&
+      !currentUrl.current &&
       !props.element &&
       !props.route?.params.needsSubStack
     ) {
@@ -194,14 +194,10 @@ const HvDoc = (props: Props) => {
 
   // Monitor prop changes
   useEffect(() => {
-    if (
-      props.url &&
-      currentProps.current?.url &&
-      props.url !== currentProps.current?.url
-    ) {
+    if (props.url && currentUrl.current && props.url !== currentUrl.current) {
       loadUrl(props.url);
     }
-    currentProps.current = props;
+    currentUrl.current = props.url;
   }, [loadUrl, props]);
 
   const getScreenState = useCallback(

--- a/src/core/components/hv-doc/index.tsx
+++ b/src/core/components/hv-doc/index.tsx
@@ -43,7 +43,7 @@ const HvDoc = (props: Props) => {
   const localUrl = useRef<string | null | undefined>(null);
   // </HACK>
 
-  const currentProps = useRef(props);
+  const currentProps = useRef<Props>();
 
   const [state, setState] = useState<DocState>({
     doc: null,
@@ -176,8 +176,7 @@ const HvDoc = (props: Props) => {
       loadUrl(state.loadingUrl);
     } else if (
       props.url &&
-      !state.url &&
-      props.url !== state.url &&
+      !currentProps.current?.url &&
       !props.element &&
       !props.route?.params.needsSubStack
     ) {
@@ -197,8 +196,8 @@ const HvDoc = (props: Props) => {
   useEffect(() => {
     if (
       props.url &&
-      currentProps.current.url &&
-      props.url !== currentProps.current.url
+      currentProps.current?.url &&
+      props.url !== currentProps.current?.url
     ) {
       loadUrl(props.url);
     }

--- a/src/core/components/hv-doc/index.tsx
+++ b/src/core/components/hv-doc/index.tsx
@@ -169,36 +169,27 @@ const HvDoc = (props: Props) => {
     ],
   );
 
-  // Monitor url changes
+  // Monitor prop changes
   useEffect(() => {
     if (state.loadingUrl) {
       // Handle force reload
       loadUrl(state.loadingUrl);
-    } else if (
-      props.url &&
-      !currentUrl.current &&
-      !props.element &&
-      !props.route?.params.needsSubStack
-    ) {
-      // Handle initial load
-      loadUrl(props.url);
+    } else if (props.url) {
+      if (
+        !currentUrl.current &&
+        !props.element &&
+        !props.route?.params.needsSubStack
+      ) {
+        // Handle initial load
+        loadUrl(props.url);
+      } else if (currentUrl.current && props.url !== currentUrl.current) {
+        // Handle prop change
+        loadUrl(props.url);
+      }
     }
-  }, [
-    loadUrl,
-    props.element,
-    props.route?.params.needsSubStack,
-    props.url,
-    state.url,
-    state.loadingUrl,
-  ]);
 
-  // Monitor prop changes
-  useEffect(() => {
-    if (props.url && currentUrl.current && props.url !== currentUrl.current) {
-      loadUrl(props.url);
-    }
     currentUrl.current = props.url;
-  }, [loadUrl, props]);
+  }, [loadUrl, props, state.loadingUrl]);
 
   const getScreenState = useCallback(
     () => ({ ...state, url: localUrl.current }),


### PR DESCRIPTION
`hv-doc` was causing a re-render in some cases based on the timing between the initial load and possible component redraw.
- use the ref value which is immediately updated instead of the state which is updated after the load completes https://github.com/Instawork/hyperview/commit/11c556b77d2eb36b572ea4bfed4aa50443b4bc6b
- simplify the structure of the ref to the only value currently in use https://github.com/Instawork/hyperview/commit/5083353d979d8b06bf5c00b32f84a91278f5df25
- consolidate the `useEffect` implementations https://github.com/Instawork/hyperview/commit/c2659ddcd73b8b1d0929a9ef33c70004f37d2c9a

[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1210691369249724?focus=true)