### PR TITLE
fix(hyper-ref): apply test props to a single element

### DIFF
--- a/src/components/hyper-ref/hyper-ref.tsx
+++ b/src/components/hyper-ref/hyper-ref.tsx
@@ -184,6 +184,16 @@ export default class HyperRef extends PureComponent<Props, State> {
     );
   };
 
+  getPressBehaviorElements = (): Element[] => {
+    return this.behaviorElements.filter(
+      e =>
+        PRESS_TRIGGERS.indexOf(
+          (e.getAttribute(BEHAVIOR_ATTRIBUTES.TRIGGER) ||
+            TRIGGERS.PRESS) as PressTrigger,
+        ) >= 0,
+    );
+  };
+
   getStyle = (): StyleSheet | null | undefined => {
     const styleAttr = this.props.element.getAttribute(
       BEHAVIOR_ATTRIBUTES.HREF_STYLE,
@@ -219,13 +229,7 @@ export default class HyperRef extends PureComponent<Props, State> {
   }: {
     children: React.JSX.Element;
   }): React.JSX.Element => {
-    const behaviors = this.behaviorElements.filter(
-      e =>
-        PRESS_TRIGGERS.indexOf(
-          (e.getAttribute(BEHAVIOR_ATTRIBUTES.TRIGGER) ||
-            TRIGGERS.PRESS) as PressTrigger,
-        ) >= 0,
-    );
+    const behaviors = this.getPressBehaviorElements();
 
     if (!behaviors.length) {
       return children;
@@ -424,6 +428,10 @@ export default class HyperRef extends PureComponent<Props, State> {
   render() {
     // Render the component based on the XML element. Depending on the applied behaviors,
     // this component will be wrapped with others to provide the necessary interaction.
+    // Only <TouchableView> applies the element's test props, and only when the element has
+    // press behaviors. The wrapped component skips them in that case, so that a single node
+    // carries the element's id in the native view hierarchy.
+    const skipTestProps = this.getPressBehaviorElements().length > 0;
     const children = (
       <HvElement
         element={this.props.element}
@@ -432,6 +440,7 @@ export default class HyperRef extends PureComponent<Props, State> {
           ...this.props.options,
           pressed: this.state.pressed,
           skipHref: true,
+          skipTestProps,
         }}
         stylesheets={this.props.stylesheets}
       />

--- a/src/elements/hv-view/index.test.tsx
+++ b/src/elements/hv-view/index.test.tsx
@@ -37,6 +37,15 @@ describe('HvView', () => {
         return true;
       });
     });
+    test('applies the id to a single element when wrapped by a hyper-ref', async () => {
+      render(<HyperviewMock paths={[`${__dirname}/stories/pressable.xml`]} />);
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('pressable')).toHaveLength(1);
+        expect(screen.getAllByTestId('loadable')).toHaveLength(1);
+        return true;
+      });
+    });
     test('collapsable', async () => {
       render(
         <HyperviewMock paths={[`${__dirname}/stories/collapsable.xml`]} />,

--- a/src/elements/hv-view/index.tsx
+++ b/src/elements/hv-view/index.tsx
@@ -24,6 +24,7 @@ import React, { PureComponent } from 'react';
 import {
   createCollapsableProps,
   createStyleProp,
+  createTestProps,
 } from 'hyperview/src/services';
 import { ATTRIBUTES } from './types';
 import type { HvComponentProps } from 'hyperview/src/types';
@@ -75,14 +76,14 @@ export default class HvView extends PureComponent<HvComponentProps> {
       this.props.stylesheets,
       this.props.options,
     ) as unknown) as ViewStyle;
-    const id = this.props.element.getAttribute('id');
-    if (!id) {
+    if (!this.props.element.getAttribute('id')) {
       return { style };
     }
-    if (Platform.OS === 'ios') {
-      return { collapsable: false, style, testID: id };
-    }
-    return { accessibilityLabel: id, collapsable: false, style };
+    return {
+      ...createTestProps(this.props.element, this.props.options),
+      collapsable: false,
+      style,
+    };
   };
 
   getScrollViewProps = (

--- a/src/elements/hv-view/stories/pressable.xml
+++ b/src/elements/hv-view/stories/pressable.xml
@@ -1,0 +1,27 @@
+<doc xmlns="https://hyperview.org/hyperview">
+  <screen>
+    <styles>
+      <style
+        id="container"
+        backgroundColor="white"
+        flex="1"
+        flexDirection="column"
+      />
+      <style
+        id="content"
+        backgroundColor="#63CB76"
+        borderRadius="16"
+        height="40"
+        width="40"
+      />
+    </styles>
+    <body style="container" id="container">
+      <view style="content" id="pressable">
+        <behavior trigger="press" action="show" target="content" />
+      </view>
+      <view style="content" id="loadable">
+        <behavior trigger="load" action="show" target="content" />
+      </view>
+    </body>
+  </screen>
+</doc>

--- a/src/services/index.test.ts
+++ b/src/services/index.test.ts
@@ -78,6 +78,18 @@ describe('createTestProps', () => {
   it('returns empty id attribute is empty', () => {
     expect(createTestProps(createElement(''))).toEqual({});
   });
+
+  it('returns empty object when skipTestProps is set', () => {
+    expect(
+      createTestProps(createElement('myID'), { skipTestProps: true }),
+    ).toEqual({});
+  });
+
+  it('returns test props when skipTestProps is not set', () => {
+    expect(
+      createTestProps(createElement('myID'), { skipTestProps: false }),
+    ).not.toEqual({});
+  });
 });
 
 describe('createCollapsableProps', () => {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -67,16 +67,19 @@ export const createStyleProp = (
 /**
  * Sets the element's id attribute as a test id and accessibility label
  * (for testing automation purposes).
+ * Returns no props when `skipTestProps` is set, which happens when an ancestor
+ * component already applied them for the same element.
  */
 export const createTestProps = (
   element: Element,
+  options?: HvComponentOptions,
 ): {
   testID?: string;
   accessibilityLabel?: string;
 } => {
   const testProps = {};
   const id: DOMString | null | undefined = element.getAttribute('id');
-  if (!id) {
+  if (!id || options?.skipTestProps) {
     return testProps;
   }
   if (Platform.OS === 'ios') {
@@ -138,7 +141,7 @@ export const createProps = (
   }
 
   props.style = createStyleProp(element, stylesheets, options);
-  const testProps = createTestProps(element);
+  const testProps = createTestProps(element, options);
   return { ...props, ...testProps, ...createCollapsableProps(element) };
 };
 

--- a/src/services/render/index.tsx
+++ b/src/services/render/index.tsx
@@ -181,7 +181,7 @@ export const renderChildNodes = (
       childNodes[i] as Element,
       stylesheets,
       onUpdate,
-      { ...options, skipHref: false },
+      { ...options, skipHref: false, skipTestProps: false },
       i,
     );
     if (e) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,7 @@ export type HvComponentOptions = {
   screenUrl?: string | object | undefined;
   selected?: boolean | null | undefined;
   skipHref?: boolean | null | undefined;
+  skipTestProps?: boolean | null | undefined;
   showIndicatorIds?: DOMString | null | undefined;
   styleAttr?: DOMString | null | undefined;
   syncId?: DOMString | null | undefined;


### PR DESCRIPTION
Elements with press behaviors were rendered with the same `id` twice: once on the `TouchableOpacity` created by `HyperRef`, and once on the component it wraps. On Android, where the `id` is applied as `accessibilityLabel`, this emits two nested native views sharing the same `content-desc`, which pushes E2E tests towards brittle XPath selectors to disambiguate them.

`HyperRef` now sets a `skipTestProps` option on the component it wraps, mirroring the existing `skipHref` option, so that only the touchable carries the `id`. The option is set only when a touchable is actually rendered, as elements whose behaviors are all non-press (`load`, `visible`, `refresh`) are not wrapped in one and would otherwise lose their `id` entirely.

`hv-view` also had its own inlined copy of the platform branch in `createTestProps`, and now calls it instead.