### PR TITLE
chore(loading): do not show loading after initial fetch

### DIFF
--- a/src/elements/hv-doc/hv-doc.tsx
+++ b/src/elements/hv-doc/hv-doc.tsx
@@ -318,20 +318,14 @@ export default (props: Props) => {
     updateUrl,
   ]);
 
+  /**
+   * Don't show loading screen if the doc is already loaded
+   */
   const isLoading = useMemo(() => {
     return (
-      !!state.loadingUrl ||
-      (!state.doc &&
-        !props.route?.params?.needsSubStack &&
-        !props.hasElement &&
-        !state.loadingUrl)
+      !state.doc && !props.route?.params?.needsSubStack && !props.hasElement
     );
-  }, [
-    state.doc,
-    state.loadingUrl,
-    props.hasElement,
-    props.route?.params?.needsSubStack,
-  ]);
+  }, [state.doc, props.hasElement, props.route?.params?.needsSubStack]);
 
   if (state.error) {
     const ErrorScreen = errorScreen || LoadError;


### PR DESCRIPTION
The loading component of `hv-doc` was being shown whenever it reloaded. The loader should only show the first time and should otherwise continue showing current content until the new content is fetched.

| Before | After |
| -- | -- |
| ![before](https://github.com/user-attachments/assets/8bfeadb2-70b6-43e7-934b-558fc0c6b12a) | ![after](https://github.com/user-attachments/assets/bd4af761-801c-4cc6-8969-d5c2edc3113a) |

