### PR TITLE
fix(hyper-ref): resolve current element for on-event triggers

### DIFF
--- a/src/components/hyper-ref/hyper-ref.tsx
+++ b/src/components/hyper-ref/hyper-ref.tsx
@@ -112,8 +112,27 @@ export default class HyperRef extends PureComponent<Props, State> {
       : null;
   };
 
+  /**
+   * Returns the current version of the element in the DOM.
+   * DOM updates shallow-clone every ancestor of the mutated node, which moves the
+   * children onto the clone and orphans the original. Until React re-renders with
+   * the new node, `props.element` can be an orphan with no behavior children.
+   * Behavior elements are moved rather than cloned, so they point back to the
+   * current version of the element.
+   */
+  getCurrentElement = (): Element => {
+    if (this.props.element.parentNode) {
+      return this.props.element;
+    }
+    const attachedBehavior = this.behaviorElements.find(
+      e => e !== this.props.element && e.parentNode,
+    );
+    return (attachedBehavior?.parentNode as Element) || this.props.element;
+  };
+
   onEventDispatch = (eventName: string) => {
-    const behaviorElements = Dom.getBehaviorElements(this.props.element);
+    const element = this.getCurrentElement();
+    const behaviorElements = Dom.getBehaviorElements(element);
     const onEventBehaviors = behaviorElements.filter(e => {
       if (e.getAttribute(BEHAVIOR_ATTRIBUTES.TRIGGER) === TRIGGERS.ON_EVENT) {
         const currentAttributeEventName:
@@ -141,7 +160,7 @@ export default class HyperRef extends PureComponent<Props, State> {
         behaviorElement,
         this.props.onUpdate,
       );
-      handler(this.props.element);
+      handler(element);
 
       Logging.info(
         Logging.deferredToString(() => {

--- a/src/components/hyper-ref/index.test.tsx
+++ b/src/components/hyper-ref/index.test.tsx
@@ -1,0 +1,87 @@
+import { DOMParser } from '@instawork/xmldom';
+import HyperRef from 'hyperview/src/components/hyper-ref';
+import type { StyleSheets } from 'hyperview/src/types';
+import { shallowCloneToRoot } from 'hyperview/src/services';
+
+describe('HyperRef', () => {
+  describe('onEventDispatch', () => {
+    const stylesheets: StyleSheets = {
+      focused: {},
+      pressed: {},
+      pressedSelected: {},
+      regular: {},
+      selected: {},
+    };
+
+    /**
+     * Creates a doc with an `on-event` listener on a container element, next to a
+     * field a behavior can set a value on.
+     */
+    const createContainer = (): Element => {
+      const doc = new DOMParser().parseFromString(
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <view id="container">
+                  <text-field id="field" name="field" hide="true" />
+                  <behavior
+                    action="show"
+                    trigger="on-event"
+                    event-name="test-event"
+                    target="target-view"
+                  />
+                </view>
+              </body>
+            </screen>
+          </doc>
+        `,
+        'text/xml',
+      );
+      const [container] = Array.from(doc.getElementsByTagName('view'));
+      return container;
+    };
+
+    const createHyperRef = (element: Element, onUpdate: jest.Mock) =>
+      new HyperRef({ element, onUpdate, options: {}, stylesheets });
+
+    test('triggers matching behaviors', () => {
+      const onUpdate = jest.fn();
+      const hyperRef = createHyperRef(createContainer(), onUpdate);
+
+      hyperRef.onEventDispatch('test-event');
+
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not trigger behaviors for other events', () => {
+      const onUpdate = jest.fn();
+      const hyperRef = createHyperRef(createContainer(), onUpdate);
+
+      hyperRef.onEventDispatch('other-event');
+
+      expect(onUpdate).not.toHaveBeenCalled();
+    });
+
+    /**
+     * Updating the DOM shallow-clones every ancestor of the mutated node, which
+     * moves the children onto the clone and orphans the original. Between the
+     * update and the re-render, the listener holds the orphaned element, which no
+     * longer has any behavior children.
+     */
+    test('triggers matching behaviors when the element was orphaned by a DOM update', () => {
+      const onUpdate = jest.fn();
+      const container = createContainer();
+      const hyperRef = createHyperRef(container, onUpdate);
+      const [field] = Array.from(container.getElementsByTagName('text-field'));
+
+      shallowCloneToRoot(field);
+      expect(container.parentNode).toBeNull();
+      expect(container.firstChild).toBeNull();
+
+      hyperRef.onEventDispatch('test-event');
+
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

An `on-event` listener declared as a `<behavior>` child of an element silently stops firing after certain DOM updates.

`onEventDispatch` looks up its behaviors from `props.element`. Updating the DOM shallow-clones every ancestor of the mutated node: `shallowClone` moves the children onto the clone, and `replaceChild` orphans the original. So between a DOM update and the next React commit, `props.element` can be an orphaned node with **no behavior children at all**, and the listener finds nothing to run.

It reproduces when one press fires two behaviors — the first mutating a child of the element that owns the listener, the second dispatching the event from a microtask, before React re-renders:

```xml
<view trigger="press" action="set-value" target="hidden-field" new-value="1">
  <behavior action="dispatch-event" event-name="my-event" />
</view>

<form>
  <text-field hide="true" id="hidden-field" name="hidden-field" />
  <behavior trigger="on-event" event-name="my-event" action="replace" href="..." target="results" />
</form>
```

The `set-value` clones the `<form>`, moving the listener's `<behavior>` onto the clone. The dispatch then runs against the emptied original.

This surfaced on the new architecture: Fabric's concurrent root schedules the update rather than flushing it synchronously the way Paper's legacy root did, so the window between the mutation and the re-render is now always open. Declaring the same listener as an element with the behavior attributes on itself (`<view trigger="on-event" href="..." action="...">`) keeps working, because `getBehaviorElements` returns the element itself and attributes survive the clone — only children are moved.

## Fix

Behavior elements are moved rather than cloned, so they point back at the current version of the element. `getCurrentElement` uses them to recover it when `props.element` has been orphaned, and `onEventDispatch` uses the result for both the behavior lookup and the handler call. Passing the recovered element to the handler matters too: with no explicit `target`, `findTargetByBehavior` can't resolve anything from a detached node.

The behavior list itself is still read fresh rather than from `this.behaviorElements`, since that cache is only refreshed when `props.element` changes and would miss behaviors added or removed in the meantime.

## Testing

Added `src/components/hyper-ref/index.test.tsx`. The regression case orphans the element the way a DOM update does, then dispatches — it fails on `master` with zero calls to `onUpdate` and passes here. `yarn test` is clean.

## Notes for the reviewer

The press path has the same staleness at `handler(this.props.element)` in `TouchableView` (two call sites): with multiple press behaviors, the second one receives an element the first may already have cloned away. Left out of this PR to keep it focused — happy to follow up if you'd like it in the same change.