### PR TITLE
chore: remove unneeded statics and exports

### DIFF
--- a/src/elements/hv-screen/index.js
+++ b/src/elements/hv-screen/index.js
@@ -1,10 +1,7 @@
 /* eslint instawork/flow-annotate: 0 react/prop-types: 0 */
-import * as Events from 'hyperview/src/services/events';
 import * as Namespaces from 'hyperview/src/services/namespaces';
-import * as Render from 'hyperview/src/services/render';
 // eslint-disable-next-line instawork/import-components
 import * as Scroll from 'hyperview/src/components/scroll';
-import { createProps, createStyleProp } from 'hyperview/src/services';
 import HvElement from 'hyperview/src/components/hv-element';
 import { HvScreenRenderError } from './errors';
 import LoadElementError from 'hyperview/src/components/load-element-error';
@@ -12,14 +9,6 @@ import React from 'react';
 
 // eslint-disable-next-line instawork/pure-components
 export default class HvScreen extends React.Component {
-  static createProps = createProps;
-
-  static createStyleProp = createStyleProp;
-
-  static renderChildren = Render.renderChildren;
-
-  static renderElement = Render.renderElement;
-
   componentDidMount() {
     // This legacy behavior is required to ensure the document state is updated
     // after the initial load behaviors are applied.
@@ -76,6 +65,3 @@ export default class HvScreen extends React.Component {
     );
   }
 }
-
-export * from 'hyperview/src/types';
-export { Events, Namespaces };

--- a/src/hyperview.tsx
+++ b/src/hyperview.tsx
@@ -5,7 +5,6 @@ import * as Events from 'hyperview/src/services/events';
 import * as Helpers from 'hyperview/src/services/dom/helpers';
 import * as Logging from 'hyperview/src/services/logging';
 import * as NavigatorService from 'hyperview/src/services/navigator';
-import * as Render from 'hyperview/src/services/render';
 import * as Services from 'hyperview/src/services';
 import * as Stylesheets from 'hyperview/src/services/stylesheets';
 import * as Types from './types';
@@ -34,16 +33,6 @@ import { XMLSerializer } from '@instawork/xmldom';
  * Provides routing to the correct path based on the state passed in
  */
 export default class Hyperview extends PureComponent<Types.Props> {
-  static createProps = Services.createProps;
-
-  static createStyleProp = Services.createStyleProp;
-
-  static renderChildren = Render.renderChildren;
-
-  static renderChildNodes = Render.renderChildNodes;
-
-  static renderElement = Render.renderElement;
-
   behaviorRegistry: BehaviorRegistry;
 
   componentRegistry: Components.Registry;


### PR DESCRIPTION
Removing the unneeded statics and exports from `hv-screen` and the root component.

[Asana](https://app.asana.com/1/47184964732898/project/1205761271270033/task/1210535381643187?focus=true)