### PR TITLE
chore(errors): fix component types

### DIFF
--- a/src/components/load-element-error/index.tsx
+++ b/src/components/load-element-error/index.tsx
@@ -1,9 +1,9 @@
 import { SafeAreaView, Text, TouchableOpacity, View } from 'react-native';
-import type { Props } from './types';
+import type { ElementErrorComponentProps } from 'hyperview/src/types';
 import React from 'react';
 import styles from './styles';
 
-const LoadElementError = (props: Props) => {
+const LoadElementError = (props: ElementErrorComponentProps) => {
   const getError = () => {
     if (__DEV__) {
       return `${props.error.name}: ${props.error.message}`;

--- a/src/components/load-element-error/types.ts
+++ b/src/components/load-element-error/types.ts
@@ -1,5 +1,0 @@
-export type Props = {
-  error: Error;
-  onPressReload: () => void;
-  onPressClose: () => void;
-};

--- a/src/components/load-error/index.ts
+++ b/src/components/load-error/index.ts
@@ -1,2 +1,1 @@
 export { default } from './load-error';
-export type { Props } from './types';

--- a/src/components/load-error/load-error.tsx
+++ b/src/components/load-error/load-error.tsx
@@ -1,11 +1,11 @@
 import * as Dom from 'hyperview/src/services/dom';
 import React, { PureComponent } from 'react';
 import { SafeAreaView, Text, TouchableOpacity, View } from 'react-native';
-import type { Props } from './types';
+import type { ErrorScreenProps } from 'hyperview/src/types';
 import WebView from 'hyperview/src/components/web-view';
 import styles from './styles';
 
-export default class LoadError extends PureComponent<Props> {
+export default class LoadError extends PureComponent<ErrorScreenProps> {
   getHTML = (): string | null | undefined => {
     if (
       !__DEV__ ||

--- a/src/components/load-error/types.ts
+++ b/src/components/load-error/types.ts
@@ -1,6 +1,0 @@
-export type Props = {
-  back: () => void;
-  error: Error | null | undefined;
-  onPressReload: () => void;
-  onPressViewDetails: (uri: string) => void;
-};

--- a/src/elements/hv-route/types.ts
+++ b/src/elements/hv-route/types.ts
@@ -1,5 +1,6 @@
 import * as Components from 'hyperview/src/services/components';
-import {
+import type {
+  ElementErrorComponentProps,
   HvComponentOnUpdate,
   NavigationProps,
   OnUpdateCallbacks,
@@ -7,7 +8,6 @@ import {
   ScreenState,
 } from 'hyperview/src/types';
 import { ComponentType } from 'react';
-import type { Props as ErrorProps } from 'hyperview/src/components/load-error';
 
 /**
  * The props used by inner components of hv-route
@@ -15,7 +15,7 @@ import type { Props as ErrorProps } from 'hyperview/src/components/load-error';
 export type InnerRouteProps = {
   componentRegistry: Components.Registry;
   element?: Element;
-  elementErrorComponent?: ComponentType<ErrorProps>;
+  elementErrorComponent?: ComponentType<ElementErrorComponentProps>;
   getDoc: () => Document | undefined;
   getScreenState: () => ScreenState;
   onUpdate: HvComponentOnUpdate;

--- a/src/elements/hv-screen/types.ts
+++ b/src/elements/hv-screen/types.ts
@@ -1,18 +1,18 @@
 import * as Components from 'hyperview/src/services/components';
 import type {
+  ElementErrorComponentProps,
   HvComponentOnUpdate,
   OnUpdateCallbacks,
   ScreenState,
 } from 'hyperview/src/types';
 import { ComponentType } from 'react';
-import type { Props as ErrorProps } from 'hyperview/src/components/load-error';
 
 /**
  * All of the props used by hv-screen
  */
 export type Props = {
   componentRegistry: Components.Registry;
-  elementErrorComponent?: ComponentType<ErrorProps>;
+  elementErrorComponent?: ComponentType<ElementErrorComponentProps>;
   getScreenState: () => ScreenState;
   onUpdate: HvComponentOnUpdate;
   onUpdateCallbacks: OnUpdateCallbacks;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ export { default } from './hyperview';
  */
 export type {
   DOMString,
+  ElementErrorComponentProps,
+  ErrorScreenProps,
   ExperimentalFeatures,
   HvBehavior,
   HvComponent,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,6 @@ import type {
   Route as NavigatorRoute,
 } from '@react-navigation/native';
 import React, { ComponentType } from 'react';
-import type { Props as ErrorProps } from 'hyperview/src/components/load-error';
 import type { Props as LoadingProps } from 'hyperview/src/components/loading';
 import type { BottomTabBarProps as RNBottomTabBarProps } from '@react-navigation/bottom-tabs';
 import type { RefreshControlProps } from 'react-native';
@@ -336,6 +335,19 @@ export type ScreenState = {
   url?: string | null;
 };
 
+export type ElementErrorComponentProps = {
+  error: Error;
+  onPressReload: () => void;
+  onPressClose: () => void;
+};
+
+export type ErrorScreenProps = {
+  back: () => void;
+  error: Error | null | undefined;
+  onPressReload: () => void;
+  onPressViewDetails: (uri: string) => void;
+};
+
 export type ExperimentalFeatures = {
   // Delay the mutation of the navigation state until after the screen has been rendered
   // This is intended to improve the performance of navigation actions
@@ -363,9 +375,9 @@ export type NavigationComponents = {
 export type Props = {
   behaviors?: HvBehavior[];
   components?: HvComponent[];
-  elementErrorComponent?: ComponentType<ErrorProps>;
+  elementErrorComponent?: ComponentType<ElementErrorComponentProps>;
   entrypointUrl: string;
-  errorScreen?: ComponentType<ErrorProps>;
+  errorScreen?: ComponentType<ErrorScreenProps>;
   experimentalFeatures?: ExperimentalFeatures;
   fetch: Fetch;
   formatDate: FormatDate;


### PR DESCRIPTION
There was a mismatch of the type being passed for the `elementErrorComponent`.

- moved the types into src/types and improved names https://github.com/Instawork/hyperview/commit/48396b326e12290f809f4b2b542a8b6f9a293322
- update the default `load-error` and `load-element-error` components to use the new types https://github.com/Instawork/hyperview/commit/86029dec98b3044837d6296ec7698a79449b2905
- update the internal references to the new types https://github.com/Instawork/hyperview/commit/a4a7f3ae3d8b3c1464a1ed74f2b887ba865d26c6

[Asana](https://app.asana.com/1/47184964732898/project/1205761271270033/task/1211524780184717)