### PR TITLE
fix(ts): Resolve TypeScript errors with React 19 

### DIFF
--- a/src/components/hv-element/index.tsx
+++ b/src/components/hv-element/index.tsx
@@ -9,7 +9,7 @@ import type { HvComponentProps } from 'hyperview/src/types';
 import HyperRef from 'hyperview/src/components/hyper-ref';
 import { needsHyperRef } from './utils';
 
-export default (props: HvComponentProps): JSX.Element | null | string => {
+export default (props: HvComponentProps): React.JSX.Element | null | string => {
   // eslint-disable-next-line react/destructuring-assignment
   const { element, onUpdate, options, stylesheets } = props;
   if (!element) {

--- a/src/components/hyper-ref/hyper-ref.tsx
+++ b/src/components/hyper-ref/hyper-ref.tsx
@@ -195,7 +195,11 @@ export default class HyperRef extends PureComponent<Props, State> {
     }
   };
 
-  TouchableView = ({ children }: { children: JSX.Element }): JSX.Element => {
+  TouchableView = ({
+    children,
+  }: {
+    children: React.JSX.Element;
+  }): React.JSX.Element => {
     const behaviors = this.behaviorElements.filter(
       e =>
         PRESS_TRIGGERS.indexOf(
@@ -331,7 +335,11 @@ export default class HyperRef extends PureComponent<Props, State> {
     );
   };
 
-  ScrollableView = ({ children }: { children: JSX.Element }): JSX.Element => {
+  ScrollableView = ({
+    children,
+  }: {
+    children: React.JSX.Element;
+  }): React.JSX.Element => {
     const behaviors = this.getBehaviorElements(TRIGGERS.REFRESH);
     if (!behaviors.length) {
       return children;
@@ -357,7 +365,11 @@ export default class HyperRef extends PureComponent<Props, State> {
     );
   };
 
-  VisibilityView = ({ children }: { children: JSX.Element }): JSX.Element => {
+  VisibilityView = ({
+    children,
+  }: {
+    children: React.JSX.Element;
+  }): React.JSX.Element => {
     const behaviors = this.getBehaviorElements(TRIGGERS.VISIBLE);
     if (!behaviors.length) {
       return children;
@@ -416,7 +428,9 @@ export default class HyperRef extends PureComponent<Props, State> {
     return (
       <VisibilityView>
         <ScrollableView>
-          <TouchableView>{(children as JSX.Element) || null}</TouchableView>
+          <TouchableView>
+            {(children as React.JSX.Element) || null}
+          </TouchableView>
         </ScrollableView>
       </VisibilityView>
     );

--- a/src/components/hyper-ref/hyper-ref.tsx
+++ b/src/components/hyper-ref/hyper-ref.tsx
@@ -48,8 +48,8 @@ export default class HyperRef extends PureComponent<Props, State> {
 
   style: StyleSheet | null | undefined;
 
-  constructor(props: Props, state: State) {
-    super(props, state);
+  constructor(props: Props) {
+    super(props);
     this.updateBehaviorElements();
     this.updateStyle();
   }

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -18,7 +18,7 @@ import styles from './styles';
  * Uses styles defined on the <picker-field> element for the modal and buttons.
  * This is used on iOS only.
  */
-export default (props: Props): JSX.Element => {
+export default (props: Props): React.JSX.Element => {
   const [visible, setVisible] = useState(props.focused);
   const [height, setHeight] = useState(0);
 

--- a/src/elements/hv-date-field/index.tsx
+++ b/src/elements/hv-date-field/index.tsx
@@ -14,7 +14,7 @@ import { getNameValueFormInputValues } from 'hyperview/src/services';
  * - On iOS, pressing the field brings up a custom bottom sheet with a picker and action buttons.
  * - On Android and web, pressing the field brings up the system date picker modal.
  */
-const HvDateField = (props: HvComponentProps): JSX.Element | null => {
+const HvDateField = (props: HvComponentProps): React.JSX.Element | null => {
   /**
    * Shows the picker, defaulting to the field's value.
    * If the field is not set, use today's date in the picker.

--- a/src/elements/hv-date-field/picker/index.android.tsx
+++ b/src/elements/hv-date-field/picker/index.android.tsx
@@ -3,7 +3,7 @@ import DateTimePicker from 'hyperview/src/components/date-time-picker';
 import type { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import React from 'react';
 
-export default (props: Props): JSX.Element | null => {
+export default (props: Props): React.JSX.Element | null => {
   if (!props.focused) {
     return null;
   }

--- a/src/elements/hv-date-field/picker/index.ios.tsx
+++ b/src/elements/hv-date-field/picker/index.ios.tsx
@@ -8,7 +8,7 @@ import styles from './styles';
  * On iOS this component is rendered inline, and on Android it's rendered as a modal.
  * Thus, on iOS we need to wrap this component in our own modal for consistency.
  */
-export default (props: Props): JSX.Element | null => {
+export default (props: Props): React.JSX.Element | null => {
   if (!props.focused) {
     return null;
   }

--- a/src/elements/hv-date-field/picker/index.web.tsx
+++ b/src/elements/hv-date-field/picker/index.web.tsx
@@ -5,7 +5,7 @@ import {
 } from 'hyperview/src/elements/hv-date-field/helpers';
 import type { Props } from './types';
 
-export default (props: Props): JSX.Element => {
+export default (props: Props): React.JSX.Element => {
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {

--- a/src/elements/hv-doc/hv-doc.tsx
+++ b/src/elements/hv-doc/hv-doc.tsx
@@ -251,7 +251,7 @@ export default (props: Props) => {
     [parentDocState, setScreenState],
   );
 
-  const onUpdateCallbacksRef = useRef<OnUpdateCallbacks>();
+  const onUpdateCallbacksRef = useRef<OnUpdateCallbacks>(undefined);
 
   const onDocUpdate = useCallback(
     (

--- a/src/types.ts
+++ b/src/types.ts
@@ -363,7 +363,9 @@ type BottomTabBarProps = RNBottomTabBarProps & {
   id: string;
 };
 
-type BottomTabBarComponent = (props: BottomTabBarProps) => JSX.Element | null;
+type BottomTabBarComponent = (
+  props: BottomTabBarProps,
+) => React.JSX.Element | null;
 
 export type NavigationComponents = {
   BottomTabBar?: BottomTabBarComponent;


### PR DESCRIPTION
Resolves TypeScript errors that surface when consumers upgrade to React 19. Three categories of breaking type changes are addressed:

* Global `JSX.Element` removed — [React 19 no longer exports a global JSX namespace](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript); all JSX.Element references must be qualified as React.JSX.Element.
* Class component constructor signature — The legacy pattern of passing state as the second constructor argument (constructor(props, state)) is incompatible with React 19.
* useRef requires an explicit initial value — [React 19 makes the initial value argument required](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#useref-requires-argument).