### PR TITLE
chore(demo): resolve inline indicator issues

### DIFF
--- a/demo/backend/behaviors/basic/indicators/inline-indicator/index.xml.njk
+++ b/demo/backend/behaviors/basic/indicators/inline-indicator/index.xml.njk
@@ -27,7 +27,7 @@ hv_button_behavior: "back"
   {%- endcall %}
   {% call button('', attributes = {
   "action": "replace",
-  "href": "/behaviors/basic/target_sibling_fragment.xml",
+  "href": "/hyperview/public/behaviors/basic/target_sibling_fragment.xml",
   "hide-during-load": "normalLabel",
   "target": "container",
   "delay": "300",

--- a/demo/backend/behaviors/basic/indicators/inline-indicator/index.xml.njk
+++ b/demo/backend/behaviors/basic/indicators/inline-indicator/index.xml.njk
@@ -26,6 +26,7 @@ hv_button_behavior: "back"
     The button shows a spinner and alternate text during the loading.
   {%- endcall %}
   {% call button('', attributes = {
+  "id": "replace-button",
   "action": "replace",
   "href": "/hyperview/public/behaviors/basic/target_sibling_fragment.xml",
   "hide-during-load": "normalLabel",


### PR DESCRIPTION
The url was incorrect and was causing a failure to load. Also, without an id assigned to the view, it can't be found in the doc after the delay.

| Before | After |
| -- | -- |
| ![before](https://github.com/user-attachments/assets/25f69aa0-c295-4229-96a1-e7354c3dda49) | ![after](https://github.com/user-attachments/assets/982432d5-99b4-428b-bace-b9a81d246022) |


[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1210741698093693?focus=true)