### PR TITLE
refactor(e2e/android): [BREAKING] remove `createTestProps`

### DIFF
--- a/src/components/hyper-ref/hyper-ref.tsx
+++ b/src/components/hyper-ref/hyper-ref.tsx
@@ -19,7 +19,6 @@ import type {
 } from './types';
 import React, { PureComponent } from 'react';
 import { RefreshControl, Text, TouchableOpacity } from 'react-native';
-import { createEventHandler, createTestProps } from 'hyperview/src/services';
 import { BackBehaviorContext } from 'hyperview/src/contexts/back-behaviors';
 import HvElement from 'hyperview/src/components/hv-element';
 // eslint-disable-next-line instawork/import-components
@@ -27,6 +26,7 @@ import { ScrollView } from 'hyperview/src/components/scroll';
 import type { StyleSheet } from 'hyperview/src/types';
 import VisibilityDetectingView from './VisibilityDetectingView';
 import { XMLSerializer } from '@instawork/xmldom';
+import { createEventHandler } from 'hyperview/src/services';
 
 /**
  * Component that handles dispatching behaviors based on the appropriate
@@ -296,7 +296,7 @@ export default class HyperRef extends PureComponent<Props, State> {
     }
 
     const style = this.getStyle();
-    const { accessibilityLabel, testID } = createTestProps(this.props.element);
+    const testID = this.props.element.getAttribute('id') || undefined;
     const { onLongPress, onPress, onPressIn, onPressOut } = pressHandlers;
     const disabled = this.props.element.getAttribute('disabled') === 'true';
 
@@ -311,7 +311,6 @@ export default class HyperRef extends PureComponent<Props, State> {
       const noop = () => {};
       return (
         <Text
-          accessibilityLabel={accessibilityLabel}
           accessible={false}
           disabled={disabled}
           onLongPress={onLongPress}
@@ -340,7 +339,6 @@ export default class HyperRef extends PureComponent<Props, State> {
 
     return (
       <TouchableOpacity
-        accessibilityLabel={accessibilityLabel}
         accessible={false}
         activeOpacity={1}
         disabled={disabled}
@@ -435,7 +433,7 @@ export default class HyperRef extends PureComponent<Props, State> {
     // Only <TouchableView> applies the element's test props, and only when the element has
     // press behaviors. The wrapped component skips them in that case, so that a single node
     // carries the element's id in the native view hierarchy.
-    const skipTestProps = this.getPressBehaviorElements().length > 0;
+    const skipTestId = this.getPressBehaviorElements().length > 0;
     const children = (
       <HvElement
         element={this.props.element}
@@ -444,7 +442,7 @@ export default class HyperRef extends PureComponent<Props, State> {
           ...this.props.options,
           pressed: this.state.pressed,
           skipHref: true,
-          skipTestProps,
+          skipTestId,
         }}
         stylesheets={this.props.stylesheets}
       />

--- a/src/elements/hv-date-field/field-label/index.tsx
+++ b/src/elements/hv-date-field/field-label/index.tsx
@@ -3,7 +3,6 @@ import type { Props } from './types';
 import React from 'react';
 import type { StyleSheet } from 'hyperview/src/types';
 import { Text } from 'react-native';
-import { createTestPropsFromId } from 'hyperview/src/services';
 
 /**
  * This text label of the field. Contains logic to decide how to format the value
@@ -24,14 +23,15 @@ export default (props: Props) => {
     ? props.formatter(props.value, labelFormat || undefined)
     : placeholder || '';
   const fieldId = props.element.getAttribute('id');
-  const textProps = {
-    ...createTestPropsFromId(fieldId && `${fieldId}/field-label`),
-    ...FontScale.getFontScaleProps(props.element),
-  };
+  const testID = fieldId ? `${fieldId}/field-label` : undefined;
 
   return (
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    <Text style={labelStyles} {...textProps}>
+    <Text
+      style={labelStyles}
+      testID={testID}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...FontScale.getFontScaleProps(props.element)}
+    >
       {label}
     </Text>
   );

--- a/src/elements/hv-list/index.tsx
+++ b/src/elements/hv-list/index.tsx
@@ -13,11 +13,7 @@ import {
   Platform,
 } from 'react-native';
 import React, { useCallback, useRef, useState } from 'react';
-import {
-  createStyleProp,
-  createTestProps,
-  getAncestorByTagName,
-} from 'hyperview/src/services';
+import { createStyleProp, getAncestorByTagName } from 'hyperview/src/services';
 import { BehaviorScrollError } from 'hyperview/src/errors';
 import type { ElementRef } from 'react';
 // eslint-disable-next-line instawork/import-components
@@ -218,7 +214,7 @@ const HvList = (props: HvComponentProps) => {
       : acc;
   }, []);
 
-  const { testID, accessibilityLabel } = createTestProps(element);
+  const testID = element.getAttribute('id') || undefined;
 
   const contentContainerStyle = element.getAttribute('content-container-style')
     ? createStyleProp(element, stylesheets, {
@@ -245,7 +241,6 @@ const HvList = (props: HvComponentProps) => {
         return (
           <FlatList
             ref={ref}
-            accessibilityLabel={accessibilityLabel}
             bounces={bounces}
             contentContainerStyle={contentContainerStyle}
             data={getItems()}

--- a/src/elements/hv-picker-field/index.ios.tsx
+++ b/src/elements/hv-picker-field/index.ios.tsx
@@ -8,7 +8,6 @@ import type {
 import React, { useCallback } from 'react';
 import {
   createStyleProp,
-  createTestProps,
   getNameValueFormInputValues,
 } from 'hyperview/src/services';
 import Field from './field';
@@ -166,7 +165,7 @@ const HvPickerField = (props: HvComponentProps) => {
     ...options,
     styleAttr: 'field-text-style',
   });
-  const { testID, accessibilityLabel } = createTestProps(element);
+  const testID = element.getAttribute('id') || undefined;
   const value: DOMString | null | undefined = element.getAttribute('value');
   const placeholderTextColor:
     | DOMString
@@ -208,7 +207,7 @@ const HvPickerField = (props: HvComponentProps) => {
           options={options}
           stylesheets={stylesheets}
         >
-          <View accessibilityLabel={accessibilityLabel} testID={testID}>
+          <View testID={testID}>
             <Picker
               onValueChange={setPickerValue}
               selectedValue={getPickerValue()}

--- a/src/elements/hv-picker-field/index.tsx
+++ b/src/elements/hv-picker-field/index.tsx
@@ -8,7 +8,6 @@ import type {
 import React, { useCallback } from 'react';
 import {
   createStyleProp,
-  createTestProps,
   getNameValueFormInputValues,
 } from 'hyperview/src/services';
 import { LOCAL_NAME } from 'hyperview/src/types';
@@ -114,7 +113,7 @@ const HvPickerField = (props: HvComponentProps) => {
     ...options,
     styleAttr: 'field-text-style',
   });
-  const { testID, accessibilityLabel } = createTestProps(element);
+  const testID = element.getAttribute('id') || undefined;
   const value: DOMString | null | undefined = element.getAttribute('value');
   const placeholderTextColor:
     | DOMString
@@ -168,11 +167,7 @@ const HvPickerField = (props: HvComponentProps) => {
   }
 
   return (
-    <View
-      accessibilityLabel={accessibilityLabel}
-      style={fieldStyle}
-      testID={testID}
-    >
+    <View style={fieldStyle} testID={testID}>
       <Picker
         onBlur={onBlur}
         onFocus={onFocus}

--- a/src/elements/hv-section-list/index.tsx
+++ b/src/elements/hv-section-list/index.tsx
@@ -15,11 +15,7 @@ import {
 import { LOCAL_NAME, NODE_TYPE } from 'hyperview/src/types';
 import React, { PureComponent } from 'react';
 import type { ScrollParams, State } from './types';
-import {
-  createStyleProp,
-  createTestProps,
-  getAncestorByTagName,
-} from 'hyperview/src/services';
+import { createStyleProp, getAncestorByTagName } from 'hyperview/src/services';
 import { BehaviorScrollError } from 'hyperview/src/errors';
 import { DOMParser } from '@instawork/xmldom';
 import { Context as DocContext } from 'hyperview/src/elements/hv-doc/context';
@@ -379,7 +375,7 @@ export default class HvSectionList extends PureComponent<
         ? 'never'
         : undefined;
 
-    const { testID, accessibilityLabel } = createTestProps(this.props.element);
+    const testID = this.props.element.getAttribute('id') || undefined;
 
     return (
       <HyperviewContext.Consumer>
@@ -391,7 +387,6 @@ export default class HvSectionList extends PureComponent<
           return (
             <SectionList
               ref={this.onRef}
-              accessibilityLabel={accessibilityLabel}
               bounces={bounces}
               contentContainerStyle={contentContainerStyle}
               element={this.props.element}

--- a/src/elements/hv-spinner/index.tsx
+++ b/src/elements/hv-spinner/index.tsx
@@ -3,19 +3,12 @@ import { ActivityIndicator } from 'react-native';
 import type { HvComponentProps } from 'hyperview/src/types';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import React from 'react';
-import { createTestProps } from 'hyperview/src/services';
 
 const HvSpinner = (props: HvComponentProps) => {
   const color = props.element.getAttribute('color') || '#8d9494';
-  const { testID, accessibilityLabel } = createTestProps(props.element);
+  const testID = props.element.getAttribute('id') || undefined;
 
-  return (
-    <ActivityIndicator
-      accessibilityLabel={accessibilityLabel}
-      color={color}
-      testID={testID}
-    />
-  );
+  return <ActivityIndicator color={color} testID={testID} />;
 };
 
 HvSpinner.namespaceURI = Namespaces.HYPERVIEW;

--- a/src/elements/hv-switch/index.tsx
+++ b/src/elements/hv-switch/index.tsx
@@ -3,7 +3,6 @@ import * as Namespaces from 'hyperview/src/services/namespaces';
 import { Platform, StyleSheet, Switch } from 'react-native';
 import {
   createStyleProp,
-  createTestProps,
   getNameValueFormInputValues,
 } from 'hyperview/src/services';
 import type { ColorValue } from './style-sheet';
@@ -48,10 +47,9 @@ const HvSwitch = (props: HvComponentProps) => {
     }),
   );
 
-  const { testID, accessibilityLabel } = createTestProps(props.element);
+  const testID = props.element.getAttribute('id') || undefined;
 
   const componentProps = {
-    accessibilityLabel,
     ios_backgroundColor: unselectedStyle
       ? unselectedStyle.backgroundColor
       : null,

--- a/src/elements/hv-view/index.tsx
+++ b/src/elements/hv-view/index.tsx
@@ -24,7 +24,6 @@ import React, { PureComponent } from 'react';
 import {
   createCollapsableProps,
   createStyleProp,
-  createTestProps,
 } from 'hyperview/src/services';
 import { ATTRIBUTES } from './types';
 import type { HvComponentProps } from 'hyperview/src/types';
@@ -76,14 +75,11 @@ export default class HvView extends PureComponent<HvComponentProps> {
       this.props.stylesheets,
       this.props.options,
     ) as unknown) as ViewStyle;
-    if (!this.props.element.getAttribute('id')) {
+    const testID = this.props.element.getAttribute('id') ?? undefined;
+    if (!testID || this.props.options.skipTestId) {
       return { style };
     }
-    return {
-      ...createTestProps(this.props.element, this.props.options),
-      collapsable: false,
-      style,
-    };
+    return { collapsable: false, style, testID };
   };
 
   getScrollViewProps = (

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,6 @@ export { Events, Logging, Namespaces };
 export {
   createProps,
   createStyleProp,
-  createTestProps,
   getAncestorByTagName,
   shallowCloneToRoot,
 } from 'hyperview/src/services';

--- a/src/services/index.test.ts
+++ b/src/services/index.test.ts
@@ -2,7 +2,6 @@ import * as Stylesheets from 'hyperview/src/services/stylesheets';
 import {
   createCollapsableProps,
   createProps,
-  createTestProps,
   encodeXml,
 } from 'hyperview/src/services';
 import { DOMParser } from '@instawork/xmldom';
@@ -27,68 +26,6 @@ describe('encodeXml', () => {
     ).toEqual(
       '&lt;behavior href=&quot;https://hyperview.org/foo=bar&amp;bar=baz&quot; action=&apos;new&apos; /&gt;',
     );
-  });
-});
-
-const mockPlatform = (OS: 'android' | 'ios' | 'web') => {
-  jest.resetModules();
-  jest.doMock('react-native/Libraries/Utilities/Platform', () => ({
-    OS,
-    select: (objs: { android?: unknown; ios?: unknown; web?: unknown }) =>
-      objs[OS],
-  }));
-};
-
-describe('createTestProps', () => {
-  describe('valid cases', () => {
-    let testProps: {
-      testID?: string;
-      accessibilityLabel?: string;
-    };
-    beforeEach(() => {
-      testProps = createTestProps(createElement('myID'));
-    });
-    describe('Android', () => {
-      beforeAll(() => mockPlatform('android'));
-      it('does not set testID', () => {
-        expect(testProps).not.toHaveProperty('testID');
-      });
-
-      it('sets accessibilityLabel from id attribute', () => {
-        expect(testProps).toHaveProperty('accessibilityLabel', 'myID');
-      });
-    });
-
-    describe('iOS', () => {
-      beforeAll(() => mockPlatform('ios'));
-      it('sets testID from id attribute', () => {
-        expect(testProps).toHaveProperty('testID', 'myID');
-      });
-
-      it('does not set accessibilityLabel', () => {
-        expect(testProps).not.toHaveProperty('accessibilityLabel');
-      });
-    });
-  });
-
-  it('returns empty object if no id attribute present', () => {
-    expect(createTestProps(createElement(null))).toEqual({});
-  });
-
-  it('returns empty id attribute is empty', () => {
-    expect(createTestProps(createElement(''))).toEqual({});
-  });
-
-  it('returns empty object when skipTestProps is set', () => {
-    expect(
-      createTestProps(createElement('myID'), { skipTestProps: true }),
-    ).toEqual({});
-  });
-
-  it('returns test props when skipTestProps is not set', () => {
-    expect(
-      createTestProps(createElement('myID'), { skipTestProps: false }),
-    ).not.toEqual({});
   });
 });
 
@@ -152,26 +89,8 @@ describe('createProps', () => {
   it('sets id from id attribute', () => {
     expect(props).toHaveProperty('id', 'myID');
   });
-  describe('Android', () => {
-    beforeAll(() => mockPlatform('android'));
-    it('does not set testID', () => {
-      expect(props).not.toHaveProperty('testID');
-    });
-
-    it('sets accessibilityLabel from id attribute', () => {
-      expect(props).toHaveProperty('accessibilityLabel', 'myID');
-    });
-  });
-
-  describe('iOS', () => {
-    beforeAll(() => mockPlatform('ios'));
-    it('sets testID from id attribute', () => {
-      expect(props).toHaveProperty('testID', 'myID');
-    });
-
-    it('does not set accessibilityLabel', () => {
-      expect(props).not.toHaveProperty('accessibilityLabel');
-    });
+  it('sets testID', () => {
+    expect(props).toHaveProperty('testID', 'myID');
   });
 
   describe('collapsable attributes', () => {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,13 +1,11 @@
 import * as Xml from 'hyperview/src/services/xml';
 import { DEFAULT_PRESS_OPACITY, HV_TIMEOUT_ID_ATTR } from './types';
 import type {
-  DOMString,
   HvComponentOptions,
   StyleSheet,
   StyleSheets,
 } from 'hyperview/src/types';
 import { NODE_TYPE } from 'hyperview/src/types';
-import { Platform } from 'react-native';
 
 /**
  * This file is currently a dumping place for every functions used accross
@@ -64,46 +62,6 @@ export const createStyleProp = (
   return styleRules;
 };
 
-/**
- * Sets the given id as a test id and accessibility label
- * (for testing automation purposes).
- */
-export const createTestPropsFromId = (
-  id: DOMString | null | undefined,
-): {
-  testID?: string;
-  accessibilityLabel?: string;
-} => {
-  const testProps = {};
-  if (!id) {
-    return testProps;
-  }
-  if (Platform.OS === 'ios') {
-    return { testID: id };
-  }
-  return { accessibilityLabel: id };
-};
-
-/**
- * Sets the element's id attribute as a test id and accessibility label
- * (for testing automation purposes).
- * Returns no props when `skipTestProps` is set, which happens when an ancestor
- * component already applied them for the same element.
- */
-export const createTestProps = (
-  element: Element,
-  options?: HvComponentOptions,
-): {
-  testID?: string;
-  accessibilityLabel?: string;
-} => {
-  if (options?.skipTestProps) {
-    return {};
-  }
-
-  return createTestPropsFromId(element.getAttribute('id'));
-};
-
 export const createCollapsableProps = (
   element: Element,
 ): { collapsable?: boolean; collapsableChildren?: boolean } => {
@@ -157,8 +115,8 @@ export const createProps = (
   }
 
   props.style = createStyleProp(element, stylesheets, options);
-  const testProps = createTestProps(element, options);
-  return { ...props, ...testProps, ...createCollapsableProps(element) };
+  const testID = element.getAttribute('id') || undefined;
+  return { ...props, testID, ...createCollapsableProps(element) };
 };
 
 export const later = (delayMs: number): Promise<void> => {

--- a/src/services/render/index.tsx
+++ b/src/services/render/index.tsx
@@ -181,7 +181,7 @@ export const renderChildNodes = (
       childNodes[i] as Element,
       stylesheets,
       onUpdate,
-      { ...options, skipHref: false, skipTestProps: false },
+      { ...options, skipHref: false, skipTestId: false },
       i,
     );
     if (e) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,7 +104,7 @@ export type HvComponentOptions = {
   screenUrl?: string | object | undefined;
   selected?: boolean | null | undefined;
   skipHref?: boolean | null | undefined;
-  skipTestProps?: boolean | null | undefined;
+  skipTestId?: boolean | null | undefined;
   showIndicatorIds?: DOMString | null | undefined;
   styleAttr?: DOMString | null | undefined;
   syncId?: DOMString | null | undefined;


### PR DESCRIPTION
> [!WARNING]
> BREAKING CHANGE
> This change removes the `createTestProps` method from the public API. If you're using it, update your code before updating Hyperview. You can now just set `testID` prop directly.

Stop using `accessibilityLabel` on Android as a test ID. The origin of this hack was to work around our test automation framework, which is being fixed: both Android and iOS can use the `testID` prop consistently. This improves accessibility of apps built with Hyperview, since the accessibility label is not longer overriden by a label readable by machines only. We will revisit in a future PR the ability to set the `accessibilityLabel` via a new attribute.