### PR TITLE
chore(behaviors): 

### DIFF
--- a/__mocks__/react-native-gesture-handler.ts
+++ b/__mocks__/react-native-gesture-handler.ts
@@ -1,1 +1,30 @@
-export default jest.fn();
+import mocks from 'react-native-gesture-handler/src/mocks';
+
+export const {
+  TouchableHighlight,
+  TouchableNativeFeedback,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  ScrollView,
+  FlatList,
+  Switch,
+  TextInput,
+  DrawerLayoutAndroid,
+  NativeViewGestureHandler,
+  TapGestureHandler,
+  ForceTouchGestureHandler,
+  LongPressGestureHandler,
+  PinchGestureHandler,
+  RotationGestureHandler,
+  FlingGestureHandler,
+  RawButton,
+  BaseButton,
+  RectButton,
+  BorderlessButton,
+  PanGestureHandler,
+  attachGestureHandler,
+  createGestureHandler,
+  dropGestureHandler,
+  updateGestureHandler,
+  flushOperations,
+} = mocks;

--- a/__mocks__/react-native-safe-area-context.ts
+++ b/__mocks__/react-native-safe-area-context.ts
@@ -1,1 +1,3 @@
-export default jest.fn();
+import mock from 'react-native-safe-area-context/jest/mock';
+
+export default jest.mock('react-native-safe-area-context', () => mock);

--- a/src/core/components/hv-root/index.test.tsx
+++ b/src/core/components/hv-root/index.test.tsx
@@ -1,0 +1,249 @@
+import { render, screen, waitFor } from '@testing-library/react-native';
+import Hyperview from '.';
+import { NavigationContainer } from '@react-navigation/native';
+import React from 'react';
+
+type FetchResponse = [string, Response];
+
+export const navigator: FetchResponse = [
+  'http://myapp.com/navigator',
+  new Response(
+    `
+     <doc xmlns="https://hyperview.org/hyperview">
+      <navigator id="root" type="stack">
+        <nav-route id="home" href="http://myapp.com/behavior-view" />
+      </navigator>
+    </doc>
+  `,
+    { status: 200 },
+  ),
+];
+
+export const navigator2: FetchResponse = [
+  'http://myapp.com/navigator2',
+  new Response(
+    `
+     <doc xmlns="https://hyperview.org/hyperview">
+      <navigator id="root" type="stack">
+        <nav-route id="home" href="http://myapp.com/view-as-behavior" />
+      </navigator>
+    </doc>
+  `,
+    { status: 200 },
+  ),
+];
+
+/**
+ * Test for a view which has two behaviors which originally caused a bug.
+ * - The first behavior shows the view mutates the dom by calling 'show' on the view.
+ * - The second behavior replaces the view by calling 'replace' on the view.
+ * - The second behavior would originallyfail because the target
+ * will have been orphaned by the first behavior.
+ * - If the behaviors included `id` attributes, the bug would not occur.
+ */
+export const behaviorView: FetchResponse = [
+  'http://myapp.com/behavior-view',
+  new Response(
+    `
+    <doc xmlns="https://hyperview.org/hyperview">
+      <screen>
+        <body>
+          <text id="behavior-view-text">Behavior View</text>
+          <view id="replacement-view">
+            <!-- This behavior immediately mutates the dom -->
+            <behavior
+              action="show"
+              trigger="load"
+              target="replacement-view"
+              once="true"
+            />
+
+            <!-- This behavior would fail because the target will have been orphaned by the first behavior. -->
+            <behavior
+              action="replace"
+              trigger="load"
+              href="http://myapp.com/replacement-1"
+              once="true"
+              delay="10"
+            />
+          </view>
+        </body>
+      </screen>
+    </doc>
+  `,
+    { status: 200 },
+  ),
+];
+
+/**
+ * Test for a view which has a behavior which mutates the dom by calling 'show' on the view.
+ * - The second behavior replaces the view by calling 'replace' on the view.
+ * - The second behavior would fail because the target
+ * will have been orphaned by the first behavior.
+ * - If the views included `id` attributes, the bug would not occur.
+ */
+export const viewAsBehavior: FetchResponse = [
+  'http://myapp.com/view-as-behavior',
+  new Response(
+    `
+    <doc xmlns="https://hyperview.org/hyperview">
+      <screen>
+        <body>
+          <text id="behavior-view-text">Behavior View</text>
+          <view id="replacement-view">
+            <!-- This behavior immediately mutates the dom -->
+            <view
+              action="show"
+              trigger="load"
+              target="replacement-view"
+              once="true"
+            />
+
+            <!-- This behavior would fail because the target will have been orphaned by the first behavior. -->
+            <view
+              action="replace"
+              trigger="load"
+              href="http://myapp.com/replacement-1"
+              once="true"
+              delay="10"
+              target="replacement-view"
+            />
+          </view>
+        </body>
+      </screen>
+    </doc>
+  `,
+    { status: 200 },
+  ),
+];
+
+/**
+ * Test content for the view which is replaced by the behavior.
+ */
+export const replacement1: FetchResponse = [
+  'http://myapp.com/replacement-1',
+  new Response(
+    `
+    <view xmlns="https://hyperview.org/hyperview" id="replacement-1">
+      <text id="replacement-1-text">Replacement 1</text>
+    </view>
+  `,
+    { status: 200 },
+  ),
+];
+
+const fetch = jest.fn().mockImplementation(async url => {
+  switch (url) {
+    case navigator[0]:
+      return navigator[1];
+    case navigator2[0]:
+      return navigator2[1];
+    case behaviorView[0]:
+      return behaviorView[1];
+    case replacement1[0]:
+      return replacement1[1];
+    case viewAsBehavior[0]:
+      return viewAsBehavior[1];
+    default:
+      return new Response('', { status: 404 });
+  }
+});
+
+const formatDate = jest.fn();
+
+describe('Hyperview', () => {
+  describe('Behaviors', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+      jest.resetAllMocks();
+    });
+
+    /**
+     * Test for a view which has two behaviors which originally caused a bug.
+     * Uses the `behaviorView` test content.
+     */
+    test('Replace behavior', async () => {
+      render(
+        <NavigationContainer>
+          <Hyperview
+            entrypointUrl={navigator[0]}
+            fetch={fetch}
+            formatDate={formatDate}
+          />
+        </NavigationContainer>,
+      );
+
+      await waitFor(
+        () => {
+          expect(fetch).toHaveBeenCalledTimes(3);
+          expect(fetch).toHaveBeenCalledWith(navigator[0], expect.anything());
+          expect(fetch).toHaveBeenCalledWith(
+            behaviorView[0],
+            expect.anything(),
+          );
+          expect(fetch).toHaveBeenCalledWith(
+            replacement1[0],
+            expect.anything(),
+          );
+          const behaviorViewText = screen.getByTestId('behavior-view-text');
+          expect(behaviorViewText).toBeOnTheScreen();
+          const replacementViewText = screen.getByTestId('replacement-1-text');
+          expect(replacementViewText).toBeOnTheScreen();
+          return true;
+        },
+        { timeout: 1000 },
+      );
+    });
+  });
+
+  /**
+   * Test for a view which has a views with behavior attributes
+   * which mutate the dom by calling 'show' on the view.
+   * - The second behavior replaces the view by calling 'replace' on the view.
+   * - The second behavior would fail because the target
+   * will have been orphaned by the first behavior.
+   */
+  describe.only('View as behavior', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+      jest.resetAllMocks();
+    });
+
+    /**
+     * Test for a view which has two behaviors which originally caused a bug.
+     * Uses the `viewAsBehavior` test content.
+     */
+    test('Replace behavior as view', async () => {
+      render(
+        <NavigationContainer>
+          <Hyperview
+            entrypointUrl={navigator2[0]}
+            fetch={fetch}
+            formatDate={formatDate}
+          />
+        </NavigationContainer>,
+      );
+
+      await waitFor(
+        () => {
+          expect(fetch).toHaveBeenCalledTimes(3);
+          expect(fetch).toHaveBeenCalledWith(navigator2[0], expect.anything());
+          expect(fetch).toHaveBeenCalledWith(
+            viewAsBehavior[0],
+            expect.anything(),
+          );
+          expect(fetch).toHaveBeenCalledWith(
+            replacement1[0],
+            expect.anything(),
+          );
+          const behaviorViewText = screen.getByTestId('behavior-view-text');
+          expect(behaviorViewText).toBeOnTheScreen();
+          const replacementViewText = screen.getByTestId('replacement-1-text');
+          expect(replacementViewText).toBeOnTheScreen();
+          return true;
+        },
+        { timeout: 1000 },
+      );
+    });
+  });
+});

--- a/src/services/dom/helpers.ts
+++ b/src/services/dom/helpers.ts
@@ -116,12 +116,35 @@ function isDoc(object: Element | Document): object is Element | Document {
   return 'getElementById' in object;
 }
 
+function getAllBehaviorTypeElements(doc: Document): Element[] {
+  // List of tags which support behavior attributes
+  const behaviorTags = [
+    'behavior',
+    'date-field',
+    'image',
+    'list',
+    'option',
+    'picker-field',
+    'section-list',
+    'switch',
+    'text',
+    'text-field',
+    'view',
+  ];
+  const behaviors: Element[] = [];
+  behaviorTags.forEach(tag => {
+    const elements = Array.from(doc.getElementsByTagName(tag));
+    behaviors.push(...elements);
+  });
+  return behaviors;
+}
+
 /**
  * Process the incoming doc before it is added to state
  * - Ensure all behaviors with an update action have an id to allow for targeting
  */
 export const processDocument = (doc: Document): Document => {
-  const behaviors = Array.from(doc.getElementsByTagName('behavior'));
+  const behaviors = getAllBehaviorTypeElements(doc);
   behaviors.forEach(behavior => {
     const action = behavior.getAttribute('action');
     const updateAction: UpdateAction = action as UpdateAction;


### PR DESCRIPTION
The original fix for white screen issues [here](https://github.com/Instawork/hyperview/pull/1068) worked by injecting an id into any `behavior` element which used an "update" action.

##Example issue##
```es6
<view
  action="replace"
  href="#fragment"
  style="button"
>
  <text style="button-label">Press me</text>
</view>
```
This code would not execute properly because the `view` element does not contain an id and none is generated. The code updates in this PR expand this functionality to include all element types which inherit `hv:behaviorAttributes`.

Using either of the following would also have resolved the issue:
```es6
<!-- id added to view -->
<view
  id="button-id"
  action="replace"
  href="#fragment"
  style="button"
>
  <text style="button-label">Press me</text>
</view>

-- OR --
<!-- behavior used inside view -->
<view id="view">
  <behavior
    id="button-id"
    action="replace"
    href="#fragment"
    style="button"
  >
  <text style="button-label">Press me</text>
</view>

```

| Before | After |
| -- | -- |
| ![before](https://github.com/user-attachments/assets/2b1f7d7e-1331-4e8b-981e-e29a3144f3df) | ![after](https://github.com/user-attachments/assets/17833cc6-7128-4346-97e3-8082294d290d) |


[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1210709652871031?focus=true)