### PR TITLE
fix(behaviors): Use `queueMicrotask` instead of `setTimeOut`

### DIFF
--- a/src/services/behaviors/index.ts
+++ b/src/services/behaviors/index.ts
@@ -163,7 +163,9 @@ export const triggerBehaviors = (
     ) {
       handler(element);
     } else {
-      setTimeout(() => handler(element), 0);
+      // Use queueMicrotask to maintain order while avoiding blocking
+      // Microtasks execute in FIFO order before the next event loop tick
+      queueMicrotask(() => handler(element));
     }
   });
 };


### PR DESCRIPTION
Use `queueMicrotask` instead of `setTimeOut` to make sure behaviors are triggered in the order that are called

https://reactnative.dev/docs/next/global-queueMicrotask
https://developer.mozilla.org/en-US/docs/Web/API/Window/queueMicrotask