### PR TITLE
chore(hyper-ref): remove legacy bridge

### DIFF
--- a/src/core/hyper-ref/index.ts
+++ b/src/core/hyper-ref/index.ts
@@ -1,5 +1,0 @@
-import { createEventHandler } from 'hyperview/src/services';
-
-// TODO: Remove this once we have a proper way to import the createEventHandler
-// function from external files
-export { createEventHandler };


### PR DESCRIPTION
The path `src/core/hyper-ref` was a legacy path which existed before the code reorganization. This file was create as a temporary bridge to allow the demo and mobile clients to work without migrating. The path has been corrected in both demo and mobile apps and this legacy path can be removed.

[Asana](https://app.asana.com/1/47184964732898/project/1205761271270033/task/1210633057805216?focus=true)