### PR TITLE
chore(hv-doc): force state refresh

### DIFF
--- a/src/elements/hv-route/hv-route.tsx
+++ b/src/elements/hv-route/hv-route.tsx
@@ -70,24 +70,6 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
     );
   };
 
-  componentDidMount(): void {
-    // This legacy behavior is required to ensure the document state is updated
-    // after the initial load behaviors are applied.
-    // See: https://github.com/Instawork/hyperview/pull/1238
-    // TODO: remove this once we remove HvDoc localDoc
-
-    const needsSubStack = this.props.route?.params?.needsSubStack
-      ? this.props.route.params.needsSubStack
-      : false;
-
-    const renderElement: Element | undefined = needsSubStack
-      ? undefined
-      : this.getRenderElement();
-    if (renderElement?.localName === LOCAL_NAME.SCREEN) {
-      this.props.setScreenState({});
-    }
-  }
-
   /**
    * Build the <HvScreen> component with injected props
    */

--- a/src/elements/hv-screen/index.js
+++ b/src/elements/hv-screen/index.js
@@ -20,6 +20,15 @@ export default class HvScreen extends React.Component {
 
   static renderElement = Render.renderElement;
 
+  componentDidMount() {
+    // This legacy behavior is required to ensure the document state is updated
+    // after the initial load behaviors are applied.
+    // See: https://github.com/Instawork/hyperview/pull/1238
+    // TODO: remove this once we remove HvDoc localDoc
+
+    this.props.setScreenState({});
+  }
+
   /**
    * Renders the XML doc into React components. Shows blank screen until the XML doc is available.
    */


### PR DESCRIPTION
An issue exists where the document state can become stale in the `hv-doc` component when mutations occur without cloning the document. For example, the auto-complete component is adding a `<text-field>` element [during construction](https://github.com/Instawork/mobile/blob/ccd92c5ab5ea1c8e30546d01a3894f493b767d9a/core-mobile/src/components/hyperview-autocomplete-input/index.tsx#L65).

This problem was previously hidden by the [state refresh](https://github.com/Instawork/hyperview/blob/ffd315ab2834f061573ce7e4b2114d600455aa4d/src/core/components/hv-screen/index.js#L61-L75) in `<hv-screen>`. This temporary fix restores this functionality.

| Before | After |
| -- | -- |
| ![before](https://github.com/user-attachments/assets/8b825a8c-9cc2-487e-906a-febade1a9a70) | ![after](https://github.com/user-attachments/assets/881990d8-c221-4b9e-b1ab-b29fba917b36) |


See videos:
[before](https://github.com/user-attachments/assets/17cbb69f-8bd3-46b6-9609-11f88233c265)
[after](https://github.com/user-attachments/assets/985e3be0-1f60-4cf7-9f32-59734483e25a)


[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1210788582235847?focus=true)
