### PR TITLE
feat: `collapsable`/`collapsable-children` attributes on view-like elements

### DIFF
--- a/demo/backend/ui/ui-elements/view/view/index.xml.njk
+++ b/demo/backend/ui/ui-elements/view/view/index.xml.njk
@@ -63,6 +63,4 @@ hv_button_behavior: "back"
       </view>
     </view>
   </view>
-
-  </view>
 {% endblock %}

--- a/demo/backend/ui/ui-elements/view/view/index.xml.njk
+++ b/demo/backend/ui/ui-elements/view/view/index.xml.njk
@@ -39,4 +39,30 @@ hv_button_behavior: "back"
     <view style="flex-child styled"/>
     <view style="flex-child styled"/>
   </view>
+  {{ description('Collapsing enabled (default)') }}
+  <view style="border" key="view-1">
+    <view key="view-2">
+      <view key="view-3">
+        <view style="border styled" key="view-4"/>
+      </view>
+    </view>
+  </view>
+  {{ description('Collapsing disabled') }}
+  <view style="border" key="view-5">
+    <view collapsable="false" key="view-6">
+      <view key="view-7">
+        <view style="border styled" key="view-8"/>
+      </view>
+    </view>
+  </view>
+  {{ description('Children collapsing disabled') }}
+  <view style="border" key="view-9">
+    <view collapsable-children="false" key="view-10">
+      <view key="view-11">
+        <view style="border styled" key="view-12"/>
+      </view>
+    </view>
+  </view>
+
+  </view>
 {% endblock %}

--- a/docs/reference_option.md
+++ b/docs/reference_option.md
@@ -77,7 +77,7 @@ If `hide="true"`, the element will not be rendered on screen. If the element or 
 | ------------------------- | -------- |
 | **true** (default), false | No       |
 
-Controls whether Android is allowed to collapse this view for rendering optimizations. Setting `collapsable="false"` prevents Android from removing this element from the native view hierarchy. Has no effect on iOS. See the [React Native docs](https://reactnative.dev/docs/view#collapsable-android) for details.
+When this element is only used to lay out its children, it may be automatically removed from the native view hierarchy as an optimization. Setting `collapsable="false"` disables this optimization and ensures the element exists in the native view hierarchy. See the [React Native docs](https://reactnative.dev/docs/view#collapsable) for details.
 
 #### `collapsable-children`
 
@@ -85,4 +85,4 @@ Controls whether Android is allowed to collapse this view for rendering optimiza
 | ------------------------- | -------- |
 | **true** (default), false | No       |
 
-Setting `collapsable-children="false"` prevents Android from collapsing the children of this element for rendering optimizations. Has no effect on iOS. See the [React Native docs](https://reactnative.dev/docs/view#collapsablechildren-android) for details.
+Setting `collapsable-children="false"` prevents the direct children of this element from being removed from the native view hierarchy, similar to setting `collapsable="false"` on each child. See the [React Native docs](https://reactnative.dev/docs/view#collapsablechildren) for details.

--- a/docs/reference_option.md
+++ b/docs/reference_option.md
@@ -34,6 +34,8 @@ A `<option>` element can appear anywhere within a `<select-single>` or `<select-
 - [`style`](#style)
 - [`id`](#id)
 - [`hide`](#hide)
+- [`collapsable`](#collapsable)
+- [`collapsable-children`](#collapsable-children)
 
 #### `value`
 
@@ -68,3 +70,19 @@ A global attribute uniquely identifying the element in the whole document.
 | **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.
+
+#### `collapsable`
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **true** (default), false | No       |
+
+Controls whether Android is allowed to collapse this view for rendering optimizations. Setting `collapsable="false"` prevents Android from removing this element from the native view hierarchy. Has no effect on iOS. See the [React Native docs](https://reactnative.dev/docs/view#collapsable-android) for details.
+
+#### `collapsable-children`
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **true** (default), false | No       |
+
+Setting `collapsable-children="false"` prevents Android from collapsing the children of this element for rendering optimizations. Has no effect on iOS. See the [React Native docs](https://reactnative.dev/docs/view#collapsablechildren-android) for details.

--- a/docs/reference_selectmultiple.md
+++ b/docs/reference_selectmultiple.md
@@ -77,7 +77,7 @@ If `hide="true"`, the element will not be rendered on screen. If the element or 
 | ------------------------- | -------- |
 | **true** (default), false | No       |
 
-Controls whether Android is allowed to collapse this view for rendering optimizations. Setting `collapsable="false"` prevents Android from removing this element from the native view hierarchy. Has no effect on iOS. See the [React Native docs](https://reactnative.dev/docs/view#collapsable-android) for details.
+When this element is only used to lay out its children, it may be automatically removed from the native view hierarchy as an optimization. Setting `collapsable="false"` disables this optimization and ensures the element exists in the native view hierarchy. See the [React Native docs](https://reactnative.dev/docs/view#collapsable) for details.
 
 #### `collapsable-children`
 
@@ -85,4 +85,4 @@ Controls whether Android is allowed to collapse this view for rendering optimiza
 | ------------------------- | -------- |
 | **true** (default), false | No       |
 
-Setting `collapsable-children="false"` prevents Android from collapsing the children of this element for rendering optimizations. Has no effect on iOS. See the [React Native docs](https://reactnative.dev/docs/view#collapsablechildren-android) for details.
+Setting `collapsable-children="false"` prevents the direct children of this element from being removed from the native view hierarchy, similar to setting `collapsable="false"` on each child. See the [React Native docs](https://reactnative.dev/docs/view#collapsablechildren) for details.

--- a/docs/reference_selectmultiple.md
+++ b/docs/reference_selectmultiple.md
@@ -36,6 +36,8 @@ A `<select-multiple>` element most often appears within a `<form>` element. Howe
 - [`style`](#style)
 - [`id`](#id)
 - [`hide`](#hide)
+- [`collapsable`](#collapsable)
+- [`collapsable-children`](#collapsable-children)
 
 #### `name`
 
@@ -68,3 +70,19 @@ A global attribute uniquely identifying the element in the whole document.
 | **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.
+
+#### `collapsable`
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **true** (default), false | No       |
+
+Controls whether Android is allowed to collapse this view for rendering optimizations. Setting `collapsable="false"` prevents Android from removing this element from the native view hierarchy. Has no effect on iOS. See the [React Native docs](https://reactnative.dev/docs/view#collapsable-android) for details.
+
+#### `collapsable-children`
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **true** (default), false | No       |
+
+Setting `collapsable-children="false"` prevents Android from collapsing the children of this element for rendering optimizations. Has no effect on iOS. See the [React Native docs](https://reactnative.dev/docs/view#collapsablechildren-android) for details.

--- a/docs/reference_selectsingle.md
+++ b/docs/reference_selectsingle.md
@@ -86,7 +86,7 @@ If `allow-deselect="true"`, the `<option>` element can be deselected.
 | ------------------------- | -------- |
 | **true** (default), false | No       |
 
-Controls whether Android is allowed to collapse this view for rendering optimizations. Setting `collapsable="false"` prevents Android from removing this element from the native view hierarchy. Has no effect on iOS. See the [React Native docs](https://reactnative.dev/docs/view#collapsable-android) for details.
+When this element is only used to lay out its children, it may be automatically removed from the native view hierarchy as an optimization. Setting `collapsable="false"` disables this optimization and ensures the element exists in the native view hierarchy. See the [React Native docs](https://reactnative.dev/docs/view#collapsable) for details.
 
 #### `collapsable-children`
 
@@ -94,4 +94,4 @@ Controls whether Android is allowed to collapse this view for rendering optimiza
 | ------------------------- | -------- |
 | **true** (default), false | No       |
 
-Setting `collapsable-children="false"` prevents Android from collapsing the children of this element for rendering optimizations. Has no effect on iOS. See the [React Native docs](https://reactnative.dev/docs/view#collapsablechildren-android) for details.
+Setting `collapsable-children="false"` prevents the direct children of this element from being removed from the native view hierarchy, similar to setting `collapsable="false"` on each child. See the [React Native docs](https://reactnative.dev/docs/view#collapsablechildren) for details.

--- a/docs/reference_selectsingle.md
+++ b/docs/reference_selectsingle.md
@@ -37,6 +37,8 @@ A `<select-single>` element most often appears within a `<form>` element. Howeve
 - [`id`](#id)
 - [`hide`](#hide)
 - [`allow-deselect`](#allow-deselect)
+- [`collapsable`](#collapsable)
+- [`collapsable-children`](#collapsable-children)
 
 #### `name`
 
@@ -77,3 +79,19 @@ If `hide="true"`, the element will not be rendered on screen. If the element or 
 | **false** (default), true | No       |
 
 If `allow-deselect="true"`, the `<option>` element can be deselected.
+
+#### `collapsable`
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **true** (default), false | No       |
+
+Controls whether Android is allowed to collapse this view for rendering optimizations. Setting `collapsable="false"` prevents Android from removing this element from the native view hierarchy. Has no effect on iOS. See the [React Native docs](https://reactnative.dev/docs/view#collapsable-android) for details.
+
+#### `collapsable-children`
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **true** (default), false | No       |
+
+Setting `collapsable-children="false"` prevents Android from collapsing the children of this element for rendering optimizations. Has no effect on iOS. See the [React Native docs](https://reactnative.dev/docs/view#collapsablechildren-android) for details.

--- a/docs/reference_view.md
+++ b/docs/reference_view.md
@@ -63,6 +63,8 @@ A `<view>` element can only appear anywhere within a `<screen>` element.
 - [`sticky`](#sticky)
 - [`keyboard-dismiss-mode`](#keyboard-dismiss-mode)
 - [`over-scroll`](#over-scroll)
+- [`collapsable`](#collapsable)
+- [`collapsable-children`](#collapsable-children)
 
 #### Behavior attributes
 
@@ -183,3 +185,19 @@ An attribute that controls the virtual keyboard behavior when the scrollable vie
 | **true** (default), false | No       |
 
 An attribute that helps disabling the "over-scroll" or "bounce" effect when reaching the beginning or end of the scrollable content. Attribute `scroll` should be set in for this to have any effect.
+
+#### `collapsable`
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **true** (default), false | No       |
+
+Controls whether Android is allowed to collapse this view for rendering optimizations. Setting `collapsable="false"` prevents Android from removing this view from the native view hierarchy, which is required when you need to measure the view or perform certain native operations. Only applies to non-scrollable views. Has no effect on iOS. See the [React Native docs](https://reactnative.dev/docs/view#collapsable-android) for details.
+
+#### `collapsable-children`
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **true** (default), false | No       |
+
+Setting `collapsable-children="false"` prevents Android from collapsing the children of this view for rendering optimizations. Has no effect on iOS. See the [React Native docs](https://reactnative.dev/docs/view#collapsablechildren-android) for details.

--- a/docs/reference_view.md
+++ b/docs/reference_view.md
@@ -192,7 +192,7 @@ An attribute that helps disabling the "over-scroll" or "bounce" effect when reac
 | ------------------------- | -------- |
 | **true** (default), false | No       |
 
-Controls whether Android is allowed to collapse this view for rendering optimizations. Setting `collapsable="false"` prevents Android from removing this view from the native view hierarchy, which is required when you need to measure the view or perform certain native operations. Only applies to non-scrollable views. Has no effect on iOS. See the [React Native docs](https://reactnative.dev/docs/view#collapsable-android) for details.
+Views that are only used to lay out their children or otherwise don't draw anything may be automatically removed from the native view hierarchy as an optimization. Setting `collapsable="false"` disables this optimization and ensures the view exists in the native view hierarchy. Only applies to the non-scrollable `<view>`. See the [React Native docs](https://reactnative.dev/docs/view#collapsable) for details.
 
 #### `collapsable-children`
 
@@ -200,4 +200,4 @@ Controls whether Android is allowed to collapse this view for rendering optimiza
 | ------------------------- | -------- |
 | **true** (default), false | No       |
 
-Setting `collapsable-children="false"` prevents Android from collapsing the children of this view for rendering optimizations. Has no effect on iOS. See the [React Native docs](https://reactnative.dev/docs/view#collapsablechildren-android) for details.
+Setting `collapsable-children="false"` prevents the direct children of this view from being removed from the native view hierarchy, similar to setting `collapsable="false"` on each child. See the [React Native docs](https://reactnative.dev/docs/view#collapsablechildren) for details.

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -486,6 +486,8 @@
     <xs:attribute name="value" type="xs:string" />
     <xs:attribute name="sticky" type="xs:boolean" />
     <xs:attribute name="scroll-to-input-offset" type="xs:nonNegativeInteger" />
+    <xs:attribute name="collapsable" type="xs:boolean" />
+    <xs:attribute name="collapsable-children" type="xs:boolean" />
     <xs:attributeGroup ref="hv:behaviorAttributes" />
     <xs:attributeGroup ref="hv:scrollAttributes" />
   </xs:attributeGroup>
@@ -1274,6 +1276,8 @@
       <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="style" type="hv:styleList" />
+      <xs:attribute name="collapsable" type="xs:boolean" />
+      <xs:attribute name="collapsable-children" type="xs:boolean" />
     </xs:complexType>
   </xs:element>
 
@@ -1285,6 +1289,8 @@
       <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
       <xs:attribute name="style" type="hv:styleList" />
+      <xs:attribute name="collapsable" type="xs:boolean" />
+      <xs:attribute name="collapsable-children" type="xs:boolean" />
     </xs:complexType>
   </xs:element>
 
@@ -1298,6 +1304,8 @@
       <xs:attribute name="style" type="hv:styleList" />
       <xs:attribute name="selected" type="xs:boolean" />
       <xs:attribute name="value" type="xs:string" />
+      <xs:attribute name="collapsable" type="xs:boolean" />
+      <xs:attribute name="collapsable-children" type="xs:boolean" />
     </xs:complexType>
   </xs:element>
 

--- a/src/elements/hv-view/index.test.tsx
+++ b/src/elements/hv-view/index.test.tsx
@@ -37,5 +37,19 @@ describe('HvView', () => {
         return true;
       });
     });
+    test('collapsable', async () => {
+      render(
+        <HyperviewMock paths={[`${__dirname}/stories/collapsable.xml`]} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('collapsable-false')).toBeOnTheScreen();
+        expect(
+          screen.getByTestId('collapsable-children-false'),
+        ).toBeOnTheScreen();
+
+        return true;
+      });
+    });
   });
 });

--- a/src/elements/hv-view/index.tsx
+++ b/src/elements/hv-view/index.tsx
@@ -80,9 +80,9 @@ export default class HvView extends PureComponent<HvComponentProps> {
       return { style };
     }
     if (Platform.OS === 'ios') {
-      return { style, testID: id };
+      return { collapsable: false, style, testID: id };
     }
-    return { accessibilityLabel: id, style };
+    return { accessibilityLabel: id, collapsable: false, style };
   };
 
   getScrollViewProps = (

--- a/src/elements/hv-view/index.tsx
+++ b/src/elements/hv-view/index.tsx
@@ -21,10 +21,13 @@ import {
   ScrollView,
 } from 'hyperview/src/components/scroll';
 import React, { PureComponent } from 'react';
+import {
+  createCollapsableProps,
+  createStyleProp,
+} from 'hyperview/src/services';
 import { ATTRIBUTES } from './types';
 import type { HvComponentProps } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
-import { createStyleProp } from 'hyperview/src/services';
 
 export default class HvView extends PureComponent<HvComponentProps> {
   static namespaceURI = Namespaces.HYPERVIEW;
@@ -253,7 +256,14 @@ export default class HvView extends PureComponent<HvComponentProps> {
       );
     }
     // TODO: Replace with <HvChildren>
-    return React.createElement(View, this.getCommonProps(), ...children);
+    return React.createElement(
+      View,
+      {
+        ...this.getCommonProps(),
+        ...createCollapsableProps(this.props.element),
+      },
+      ...children,
+    );
     /* eslint-enable react/jsx-props-no-spreading */
   };
 

--- a/src/elements/hv-view/stories/collapsable.xml
+++ b/src/elements/hv-view/stories/collapsable.xml
@@ -1,0 +1,11 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style id="container" flex="1" />
+    </styles>
+    <body style="container" id="outer">
+      <view id="collapsable-false" collapsable="false" />
+      <view id="collapsable-children-false" collapsable-children="false" />
+    </body>
+  </screen>
+</doc>

--- a/src/elements/hv-view/types.ts
+++ b/src/elements/hv-view/types.ts
@@ -26,6 +26,8 @@ export type Attributes = {
 
 export type CommonProps = {
   accessibilityLabel?: string | undefined;
+  collapsable?: boolean | undefined;
+  collapsableChildren?: boolean | undefined;
   testID?: string | undefined;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   children?: any | undefined;

--- a/src/services/index.test.ts
+++ b/src/services/index.test.ts
@@ -1,5 +1,6 @@
 import * as Stylesheets from 'hyperview/src/services/stylesheets';
 import {
+  createCollapsableProps,
   createProps,
   createTestProps,
   encodeXml,
@@ -79,6 +80,51 @@ describe('createTestProps', () => {
   });
 });
 
+describe('createCollapsableProps', () => {
+  const makeEl = (attrs: Record<string, string> = {}) => {
+    const doc = parser.parseFromString('<doc></doc>');
+    const el = doc.createElement('el');
+    Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, v));
+    return el;
+  };
+
+  it('returns empty object when neither attribute is present', () => {
+    expect(createCollapsableProps(makeEl())).toEqual({});
+  });
+
+  it('maps collapsable="true" to collapsable: true', () => {
+    expect(createCollapsableProps(makeEl({ collapsable: 'true' }))).toEqual({
+      collapsable: true,
+    });
+  });
+
+  it('maps collapsable="false" to collapsable: false', () => {
+    expect(createCollapsableProps(makeEl({ collapsable: 'false' }))).toEqual({
+      collapsable: false,
+    });
+  });
+
+  it('maps collapsable-children="true" to collapsableChildren: true', () => {
+    expect(
+      createCollapsableProps(makeEl({ 'collapsable-children': 'true' })),
+    ).toEqual({ collapsableChildren: true });
+  });
+
+  it('maps collapsable-children="false" to collapsableChildren: false', () => {
+    expect(
+      createCollapsableProps(makeEl({ 'collapsable-children': 'false' })),
+    ).toEqual({ collapsableChildren: false });
+  });
+
+  it('handles both attributes together', () => {
+    expect(
+      createCollapsableProps(
+        makeEl({ collapsable: 'false', 'collapsable-children': 'true' }),
+      ),
+    ).toEqual({ collapsable: false, collapsableChildren: true });
+  });
+});
+
 describe('createProps', () => {
   const styleSheets = Stylesheets.createStylesheets(
     parser.parseFromString('<doc></doc>'),
@@ -113,6 +159,45 @@ describe('createProps', () => {
 
     it('does not set accessibilityLabel', () => {
       expect(props).not.toHaveProperty('accessibilityLabel');
+    });
+  });
+
+  describe('collapsable attributes', () => {
+    const styleSheets2 = Stylesheets.createStylesheets(
+      parser.parseFromString('<doc></doc>'),
+    );
+    const makeEl = (attrs: Record<string, string>) => {
+      const doc = parser.parseFromString('<doc></doc>');
+      const el = doc.createElement('el');
+      Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, v));
+      return el;
+    };
+
+    it('emits collapsable: false when collapsable="false"', () => {
+      const result = createProps(
+        makeEl({ collapsable: 'false' }),
+        styleSheets2,
+        {},
+      );
+      expect(result).toHaveProperty('collapsable', false);
+    });
+
+    it('does not emit a stray collapsable-children string prop', () => {
+      const result = createProps(
+        makeEl({ 'collapsable-children': 'false' }),
+        styleSheets2,
+        {},
+      );
+      expect(result).not.toHaveProperty('collapsable-children');
+    });
+
+    it('emits collapsableChildren: true when collapsable-children="true"', () => {
+      const result = createProps(
+        makeEl({ 'collapsable-children': 'true' }),
+        styleSheets2,
+        {},
+      );
+      expect(result).toHaveProperty('collapsableChildren', true);
     });
   });
 });

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -85,6 +85,20 @@ export const createTestProps = (
   return { accessibilityLabel: id };
 };
 
+export const createCollapsableProps = (
+  element: Element,
+): { collapsable?: boolean; collapsableChildren?: boolean } => {
+  const props: { collapsable?: boolean; collapsableChildren?: boolean } = {};
+  if (element.hasAttribute('collapsable')) {
+    props.collapsable = element.getAttribute('collapsable') === 'true';
+  }
+  if (element.hasAttribute('collapsable-children')) {
+    props.collapsableChildren =
+      element.getAttribute('collapsable-children') === 'true';
+  }
+  return props;
+};
+
 export const createProps = (
   element: Element,
   stylesheets: StyleSheets,
@@ -107,7 +121,9 @@ export const createProps = (
   for (let i = 0; i < element.attributes.length; i += 1) {
     const attr = element.attributes.item(i);
     if (attr) {
-      if (numericRules.indexOf(attr.name) >= 0) {
+      if (attr.name === 'collapsable' || attr.name === 'collapsable-children') {
+        // handled by createCollapsableProps
+      } else if (numericRules.indexOf(attr.name) >= 0) {
         const intValue = parseInt(attr.value, 10);
         props[attr.name] = intValue || 0;
       } else if (booleanRules.indexOf(attr.name) >= 0) {
@@ -123,7 +139,7 @@ export const createProps = (
 
   props.style = createStyleProp(element, stylesheets, options);
   const testProps = createTestProps(element);
-  return { ...props, ...testProps };
+  return { ...props, ...testProps, ...createCollapsableProps(element) };
 };
 
 export const later = (delayMs: number): Promise<void> =>


### PR DESCRIPTION
These control the equivalent RN's `View` props, which prevents view from being collapsed when explicitly set to `false` (default to `true` when new architecture is enabled). In addition, automatically add the prop when a test ID is set (so the view remains selectable by the test automation framework).