### PR TITLE
chore(demo): replace static access

### DIFF
--- a/demo/src/Components/BottomSheet/BottomSheet.tsx
+++ b/demo/src/Components/BottomSheet/BottomSheet.tsx
@@ -1,5 +1,5 @@
 import { Animated, LayoutChangeEvent, Modal } from 'react-native';
-import Hyperview, { Events } from 'hyperview';
+import { Events, renderChildren } from 'hyperview';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { HvComponentProps } from 'hyperview';
 import type { HvProps } from './types';
@@ -111,7 +111,7 @@ const BottomSheet = (props: HvComponentProps) => {
     };
   }, [onHyperviewEventDispatch, visible]);
 
-  const children = Hyperview.renderChildren(
+  const children = renderChildren(
     props.element,
     props.stylesheets,
     props.onUpdate,

--- a/demo/src/Components/Filter/Filter.tsx
+++ b/demo/src/Components/Filter/Filter.tsx
@@ -1,4 +1,10 @@
-import Hyperview, { Events, LOCAL_NAME, Logging, Namespaces } from 'hyperview';
+import {
+  Events,
+  LOCAL_NAME,
+  Logging,
+  Namespaces,
+  renderChildren,
+} from 'hyperview';
 import type { HvComponentProps } from 'hyperview';
 import { findElements } from '../../Helpers';
 import { useEffect } from 'react';
@@ -100,7 +106,7 @@ const Filter = (props: HvComponentProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.element]);
 
-  return (Hyperview.renderChildren(
+  return (renderChildren(
     props.element,
     props.stylesheets,
     props.onUpdate,

--- a/demo/src/Components/Map/Map.tsx
+++ b/demo/src/Components/Map/Map.tsx
@@ -1,13 +1,13 @@
 import type { AutoZoomToMarker, Coordinate, HvProps } from './types';
 import React, { useCallback, useRef } from 'react';
+import { createStyleProp, renderChildren } from 'hyperview';
 import type { ElementRef } from 'react';
 import type { HvComponentProps } from 'hyperview';
-import Hyperview from 'hyperview';
 import MapView from 'react-native-maps';
 import { namespace } from './types';
 
 const Map = (props: HvComponentProps) => {
-  const style = Hyperview.createStyleProp(
+  const style = createStyleProp(
     props.element,
     props.stylesheets,
     props.options,
@@ -81,7 +81,7 @@ const Map = (props: HvComponentProps) => {
     });
   };
 
-  const children = Hyperview.renderChildren(
+  const children = renderChildren(
     props.element,
     props.stylesheets,
     props.onUpdate,

--- a/demo/src/Components/Map/MapMarker.tsx
+++ b/demo/src/Components/Map/MapMarker.tsx
@@ -1,10 +1,10 @@
 import MapView, { MapMarker as RNMapMarker } from 'react-native-maps';
 import React, { useCallback } from 'react';
 import type { HvComponentProps } from 'hyperview';
-import Hyperview from 'hyperview';
 import type { MarkerHvProps } from './types';
 import { Platform } from 'react-native';
 import { namespace } from './types';
+import { renderChildren } from 'hyperview';
 
 const MapMarker = (props: HvComponentProps) => {
   const getAttribute = useCallback(
@@ -16,7 +16,7 @@ const MapMarker = (props: HvComponentProps) => {
     latitude: parseFloat(getAttribute('latitude') || '0'),
     longitude: parseFloat(getAttribute('longitude') || '0'),
   };
-  const children = Hyperview.renderChildren(
+  const children = renderChildren(
     props.element,
     props.stylesheets,
     props.onUpdate,

--- a/demo/src/Components/NavBack/NavBack.tsx
+++ b/demo/src/Components/NavBack/NavBack.tsx
@@ -1,7 +1,7 @@
 import type { HvComponentProps } from 'hyperview';
-import Hyperview from 'hyperview';
 import { NavigationContext } from '@react-navigation/native';
 import { findElements } from '../../Helpers';
+import { renderElement } from 'hyperview';
 import { useContext } from 'react';
 
 export const namespaceURI = 'https://hyperview.org/navigation';
@@ -25,7 +25,7 @@ const NavBack = (props: HvComponentProps) => {
   if (!element) {
     return null;
   }
-  return (Hyperview.renderElement(
+  return (renderElement(
     element,
     props.stylesheets,
     props.onUpdate,

--- a/demo/src/Components/ProgressBar/ProgressBar.tsx
+++ b/demo/src/Components/ProgressBar/ProgressBar.tsx
@@ -1,7 +1,7 @@
 import { Animated, View } from 'react-native';
 import React, { useEffect, useRef, useState } from 'react';
+import { createProps, createStyleProp } from 'hyperview';
 import type { HvComponentProps } from 'hyperview';
-import Hyperview from 'hyperview';
 
 const namespace = 'https://hyperview.org/progress-bar';
 
@@ -29,12 +29,12 @@ const ProgressBar = (props: HvComponentProps) => {
       outputRange: ['0%', '100%'],
     }),
   };
-  const containerProps = Hyperview.createProps(
+  const containerProps = createProps(
     props.element,
     props.stylesheets,
     props.options,
   );
-  const style = Hyperview.createStyleProp(props.element, props.stylesheets, {
+  const style = createStyleProp(props.element, props.stylesheets, {
     ...props.options,
     styleAttr: `${props.element.prefix}:bar-style`,
   });

--- a/demo/src/Components/SafeAreaView/SafeAreaView.tsx
+++ b/demo/src/Components/SafeAreaView/SafeAreaView.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
+import { createStyleProp, renderChildren } from 'hyperview';
 import type { HvComponentProps } from 'hyperview';
-import Hyperview from 'hyperview';
 import type { InsetsStyle } from './types';
 import { View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -34,13 +34,13 @@ const SafeAreaView = (props: HvComponentProps) => {
     props.element.getAttributeNS(namespaceURI, 'mode') || defaultMode;
   const insets =
     props.element.getAttributeNS(namespaceURI, 'insets') || defaultInsets;
-  const children = Hyperview.renderChildren(
+  const children = renderChildren(
     props.element,
     props.stylesheets,
     props.onUpdate,
     props.options,
   );
-  const extraStyle = Hyperview.createStyleProp(
+  const extraStyle = createStyleProp(
     props.element,
     props.stylesheets,
     props.options,

--- a/demo/src/Components/ScrollOpacity/ScrollOpacity.tsx
+++ b/demo/src/Components/ScrollOpacity/ScrollOpacity.tsx
@@ -1,4 +1,3 @@
-import Hyperview, { useScrollContext } from 'hyperview';
 import React, { useEffect, useRef } from 'react';
 import {
   calculateOpacity,
@@ -6,6 +5,7 @@ import {
   getRangeAttr,
   namespaceURI,
 } from './utils';
+import { createStyleProp, renderChildren, useScrollContext } from 'hyperview';
 import { Animated } from 'react-native';
 import type { HvComponentProps } from 'hyperview';
 
@@ -15,7 +15,7 @@ const ScrollOpacity = (props: HvComponentProps) => {
   const scrollRange = getRangeAttr(props.element, 'scroll-range', [0, 100]);
   const opacityRange = getRangeAttr(props.element, 'opacity-range', [0, 1]);
   const duration = getNumberAttr(props.element, 'duration', 0);
-  const style = Hyperview.createStyleProp(props.element, props.stylesheets, {
+  const style = createStyleProp(props.element, props.stylesheets, {
     ...props.options,
     styleAttr: 'style',
   });
@@ -54,7 +54,7 @@ const ScrollOpacity = (props: HvComponentProps) => {
     }).start();
   }, [duration, opacity, opacityRange, position, scrollRange]);
 
-  const children = (Hyperview.renderChildren(
+  const children = (renderChildren(
     props.element,
     props.stylesheets,
     props.onUpdate,


### PR DESCRIPTION
Replace all static references (`Hyperview.renderChildren`, etc.) from demo.

[Asana](https://app.asana.com/1/47184964732898/project/1204008699308084/task/1211107142019307?focus=true)