### PR TITLE
chore(hv-doc): use full url comparison

### DIFF
--- a/src/elements/hv-doc/hv-doc.tsx
+++ b/src/elements/hv-doc/hv-doc.tsx
@@ -183,14 +183,18 @@ export default (props: Props) => {
       ) {
         // Handle initial load
         loadUrl(props.url);
-      } else if (currentUrl.current && props.url !== currentUrl.current) {
+      } else if (
+        currentUrl.current &&
+        UrlService.getUrlFromHref(props.url, entrypointUrl) !==
+          UrlService.getUrlFromHref(currentUrl.current, entrypointUrl)
+      ) {
         // Handle prop change
         loadUrl(props.url);
       }
     }
 
     currentUrl.current = props.url;
-  }, [loadUrl, props, state.loadingUrl]);
+  }, [entrypointUrl, loadUrl, props, state.loadingUrl]);
 
   const getScreenState = useCallback(
     () => ({ ...state, url: localUrl.current }),
@@ -216,8 +220,11 @@ export default (props: Props) => {
       if (newState.doc !== undefined) {
         localDoc.current = newState.doc;
       }
-      if (newState.url !== undefined) {
-        localUrl.current = newState.url;
+      if (newState.url !== undefined && newState.url !== null) {
+        localUrl.current = UrlService.getUrlFromHref(
+          newState.url,
+          entrypointUrl,
+        );
       }
       setState(prev => ({
         ...prev,
@@ -225,7 +232,7 @@ export default (props: Props) => {
         doc: props.hasElement ? undefined : newState.doc ?? prev.doc,
       }));
     },
-    [props.hasElement],
+    [entrypointUrl, props.hasElement],
   );
 
   const setDoc = useCallback(


### PR DESCRIPTION
HvDoc receives alternate versions of a url as either a full url or a partial which can cause unnecessary reloads. This change ensures the full url is compared in all cases to avoid reloads.

> A [separate task](https://app.asana.com/1/47184964732898/project/1205761271270033/task/1210316546014483?focus=true) exists to track the root cause of why the url is changing.

[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1210778282863683?focus=true)