### PR TITLE
feat(navigation): support React Navigation 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "release:minor": "yarn version --minor",
     "release:major": "yarn version --major",
     "test:ts": "tsc",
-    "test:lint": "eslint src && prettier --check '**/*.xsd' '**/*.xml' '**/*.md' && yarn format-njk -c",
-    "test:unit": "jest --runInBand --testPathPattern src",
+    "test:lint": "eslint src test/helpers test/integration && prettier --check '**/*.xsd' '**/*.xml' '**/*.md' && yarn format-njk -c",
+    "test:unit": "jest --runInBand --testPathPattern 'src|test/integration'",
     "test:validate-xml": "find test src -name '*.xml' | xargs xmlschema-validate --schema schema/hyperview.xsd --version 1.1",
     "test": "yarn test:ts && yarn test:lint && yarn test:unit && yarn test:validate-xml"
   },

--- a/src/components/navigator-stack/helpers.test.ts
+++ b/src/components/navigator-stack/helpers.test.ts
@@ -1,8 +1,7 @@
 import * as DomErrors from 'hyperview/src/services/dom/errors';
 import { DOMParser } from '@instawork/xmldom';
-import type { ParamListBase } from '@react-navigation/routers';
-import type { StackNavigationState } from '@react-navigation/native';
 import { buildRoutesFromDom } from './helpers';
+import { createStackNavigationState } from 'hyperview/test/helpers/navigation';
 
 /**
  * Test document response
@@ -58,7 +57,7 @@ describe('buildRoutesFromDom', () => {
 
   it('should add one route', () => {
     const doc = parser.parseFromString(navDocSource);
-    const state: StackNavigationState<ParamListBase> = {
+    const state = createStackNavigationState({
       index: 0,
       key: 'key1',
       routeNames: ['route1'],
@@ -71,7 +70,7 @@ describe('buildRoutesFromDom', () => {
       ],
       stale: false,
       type: 'stack',
-    };
+    });
     const routes = buildRoutesFromDom(
       doc,
       state,
@@ -90,7 +89,7 @@ describe('buildRoutesFromDom', () => {
   it('should ignore same order route', () => {
     // When the incoming dom contains the same url as one already in state, don't change
     const doc = parser.parseFromString(navDocSource);
-    const state: StackNavigationState<ParamListBase> = {
+    const state = createStackNavigationState({
       index: 0,
       key: 'key1',
       routeNames: ['route1'],
@@ -108,7 +107,7 @@ describe('buildRoutesFromDom', () => {
       ],
       stale: false,
       type: 'stack',
-    };
+    });
     const routes = buildRoutesFromDom(
       doc,
       state,
@@ -125,7 +124,7 @@ describe('buildRoutesFromDom', () => {
 
   it('should replace out of order routes', () => {
     const doc = parser.parseFromString(navDocSource);
-    const state: StackNavigationState<ParamListBase> = {
+    const state = createStackNavigationState({
       index: 0,
       key: 'key1',
       routeNames: ['route1'],
@@ -143,7 +142,7 @@ describe('buildRoutesFromDom', () => {
       ],
       stale: false,
       type: 'stack',
-    };
+    });
     const routes = buildRoutesFromDom(
       doc,
       state,
@@ -162,7 +161,7 @@ describe('buildRoutesFromDom', () => {
     // When the incoming dom contains the same order as state but adds new ones after,
     // leave the current one intact and add a new ones
     const doc = parser.parseFromString(navDocSourceThreeRoute);
-    const state: StackNavigationState<ParamListBase> = {
+    const state = createStackNavigationState({
       index: 0,
       key: 'key1',
       routeNames: ['route1'],
@@ -180,7 +179,7 @@ describe('buildRoutesFromDom', () => {
       ],
       stale: false,
       type: 'stack',
-    };
+    });
     const routes = buildRoutesFromDom(
       doc,
       state,
@@ -199,7 +198,7 @@ describe('buildRoutesFromDom', () => {
 
   it('should change presentation to modal', () => {
     const doc = parser.parseFromString(navDocSourceModal);
-    const state: StackNavigationState<ParamListBase> = {
+    const state = createStackNavigationState({
       index: 0,
       key: 'key1',
       routeNames: ['route1'],
@@ -222,7 +221,7 @@ describe('buildRoutesFromDom', () => {
       ],
       stale: false,
       type: 'stack',
-    };
+    });
     const routes = buildRoutesFromDom(
       doc,
       state,
@@ -241,7 +240,7 @@ describe('buildRoutesFromDom', () => {
 
   it('should change presentation to card', () => {
     const doc = parser.parseFromString(navDocSourceCard);
-    const state: StackNavigationState<ParamListBase> = {
+    const state = createStackNavigationState({
       index: 0,
       key: 'key1',
       routeNames: ['route1'],
@@ -264,7 +263,7 @@ describe('buildRoutesFromDom', () => {
       ],
       stale: false,
       type: 'stack',
-    };
+    });
     const routes = buildRoutesFromDom(
       doc,
       state,

--- a/src/components/navigator-stack/helpers.ts
+++ b/src/components/navigator-stack/helpers.ts
@@ -1,5 +1,4 @@
-import * as NavigatorHelpers from 'hyperview/src/services/navigator/helpers';
-import { ID_CARD, ID_MODAL } from 'hyperview/src/services/navigator/types';
+import * as NavigatorService from 'hyperview/src/services/navigator';
 import { LOCAL_NAME } from 'hyperview/src/types';
 import type { ParamListBase } from '@react-navigation/routers';
 import type { RouteProps } from 'hyperview/src/types';
@@ -13,10 +12,10 @@ export const buildRoutesFromDom = (
   entrypointUrl: string | undefined,
 ): RouteProps[] => {
   const element = doc
-    ? NavigatorHelpers.getNavigatorById(doc, navigatorId)
+    ? NavigatorService.getNavigatorById(doc, navigatorId)
     : null;
   const elementRoutes = element
-    ? NavigatorHelpers.getChildElements(element).filter(
+    ? NavigatorService.getChildElements(element).filter(
         e => e.localName === LOCAL_NAME.NAV_ROUTE,
       )
     : [];
@@ -25,7 +24,7 @@ export const buildRoutesFromDom = (
   const routeIds = state.routes.map((r: RouteProps) => r.params?.id);
   const routeHrefs = state.routes.map((r: RouteProps) => {
     return r.params?.url
-      ? NavigatorHelpers.getUrlFromHref(r.params.url, entrypointUrl)
+      ? NavigatorService.getUrlFromHref(r.params.url, entrypointUrl)
       : undefined;
   });
 
@@ -38,7 +37,7 @@ export const buildRoutesFromDom = (
     if (id) {
       const existingIndex = href
         ? routeHrefs.indexOf(
-            NavigatorHelpers.getUrlFromHref(href, entrypointUrl),
+            NavigatorService.getUrlFromHref(href, entrypointUrl),
           )
         : routeIds.indexOf(id);
       // Ensure each existing route is in the same order and hasn't been disrupted
@@ -49,10 +48,10 @@ export const buildRoutesFromDom = (
         existingIndex > -1 &&
         !sequenceBroken &&
         // Ensure the presentation matches for dynamic screens
-        (!NavigatorHelpers.isDynamicRoute(state.routes[existingIndex].name) ||
+        (!NavigatorService.isDynamicRoute(state.routes[existingIndex].name) ||
           (isModal
-            ? state.routes[existingIndex].name === ID_MODAL
-            : state.routes[existingIndex].name === ID_CARD))
+            ? state.routes[existingIndex].name === NavigatorService.ID_MODAL
+            : state.routes[existingIndex].name === NavigatorService.ID_CARD))
       ) {
         routes.push(state.routes[existingIndex]);
       } else {

--- a/src/components/navigator-stack/index.tsx
+++ b/src/components/navigator-stack/index.tsx
@@ -1,7 +1,11 @@
 import * as CustomStackRouter from 'hyperview/src/components/navigator-stack/router';
 import * as React from 'react';
-import type { NavigationState, ParamListBase } from '@react-navigation/routers';
-import type { Props, StackOptions } from './types';
+import type {
+  CompatibleStackViewProps,
+  NavigationBuilderWithDescribe,
+  Props,
+  StackOptions,
+} from './types';
 import {
   StackActionHelpers,
   StackNavigationState,
@@ -13,20 +17,22 @@ import {
   StackNavigationOptions,
   StackView,
 } from '@react-navigation/stack';
-import type { EventMapBase } from '@react-navigation/native';
+import {
+  isReactNavigation7,
+  useCompatibleLocale,
+} from 'hyperview/src/services/navigator/helpers';
+import type { ParamListBase } from '@react-navigation/routers';
 import { useHvDocContext } from 'hyperview/src/elements/hv-doc';
 import { useHyperview } from 'hyperview/src/contexts/hyperview';
+
+const CompatibleStackView = StackView as React.ComponentType<CompatibleStackViewProps>;
 
 const CustomStackNavigator = (props: Props) => {
   const { getSourceDoc } = useHvDocContext();
   const { entrypointUrl } = useHyperview();
+  const { direction } = useCompatibleLocale();
 
-  const {
-    state,
-    descriptors,
-    navigation,
-    NavigationContent,
-  } = useNavigationBuilder<
+  const builder = useNavigationBuilder<
     StackNavigationState<ParamListBase>,
     StackOptions,
     StackActionHelpers<ParamListBase>,
@@ -40,11 +46,15 @@ const CustomStackNavigator = (props: Props) => {
     initialRouteName: props.initialRouteName,
     screenOptions: props.screenOptions,
   });
+  const { state, descriptors, navigation, NavigationContent } = builder;
+  const { describe } = (builder as unknown) as NavigationBuilderWithDescribe;
 
   return (
     <NavigationContent>
-      <StackView
+      <CompatibleStackView
+        describe={isReactNavigation7 ? describe : undefined}
         descriptors={descriptors}
+        direction={isReactNavigation7 ? direction : undefined}
         navigation={navigation}
         state={state}
       />
@@ -52,9 +62,4 @@ const CustomStackNavigator = (props: Props) => {
   );
 };
 
-export default createNavigatorFactory<
-  Readonly<NavigationState>,
-  StackNavigationOptions,
-  EventMapBase,
-  typeof CustomStackNavigator
->(CustomStackNavigator);
+export default createNavigatorFactory(CustomStackNavigator);

--- a/src/components/navigator-stack/index.tsx
+++ b/src/components/navigator-stack/index.tsx
@@ -1,4 +1,5 @@
 import * as CustomStackRouter from 'hyperview/src/components/navigator-stack/router';
+import * as NavigatorService from 'hyperview/src/services/navigator';
 import * as React from 'react';
 import type {
   CompatibleStackViewProps,
@@ -17,10 +18,6 @@ import {
   StackNavigationOptions,
   StackView,
 } from '@react-navigation/stack';
-import {
-  isReactNavigation7,
-  useCompatibleLocale,
-} from 'hyperview/src/services/navigator/helpers';
 import type { ParamListBase } from '@react-navigation/routers';
 import { useHvDocContext } from 'hyperview/src/elements/hv-doc';
 import { useHyperview } from 'hyperview/src/contexts/hyperview';
@@ -30,7 +27,7 @@ const CompatibleStackView = StackView as React.ComponentType<CompatibleStackView
 const CustomStackNavigator = (props: Props) => {
   const { getSourceDoc } = useHvDocContext();
   const { entrypointUrl } = useHyperview();
-  const { direction } = useCompatibleLocale();
+  const { direction } = NavigatorService.useCompatibleLocale();
 
   const builder = useNavigationBuilder<
     StackNavigationState<ParamListBase>,
@@ -52,9 +49,9 @@ const CustomStackNavigator = (props: Props) => {
   return (
     <NavigationContent>
       <CompatibleStackView
-        describe={isReactNavigation7 ? describe : undefined}
+        describe={NavigatorService.isReactNavigation7 ? describe : undefined}
         descriptors={descriptors}
-        direction={isReactNavigation7 ? direction : undefined}
+        direction={NavigatorService.isReactNavigation7 ? direction : undefined}
         navigation={navigation}
         state={state}
       />

--- a/src/components/navigator-stack/router.test.tsx
+++ b/src/components/navigator-stack/router.test.tsx
@@ -1,0 +1,147 @@
+import * as DomErrors from 'hyperview/src/services/dom/errors';
+import { CommonActions } from '@react-navigation/native';
+import { DOMParser } from '@instawork/xmldom';
+import { Router } from './router';
+import { createStackNavigationState } from 'hyperview/test/helpers/navigation';
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useLocale: () => ({ direction: 'ltr' }),
+}));
+
+const parser = new DOMParser({
+  errorHandler: {
+    error: (error: string) => {
+      throw new DomErrors.XMLParserError(error);
+    },
+    fatalError: (error: string) => {
+      throw new DomErrors.XMLParserFatalError(error);
+    },
+    warning: (error: string) => {
+      throw new DomErrors.XMLParserWarning(error);
+    },
+  },
+  locator: {},
+});
+
+const routerOptions = {
+  routeGetIdList: {
+    card: undefined,
+    modal: undefined,
+    'tabs-route': undefined,
+  },
+  routeNames: ['tabs-route', 'card', 'modal'],
+  routeParamList: {
+    card: undefined,
+    modal: undefined,
+    'tabs-route': {
+      id: 'tabs-route',
+    },
+  },
+};
+
+describe('custom stack router', () => {
+  it('preserves the current state when the DOM has no routes', () => {
+    const state = createStackNavigationState({
+      index: 0,
+      key: 'root-stack',
+      routeNames: routerOptions.routeNames,
+      routes: [
+        {
+          key: 'card-key',
+          name: 'card',
+        },
+      ],
+      stale: false,
+      type: 'stack',
+    });
+    const router = Router({
+      entrypointUrl: 'https://example.com',
+      getDoc: () =>
+        parser.parseFromString(
+          '<doc xmlns="https://hyperview.org/hyperview" />',
+        ),
+      id: 'root-navigator',
+    });
+
+    expect(
+      router.getStateForRouteNamesChange(state, {
+        ...routerOptions,
+        routeKeyChanges: [],
+      }),
+    ).toEqual(state);
+  });
+
+  it('routes a bare navigate through an unmounted HXML navigator', () => {
+    const doc = parser.parseFromString(`
+      <doc xmlns="https://hyperview.org/hyperview">
+        <navigator id="root-navigator" type="stack">
+          <nav-route id="tabs-route">
+            <navigator id="tabs-navigator" type="tab">
+              <nav-route id="shifts-route" href="/shifts" />
+              <nav-route id="messages-route" href="/messages" />
+            </navigator>
+          </nav-route>
+        </navigator>
+        <navigator id="other-navigator" type="stack">
+          <nav-route id="outside-route" href="/outside" />
+        </navigator>
+      </doc>
+    `);
+    const state = createStackNavigationState({
+      index: 1,
+      key: 'root-stack',
+      routeNames: routerOptions.routeNames,
+      routes: [
+        {
+          key: 'tabs-route-key',
+          name: 'tabs-route',
+          params: {
+            id: 'tabs-route',
+          },
+        },
+        {
+          key: 'card-key',
+          name: 'card',
+        },
+      ],
+      stale: false,
+      type: 'stack',
+    });
+    const router = Router({
+      entrypointUrl: 'https://example.com',
+      getDoc: () => doc,
+      id: 'root-navigator',
+    });
+
+    expect(
+      router.getStateForAction(
+        state,
+        CommonActions.navigate('messages-route'),
+        routerOptions,
+      ),
+    ).toEqual({
+      ...state,
+      index: 0,
+      routes: [
+        {
+          key: 'tabs-route-key',
+          name: 'tabs-route',
+          params: {
+            id: 'tabs-route',
+            params: undefined,
+            screen: 'messages-route',
+          },
+          path: undefined,
+        },
+      ],
+    });
+    expect(
+      router.getStateForAction(
+        state,
+        CommonActions.navigate('outside-route'),
+        routerOptions,
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/components/navigator-stack/router.tsx
+++ b/src/components/navigator-stack/router.tsx
@@ -3,6 +3,10 @@ import type {
   RouterConfigOptions,
 } from '@react-navigation/routers';
 import type { RouterRenameOptions, StackOptions } from './types';
+import {
+  expandNestedNavigate,
+  findPathFromDom,
+} from 'hyperview/src/services/navigator/helpers';
 import type { StackNavigationState } from '@react-navigation/native';
 import { StackRouter } from '@react-navigation/native';
 import { buildRoutesFromDom } from './helpers';
@@ -22,6 +26,20 @@ export const Router = (stackOptions: StackOptions) => {
         ...options,
         routeKeyChanges: [],
       });
+    },
+
+    getStateForAction(
+      state: StackNavigationState<ParamListBase>,
+      action: Parameters<typeof router.getStateForAction>[1],
+      options: RouterConfigOptions,
+    ) {
+      return router.getStateForAction(
+        state,
+        expandNestedNavigate(state, action, targetId =>
+          findPathFromDom(stackOptions.getDoc?.(), stackOptions.id, targetId),
+        ),
+        options,
+      );
     },
 
     getStateForRouteNamesChange(
@@ -51,6 +69,10 @@ const mutateState = (
     options.routeParamList,
     entrypointUrl,
   );
+
+  if (!routes.length) {
+    return state;
+  }
 
   return {
     ...state,

--- a/src/components/navigator-stack/router.tsx
+++ b/src/components/navigator-stack/router.tsx
@@ -1,12 +1,9 @@
+import * as NavigatorService from 'hyperview/src/services/navigator';
 import type {
   ParamListBase,
   RouterConfigOptions,
 } from '@react-navigation/routers';
 import type { RouterRenameOptions, StackOptions } from './types';
-import {
-  expandNestedNavigate,
-  findPathFromDom,
-} from 'hyperview/src/services/navigator/helpers';
 import type { StackNavigationState } from '@react-navigation/native';
 import { StackRouter } from '@react-navigation/native';
 import { buildRoutesFromDom } from './helpers';
@@ -37,8 +34,12 @@ export const Router = (
     ) {
       return router.getStateForAction(
         state,
-        expandNestedNavigate(state, action, targetId =>
-          findPathFromDom(stackOptions.getDoc?.(), stackOptions.id, targetId),
+        NavigatorService.expandNestedNavigate(state, action, targetId =>
+          NavigatorService.findPathFromDom(
+            stackOptions.getDoc?.(),
+            stackOptions.id,
+            targetId,
+          ),
         ),
         options,
       );

--- a/src/components/navigator-stack/router.tsx
+++ b/src/components/navigator-stack/router.tsx
@@ -14,7 +14,9 @@ import { buildRoutesFromDom } from './helpers';
 /**
  * Provides a custom stack router that allows us to set the initial route
  */
-export const Router = (stackOptions: StackOptions) => {
+export const Router = (
+  stackOptions: StackOptions,
+): ReturnType<typeof StackRouter> => {
   const router = StackRouter(stackOptions);
 
   return {

--- a/src/components/navigator-stack/types.ts
+++ b/src/components/navigator-stack/types.ts
@@ -1,9 +1,9 @@
+import type * as NavigatorService from 'hyperview/src/services/navigator';
 import * as React from 'react';
 import type {
   StackNavigationOptions,
   StackView,
 } from '@react-navigation/stack';
-import type { Locale } from 'hyperview/src/services/navigator/types';
 import type { RouterConfigOptions } from '@react-navigation/routers';
 
 export type Props = {
@@ -33,7 +33,7 @@ export type CompatibleStackViewProps = Omit<
   'describe' | 'direction'
 > & {
   describe?: unknown;
-  direction?: Locale['direction'];
+  direction?: NavigatorService.Locale['direction'];
 };
 
 export type NavigationBuilderWithDescribe = {

--- a/src/components/navigator-stack/types.ts
+++ b/src/components/navigator-stack/types.ts
@@ -1,6 +1,10 @@
 import * as React from 'react';
-import type { RouterConfigOptions } from '@react-navigation/native';
-import type { StackNavigationOptions } from '@react-navigation/stack';
+import type {
+  StackNavigationOptions,
+  StackView,
+} from '@react-navigation/stack';
+import type { Locale } from 'hyperview/src/services/navigator/types';
+import type { RouterConfigOptions } from '@react-navigation/routers';
 
 export type Props = {
   id: string;
@@ -22,4 +26,16 @@ export type StackOptions = {
   getDoc?: () => Document | undefined;
   id: string;
   initialRouteName?: string;
+};
+
+export type CompatibleStackViewProps = Omit<
+  React.ComponentProps<typeof StackView>,
+  'describe' | 'direction'
+> & {
+  describe?: unknown;
+  direction?: Locale['direction'];
+};
+
+export type NavigationBuilderWithDescribe = {
+  describe?: unknown;
 };

--- a/src/components/navigator-tab/index.tsx
+++ b/src/components/navigator-tab/index.tsx
@@ -1,22 +1,22 @@
+import * as CustomTabRouter from 'hyperview/src/components/navigator-tab/router';
 import * as React from 'react';
 import {
   BottomTabNavigationEventMap,
   BottomTabNavigationOptions,
   BottomTabView,
 } from '@react-navigation/bottom-tabs';
+import type { Props, TabOptions } from './types';
 import {
-  EventMapBase,
   TabActionHelpers,
   TabNavigationState,
-  TabRouter,
-  TabRouterOptions,
   createNavigatorFactory,
   useNavigationBuilder,
 } from '@react-navigation/native';
-import type { NavigationState, ParamListBase } from '@react-navigation/routers';
-import type { Props } from './types';
+import type { ParamListBase } from '@react-navigation/routers';
+import { useHvDocContext } from 'hyperview/src/elements/hv-doc';
 
 const CustomTabNavigator = (props: Props) => {
+  const { getSourceDoc } = useHvDocContext();
   const {
     state,
     descriptors,
@@ -24,13 +24,14 @@ const CustomTabNavigator = (props: Props) => {
     NavigationContent,
   } = useNavigationBuilder<
     TabNavigationState<ParamListBase>,
-    TabRouterOptions,
+    TabOptions,
     TabActionHelpers<ParamListBase>,
     BottomTabNavigationOptions,
     BottomTabNavigationEventMap
-  >(TabRouter, {
+  >(CustomTabRouter.Router, {
     backBehavior: props.backBehavior,
     children: props.children,
+    getDoc: () => getSourceDoc(),
     id: props.id,
     initialRouteName: props.initialRouteName,
     screenOptions: props.screenOptions,
@@ -59,9 +60,4 @@ const CustomTabNavigator = (props: Props) => {
   );
 };
 
-export default createNavigatorFactory<
-  Readonly<NavigationState>,
-  object,
-  EventMapBase,
-  typeof CustomTabNavigator
->(CustomTabNavigator);
+export default createNavigatorFactory(CustomTabNavigator);

--- a/src/components/navigator-tab/router.tsx
+++ b/src/components/navigator-tab/router.tsx
@@ -1,0 +1,33 @@
+import type {
+  ParamListBase,
+  RouterConfigOptions,
+} from '@react-navigation/routers';
+import {
+  expandNestedNavigate,
+  findPathFromDom,
+} from 'hyperview/src/services/navigator/helpers';
+import type { TabNavigationState } from '@react-navigation/native';
+import type { TabOptions } from './types';
+import { TabRouter } from '@react-navigation/native';
+
+export const Router = (options: TabOptions) => {
+  const router = TabRouter(options);
+
+  return {
+    ...router,
+
+    getStateForAction(
+      state: TabNavigationState<ParamListBase>,
+      action: Parameters<typeof router.getStateForAction>[1],
+      routerOptions: RouterConfigOptions,
+    ) {
+      return router.getStateForAction(
+        state,
+        expandNestedNavigate(state, action, targetId =>
+          findPathFromDom(options.getDoc?.(), options.id, targetId),
+        ),
+        routerOptions,
+      );
+    },
+  };
+};

--- a/src/components/navigator-tab/router.tsx
+++ b/src/components/navigator-tab/router.tsx
@@ -1,11 +1,8 @@
+import * as NavigatorService from 'hyperview/src/services/navigator';
 import type {
   ParamListBase,
   RouterConfigOptions,
 } from '@react-navigation/routers';
-import {
-  expandNestedNavigate,
-  findPathFromDom,
-} from 'hyperview/src/services/navigator/helpers';
 import type { TabNavigationState } from '@react-navigation/native';
 import type { TabOptions } from './types';
 import { TabRouter } from '@react-navigation/native';
@@ -23,8 +20,12 @@ export const Router = (options: TabOptions): ReturnType<typeof TabRouter> => {
     ) {
       return router.getStateForAction(
         state,
-        expandNestedNavigate(state, action, targetId =>
-          findPathFromDom(options.getDoc?.(), options.id, targetId),
+        NavigatorService.expandNestedNavigate(state, action, targetId =>
+          NavigatorService.findPathFromDom(
+            options.getDoc?.(),
+            options.id,
+            targetId,
+          ),
         ),
         routerOptions,
       );

--- a/src/components/navigator-tab/router.tsx
+++ b/src/components/navigator-tab/router.tsx
@@ -10,7 +10,7 @@ import type { TabNavigationState } from '@react-navigation/native';
 import type { TabOptions } from './types';
 import { TabRouter } from '@react-navigation/native';
 
-export const Router = (options: TabOptions) => {
+export const Router = (options: TabOptions): ReturnType<typeof TabRouter> => {
   const router = TabRouter(options);
 
   return {

--- a/src/components/navigator-tab/types.ts
+++ b/src/components/navigator-tab/types.ts
@@ -3,6 +3,7 @@ import {
   BottomTabBarProps,
   BottomTabNavigationOptions,
 } from '@react-navigation/bottom-tabs';
+import type { TabRouterOptions } from '@react-navigation/native';
 
 export type Props = {
   id: string;
@@ -11,4 +12,9 @@ export type Props = {
   children: React.ReactNode;
   screenOptions: BottomTabNavigationOptions;
   tabBar?: ((props: BottomTabBarProps) => React.ReactNode) | undefined;
+};
+
+export type TabOptions = TabRouterOptions & {
+  getDoc?: () => Document | undefined;
+  id: string;
 };

--- a/src/elements/hv-doc/hv-doc.tsx
+++ b/src/elements/hv-doc/hv-doc.tsx
@@ -31,6 +31,8 @@ import { useElementCache } from 'hyperview/src/contexts/element-cache';
 import { useHyperview } from 'hyperview/src/contexts/hyperview';
 
 export default (props: Props) => {
+  // eslint-disable-next-line react/destructuring-assignment
+  const { onUrlChange } = props;
   // <HACK>
   // In addition to storing the document on the react state, we keep a reference to it.
   // When performing batched updates on the DOM, we need to ensure every
@@ -47,6 +49,8 @@ export default (props: Props) => {
   // </HACK>
 
   const currentUrl = useRef<string | null | undefined>(null);
+  const activeLoadUrl = useRef<string | null>(null);
+  const pendingRouteUrl = useRef<string | null>(null);
 
   const [state, setState] = useState<DocState>({
     doc: undefined,
@@ -81,9 +85,12 @@ export default (props: Props) => {
   const parentDocState = useContext(Context);
 
   const loadUrl = useCallback(
-    async (url?: string) => {
+    async (url?: string, notifyUrlChange = false) => {
       // Updates the state and calls the error handler
       const handleError = (err: Error, u?: string | null) => {
+        if (notifyUrlChange) {
+          pendingRouteUrl.current = null;
+        }
         try {
           if (onError) {
             onError(err);
@@ -103,6 +110,11 @@ export default (props: Props) => {
         handleError(new HvDocError('No URL provided'), targetUrl);
         return;
       }
+      const fullUrl = UrlService.getUrlFromHref(targetUrl, entrypointUrl);
+      if (activeLoadUrl.current === fullUrl) {
+        return;
+      }
+      activeLoadUrl.current = fullUrl;
       const params = props.route?.params ?? {};
 
       try {
@@ -114,7 +126,6 @@ export default (props: Props) => {
           await later(delay);
         }
 
-        const fullUrl = UrlService.getUrlFromHref(targetUrl, entrypointUrl);
         const { doc, staleHeaderType } = await parser.loadDocument(fullUrl);
 
         const root = Helpers.getFirstChildTag(doc, LOCAL_NAME.DOC);
@@ -131,6 +142,7 @@ export default (props: Props) => {
 
           localDoc.current = document;
           localUrl.current = fullUrl;
+          currentUrl.current = fullUrl;
           const stylesheets = Stylesheets.createStylesheets(doc);
           setState(prev => ({
             ...prev,
@@ -141,6 +153,9 @@ export default (props: Props) => {
             styles: stylesheets,
             url: fullUrl,
           }));
+          if (notifyUrlChange) {
+            onUrlChange?.(fullUrl);
+          }
         } else {
           // Invalid document
           localDoc.current = undefined;
@@ -163,6 +178,7 @@ export default (props: Props) => {
     [
       entrypointUrl,
       onError,
+      onUrlChange,
       parser,
       props.route?.params,
       removeElement,
@@ -174,8 +190,28 @@ export default (props: Props) => {
   useEffect(() => {
     if (state.loadingUrl) {
       // Handle force reload
-      loadUrl(state.loadingUrl);
-    } else if (props.url) {
+      loadUrl(state.loadingUrl, true);
+      return;
+    }
+
+    activeLoadUrl.current = null;
+
+    if (pendingRouteUrl.current) {
+      const routeUrl = props.url
+        ? UrlService.getUrlFromHref(props.url, entrypointUrl)
+        : null;
+      const pendingUrl = UrlService.getUrlFromHref(
+        pendingRouteUrl.current,
+        entrypointUrl,
+      );
+      if (routeUrl === pendingUrl) {
+        pendingRouteUrl.current = null;
+        currentUrl.current = routeUrl;
+      }
+      return;
+    }
+
+    if (props.url) {
       if (
         !currentUrl.current &&
         !props.hasElement &&
@@ -278,6 +314,7 @@ export default (props: Props) => {
   );
 
   const updateUrl = useCallback((url: string) => {
+    pendingRouteUrl.current = url;
     setState(prev => ({
       ...prev,
       loadingUrl: url,

--- a/src/elements/hv-doc/types.ts
+++ b/src/elements/hv-doc/types.ts
@@ -10,6 +10,7 @@ export type Props = {
   children?: React.ReactNode;
   hasElement?: boolean;
   navigationProvider: NavigationProvider;
+  onUrlChange?: (url: string) => void;
   route?: RouteProps;
   url: string;
 };

--- a/src/elements/hv-navigator/index.tsx
+++ b/src/elements/hv-navigator/index.tsx
@@ -17,17 +17,20 @@ import {
   EventTriggerError,
 } from 'hyperview/src/errors';
 import {
-  ParamTypes,
+  CardStyleInterpolators,
+  StackNavigationOptions,
+} from '@react-navigation/stack';
+import {
   Props,
   SHOW_DEFAULT_FOOTER_UI,
   SHOW_DEFAULT_HEADER_UI,
+  ScreenOptionsProps,
   ScreenParams,
   StackScreenOptions,
   TabScreenOptions,
 } from './types';
 import React, { useCallback, useEffect, useRef } from 'react';
 import type { BottomTabBarProps } from '@react-navigation/bottom-tabs';
-import { CardStyleInterpolators } from '@react-navigation/stack';
 import { HvDocContext } from 'hyperview/src/elements/hv-doc';
 import NavigatorStack from 'hyperview/src/components/navigator-stack';
 import NavigatorTab from 'hyperview/src/components/navigator-tab';
@@ -35,8 +38,8 @@ import { Platform } from 'react-native';
 import { getFirstChildTag } from 'hyperview/src/services/dom/helpers';
 import { useHyperview } from 'hyperview/src/contexts/hyperview';
 
-export const Stack = NavigatorStack<ParamTypes>();
-export const BottomTab = NavigatorTab<ParamTypes>();
+export const Stack = NavigatorStack();
+export const BottomTab = NavigatorTab();
 
 export default function HvNavigator(props: Props) {
   // eslint-disable-next-line react/destructuring-assignment
@@ -119,7 +122,7 @@ export default function HvNavigator(props: Props) {
   /**
    * Logic to determine the nav route id
    */
-  const getId = useCallback((p: RouteParams): string => {
+  const getId = useCallback((p: RouteParams | undefined) => {
     if (!p) {
       throw new NavigatorService.HvNavigatorError('No params found for route');
     }
@@ -130,14 +133,14 @@ export default function HvNavigator(props: Props) {
       }
       return p.id;
     }
-    return p.url || '';
+    return p.url || undefined;
   }, []);
 
   /**
    * Encapsulated options for the stack screenOptions
    */
   const stackScreenOptions = useCallback(
-    (route: ScreenParams): StackScreenOptions => ({
+    ({ route }: ScreenOptionsProps): StackScreenOptions => ({
       headerMode: 'screen',
       headerShown: SHOW_DEFAULT_HEADER_UI,
       title: getId(route.params),
@@ -149,7 +152,7 @@ export default function HvNavigator(props: Props) {
    * Encapsulated options for the tab screenOptions
    */
   const tabScreenOptions = useCallback(
-    (route: ScreenParams): TabScreenOptions => ({
+    ({ route }: ScreenOptionsProps): TabScreenOptions => ({
       headerShown: SHOW_DEFAULT_HEADER_UI,
       tabBarStyle: {
         display: SHOW_DEFAULT_FOOTER_UI ? 'flex' : 'none',
@@ -186,6 +189,7 @@ export default function HvNavigator(props: Props) {
         );
       }
       if (type === NAVIGATOR_TYPE.STACK) {
+        const animation = isFirstScreen ? 'none' : 'default';
         const gestureEnabled = Platform.OS === 'ios' ? !needsSubStack : false;
         let cardStyleInterpolator;
         if (needsSubStack) {
@@ -201,14 +205,17 @@ export default function HvNavigator(props: Props) {
             getId={({ params: p }: ScreenParams) => getId(p)}
             initialParams={initialParams}
             name={id}
-            options={{
-              animationEnabled: !isFirstScreen,
-              cardStyleInterpolator,
-              gestureEnabled,
-              presentation: needsSubStack
-                ? NavigatorService.ID_MODAL
-                : NavigatorService.ID_CARD,
-            }}
+            options={
+              {
+                animation,
+                animationEnabled: !isFirstScreen,
+                cardStyleInterpolator,
+                gestureEnabled,
+                presentation: needsSubStack
+                  ? NavigatorService.ID_MODAL
+                  : NavigatorService.ID_CARD,
+              } as StackNavigationOptions
+            }
           />
         );
       }
@@ -367,7 +374,7 @@ export default function HvNavigator(props: Props) {
               NAVIGATOR_TYPE.STACK,
               params?.url || undefined,
               false,
-              false,
+              true,
               params?.id,
               true,
             ),
@@ -399,7 +406,7 @@ export default function HvNavigator(props: Props) {
           return (
             <Stack.Navigator
               id={navigatorId}
-              screenOptions={({ route }) => stackScreenOptions(route)}
+              screenOptions={stackScreenOptions}
             >
               {screens}
             </Stack.Navigator>
@@ -433,10 +440,7 @@ export default function HvNavigator(props: Props) {
         switch (type) {
           case NAVIGATOR_TYPE.STACK:
             return (
-              <Stack.Navigator
-                id={id}
-                screenOptions={({ route }) => stackScreenOptions(route)}
-              >
+              <Stack.Navigator id={id} screenOptions={stackScreenOptions}>
                 {buildScreens(type, element)}
               </Stack.Navigator>
             );
@@ -446,7 +450,7 @@ export default function HvNavigator(props: Props) {
                 backBehavior="none"
                 id={id}
                 initialRouteName={selectedId}
-                screenOptions={({ route }) => tabScreenOptions(route)}
+                screenOptions={tabScreenOptions}
                 tabBar={
                   BottomTabBar &&
                   ((p: BottomTabBarProps) => (

--- a/src/elements/hv-navigator/index.tsx
+++ b/src/elements/hv-navigator/index.tsx
@@ -26,6 +26,7 @@ import {
   TabScreenOptions,
 } from './types';
 import React, { useCallback, useEffect, useRef } from 'react';
+import type { BottomTabBarProps } from '@react-navigation/bottom-tabs';
 import { CardStyleInterpolators } from '@react-navigation/stack';
 import { HvDocContext } from 'hyperview/src/elements/hv-doc';
 import NavigatorStack from 'hyperview/src/components/navigator-stack';
@@ -448,7 +449,7 @@ export default function HvNavigator(props: Props) {
                 screenOptions={({ route }) => tabScreenOptions(route)}
                 tabBar={
                   BottomTabBar &&
-                  (p => (
+                  ((p: BottomTabBarProps) => (
                     <BottomTabBar
                       descriptors={p.descriptors}
                       id={id}

--- a/src/elements/hv-navigator/types.ts
+++ b/src/elements/hv-navigator/types.ts
@@ -1,6 +1,7 @@
 import type { HvComponentOnUpdate, RouteParams } from 'hyperview/src/types';
 import { FC } from 'react';
 import type { Props as HvRouteProps } from 'hyperview/src/elements/hv-route';
+import type { RouteProp } from '@react-navigation/native';
 
 /**
  * Flag to show the default navigator UIs
@@ -17,7 +18,7 @@ export const SHOW_DEFAULT_HEADER_UI = false;
 export type ParamTypes = Record<string, RouteParams>;
 
 export type ScreenParams = {
-  params: RouteParams;
+  params: RouteParams | undefined;
 };
 
 /**
@@ -51,4 +52,8 @@ export type TabScreenOptions = {
   headerShown: boolean;
   tabBarStyle: { display: 'flex' | 'none' | undefined };
   title: string | undefined;
+};
+
+export type ScreenOptionsProps = {
+  route: RouteProp<ParamTypes, string>;
 };

--- a/src/elements/hv-route/hv-route.tsx
+++ b/src/elements/hv-route/hv-route.tsx
@@ -126,11 +126,19 @@ class HvRouteInner extends PureComponent<Types.InnerRouteProps, ScreenState> {
     }
 
     if (needsSubStack || renderElement?.localName === LOCAL_NAME.NAVIGATOR) {
+      const routeParams = this.props.route?.params;
+      const navigatorParams = needsSubStack
+        ? {
+            ...routeParams,
+            id: routeParams?.id ?? this.props.route?.key,
+            needsSubStack,
+          }
+        : routeParams;
       return (
         <HvNavigator
           element={renderElement}
           onUpdate={this.props.onUpdate}
-          params={this.props.route?.params}
+          params={navigatorParams}
           routeComponent={HvRoute}
         />
       );
@@ -196,7 +204,8 @@ function HvRouteFC(props: Types.Props) {
         );
 
   const rootNavigation = useContext(NavigationContainerRefContext);
-  const nav = props.navigation || (rootNavigation as NavigationProps);
+  const nav =
+    props.navigation || ((rootNavigation as unknown) as NavigationProps);
   const navigator = useMemo(
     () =>
       new NavigatorService.Navigator({
@@ -359,6 +368,7 @@ function HvRouteFC(props: Types.Props) {
     <HvDoc
       hasElement={!!element}
       navigationProvider={navigator}
+      onUrlChange={navigator.updateRouteUrl}
       route={props.route}
       url={url}
     >

--- a/src/hyperview.navigation.test.tsx
+++ b/src/hyperview.navigation.test.tsx
@@ -1,0 +1,693 @@
+import {
+  NavigationContainer,
+  createNavigationContainerRef,
+} from '@react-navigation/native';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+import Hyperview from './hyperview';
+import { Pressable } from 'react-native';
+import React from 'react';
+import { fetchFactory } from 'hyperview/test/helpers/fetch';
+
+describe('Hyperview navigation sequences', () => {
+  const formatDate = jest.fn();
+
+  test.each(['new', 'push'])(
+    'runs adjacent close and %s load behaviors as one transition',
+    async action => {
+      const mockFetch = fetchFactory([
+        [
+          'http://myapp.com/navigation-sequence-document',
+          `
+            <doc xmlns="https://hyperview.org/hyperview">
+              <navigator id="root" type="stack">
+                <nav-route
+                  id="home"
+                  href="http://myapp.com/navigation-sequence-home"
+                />
+              </navigator>
+            </doc>
+          `,
+        ],
+        [
+          'http://myapp.com/navigation-sequence-home',
+          `
+            <doc xmlns="https://hyperview.org/hyperview">
+              <screen>
+                <body>
+                  <behavior
+                    trigger="load"
+                    action="new"
+                    href="http://myapp.com/navigation-sequence-proxy"
+                    once="true"
+                  />
+                  <text id="home">Home</text>
+                </body>
+              </screen>
+            </doc>
+          `,
+        ],
+        [
+          'http://myapp.com/navigation-sequence-proxy',
+          `
+            <doc xmlns="https://hyperview.org/hyperview">
+              <screen>
+                <body>
+                  <behavior trigger="load" action="close" once="true" />
+                  <behavior
+                    trigger="load"
+                    action="${action}"
+                    href="http://myapp.com/navigation-sequence-destination"
+                    once="true"
+                  />
+                  <text id="proxy">Proxy</text>
+                </body>
+              </screen>
+            </doc>
+          `,
+        ],
+        [
+          'http://myapp.com/navigation-sequence-destination',
+          `
+            <doc xmlns="https://hyperview.org/hyperview">
+              <screen>
+                <body>
+                  <text id="destination">Destination</text>
+                </body>
+              </screen>
+            </doc>
+          `,
+        ],
+      ]);
+
+      render(
+        <NavigationContainer>
+          <Hyperview
+            entrypointUrl="http://myapp.com/navigation-sequence-document"
+            fetch={mockFetch}
+            formatDate={formatDate}
+          />
+        </NavigationContainer>,
+      );
+
+      await waitFor(
+        () => {
+          expect(screen.getByTestId('destination')).toBeOnTheScreen();
+          expect(screen.queryByTestId('proxy')).not.toBeOnTheScreen();
+        },
+        { timeout: 2000 },
+      );
+    },
+  );
+
+  test('runs adjacent close and push press behaviors as one transition', async () => {
+    const mockFetch = fetchFactory([
+      [
+        'http://myapp.com/community-document',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <navigator id="root" type="stack">
+              <nav-route id="home" href="http://myapp.com/community-home" />
+            </navigator>
+          </doc>
+        `,
+      ],
+      [
+        'http://myapp.com/community-home',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <behavior
+                  trigger="load"
+                  action="new"
+                  href="http://myapp.com/community-intro"
+                  once="true"
+                />
+                <text id="home">Home</text>
+              </body>
+            </screen>
+          </doc>
+        `,
+      ],
+      [
+        'http://myapp.com/community-intro',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <view id="get-started">
+                  <behavior action="close" />
+                  <behavior href="http://myapp.com/community-form" />
+                  <text>Get started</text>
+                </view>
+                <text id="intro">Intro</text>
+              </body>
+            </screen>
+          </doc>
+        `,
+      ],
+      [
+        'http://myapp.com/community-form',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <text id="community-form">Community form</text>
+              </body>
+            </screen>
+          </doc>
+        `,
+      ],
+    ]);
+
+    render(
+      <NavigationContainer>
+        <Hyperview
+          entrypointUrl="http://myapp.com/community-document"
+          fetch={mockFetch}
+          formatDate={formatDate}
+        />
+      </NavigationContainer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('get-started')).toBeOnTheScreen();
+    });
+    fireEvent.press(screen.getByTestId('get-started'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('community-form')).toBeOnTheScreen();
+      expect(screen.queryByTestId('intro')).not.toBeOnTheScreen();
+    });
+  });
+
+  test('closes a named route marked as a modal', async () => {
+    const mockFetch = fetchFactory([
+      [
+        'http://myapp.com/named-modal-document',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <navigator id="root" type="stack">
+              <nav-route id="home" href="http://myapp.com/named-modal-home" />
+              <nav-route
+                id="welcome"
+                href="http://myapp.com/named-modal-welcome"
+                modal="true"
+              />
+            </navigator>
+          </doc>
+        `,
+      ],
+      [
+        'http://myapp.com/named-modal-home',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <text id="home">Home</text>
+              </body>
+            </screen>
+          </doc>
+        `,
+      ],
+      [
+        'http://myapp.com/named-modal-welcome',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <view id="close-welcome" action="close">
+                  <text>Close welcome</text>
+                </view>
+              </body>
+            </screen>
+          </doc>
+        `,
+      ],
+    ]);
+
+    render(
+      <NavigationContainer>
+        <Hyperview
+          entrypointUrl="http://myapp.com/named-modal-document"
+          fetch={mockFetch}
+          formatDate={formatDate}
+        />
+      </NavigationContainer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('close-welcome')).toBeOnTheScreen();
+    });
+    fireEvent.press(screen.getByTestId('close-welcome'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('home')).toBeOnTheScreen();
+      expect(screen.queryByTestId('close-welcome')).not.toBeOnTheScreen();
+    });
+  });
+
+  test('closes an entire flow containing nested modals', async () => {
+    const mockFetch = fetchFactory([
+      [
+        'http://myapp.com/nested-modal-document',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <navigator id="root" type="stack">
+              <nav-route id="home" href="http://myapp.com/nested-modal-home" />
+            </navigator>
+          </doc>
+        `,
+      ],
+      [
+        'http://myapp.com/nested-modal-home',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <view
+                  id="open-first-modal"
+                  action="new"
+                  href="http://myapp.com/nested-modal-first"
+                >
+                  <text>Open first modal</text>
+                </view>
+                <text id="home">Home</text>
+              </body>
+            </screen>
+          </doc>
+        `,
+      ],
+      [
+        'http://myapp.com/nested-modal-first',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <behavior
+                  trigger="on-event"
+                  event-name="close-flow"
+                  action="close"
+                />
+                <view
+                  id="open-second-modal"
+                  action="new"
+                  href="http://myapp.com/nested-modal-second"
+                >
+                  <text>Open second modal</text>
+                </view>
+              </body>
+            </screen>
+          </doc>
+        `,
+      ],
+      [
+        'http://myapp.com/nested-modal-second',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <behavior
+                  trigger="on-event"
+                  event-name="close-flow"
+                  action="close"
+                />
+                <view
+                  id="open-third-modal"
+                  action="new"
+                  href="http://myapp.com/nested-modal-third"
+                >
+                  <text>Open third modal</text>
+                </view>
+              </body>
+            </screen>
+          </doc>
+        `,
+      ],
+      [
+        'http://myapp.com/nested-modal-third',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <behavior
+                  trigger="on-event"
+                  event-name="close-flow"
+                  action="close"
+                />
+                <view id="close-modal-flow">
+                  <behavior
+                    action="dispatch-event"
+                    event-name="close-flow"
+                  />
+                  <text>Close modal flow</text>
+                </view>
+              </body>
+            </screen>
+          </doc>
+        `,
+      ],
+    ]);
+
+    render(
+      <NavigationContainer>
+        <Hyperview
+          entrypointUrl="http://myapp.com/nested-modal-document"
+          fetch={mockFetch}
+          formatDate={formatDate}
+        />
+      </NavigationContainer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('open-first-modal')).toBeOnTheScreen();
+    });
+    fireEvent.press(screen.getByTestId('open-first-modal'));
+    await waitFor(() => {
+      expect(screen.getByTestId('open-second-modal')).toBeOnTheScreen();
+    });
+    fireEvent.press(screen.getByTestId('open-second-modal'));
+    await waitFor(() => {
+      expect(screen.getByTestId('open-third-modal')).toBeOnTheScreen();
+    });
+    fireEvent.press(screen.getByTestId('open-third-modal'));
+    await waitFor(() => {
+      expect(screen.getByTestId('close-modal-flow')).toBeOnTheScreen();
+    });
+    fireEvent.press(screen.getByTestId('close-modal-flow'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('home')).toBeOnTheScreen();
+      expect(screen.queryByTestId('close-modal-flow')).not.toBeOnTheScreen();
+    });
+  });
+
+  test('closes a modal after pushing within it', async () => {
+    const mockFetch = fetchFactory([
+      [
+        'http://myapp.com/push-in-modal-document',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <navigator id="root" type="stack">
+              <nav-route
+                id="home"
+                href="http://myapp.com/push-in-modal-home"
+              />
+            </navigator>
+          </doc>
+        `,
+      ],
+      [
+        'http://myapp.com/push-in-modal-home',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <view
+                  id="open-modal"
+                  action="new"
+                  href="http://myapp.com/push-in-modal-step-one"
+                >
+                  <text>Open modal</text>
+                </view>
+                <text id="home">Home</text>
+              </body>
+            </screen>
+          </doc>
+        `,
+      ],
+      [
+        'http://myapp.com/push-in-modal-step-one',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <view
+                  id="push"
+                  action="push"
+                  href="http://myapp.com/push-in-modal-step-two"
+                >
+                  <text>Push</text>
+                </view>
+              </body>
+            </screen>
+          </doc>
+        `,
+      ],
+      [
+        'http://myapp.com/push-in-modal-step-two',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <view id="close" action="close">
+                  <text>Close</text>
+                </view>
+              </body>
+            </screen>
+          </doc>
+        `,
+      ],
+    ]);
+
+    render(
+      <NavigationContainer>
+        <Hyperview
+          entrypointUrl="http://myapp.com/push-in-modal-document"
+          fetch={mockFetch}
+          formatDate={formatDate}
+        />
+      </NavigationContainer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('open-modal')).toBeOnTheScreen();
+    });
+    fireEvent.press(screen.getByTestId('open-modal'));
+    await waitFor(() => {
+      expect(screen.getByTestId('push')).toBeOnTheScreen();
+    });
+    fireEvent.press(screen.getByTestId('push'));
+    await waitFor(() => {
+      expect(screen.getByTestId('close')).toBeOnTheScreen();
+    });
+    fireEvent.press(screen.getByTestId('close'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('home')).toBeOnTheScreen();
+      expect(screen.queryByTestId('close')).not.toBeOnTheScreen();
+    });
+  });
+
+  test('unwinds a pushed screen and modal through an event', async () => {
+    const mockFetch = fetchFactory([
+      [
+        'http://myapp.com/push-then-modal-document',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <navigator id="root" type="stack">
+              <nav-route
+                id="home"
+                href="http://myapp.com/push-then-modal-home"
+              />
+            </navigator>
+          </doc>
+        `,
+      ],
+      [
+        'http://myapp.com/push-then-modal-home',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <view
+                  id="push"
+                  action="push"
+                  href="http://myapp.com/push-then-modal-card"
+                >
+                  <text>Push</text>
+                </view>
+                <text id="home">Home</text>
+              </body>
+            </screen>
+          </doc>
+        `,
+      ],
+      [
+        'http://myapp.com/push-then-modal-card',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <behavior
+                  trigger="on-event"
+                  event-name="push-done"
+                  action="back"
+                />
+                <view
+                  id="open-modal"
+                  action="new"
+                  href="http://myapp.com/push-then-modal-done"
+                >
+                  <text>Open modal</text>
+                </view>
+              </body>
+            </screen>
+          </doc>
+        `,
+      ],
+      [
+        'http://myapp.com/push-then-modal-done',
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <behavior
+                  trigger="on-event"
+                  event-name="push-done"
+                  action="back"
+                />
+                <behavior
+                  trigger="load"
+                  delay="10"
+                  action="dispatch-event"
+                  event-name="push-done"
+                  once="true"
+                />
+                <text id="done">Done</text>
+              </body>
+            </screen>
+          </doc>
+        `,
+      ],
+    ]);
+
+    render(
+      <NavigationContainer>
+        <Hyperview
+          entrypointUrl="http://myapp.com/push-then-modal-document"
+          fetch={mockFetch}
+          formatDate={formatDate}
+        />
+      </NavigationContainer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('push')).toBeOnTheScreen();
+    });
+    fireEvent.press(screen.getByTestId('push'));
+    await waitFor(() => {
+      expect(screen.getByTestId('open-modal')).toBeOnTheScreen();
+    });
+    fireEvent.press(screen.getByTestId('open-modal'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('home')).toBeOnTheScreen();
+      expect(screen.queryByTestId('done')).not.toBeOnTheScreen();
+    });
+  });
+
+  test('loads a replacement URL once before updating its route', async () => {
+    const navigationRef = createNavigationContainerRef();
+    const getCurrentUrl = () =>
+      (navigationRef.getCurrentRoute() as
+        | { params?: { url?: string } }
+        | undefined)?.params?.url;
+    let resolveDestination: (body: string) => void = () => undefined;
+    const destinationBody = new Promise<string>(resolve => {
+      resolveDestination = resolve;
+    });
+    const destinationUrl = 'http://myapp.com/replacement-destination';
+    const destinationXml = `
+      <doc xmlns="https://hyperview.org/hyperview">
+        <screen>
+          <body>
+            <text id="destination">Destination</text>
+          </body>
+        </screen>
+      </doc>
+    `;
+    const destinationRouteUrls: Array<string | undefined> = [];
+    const mockFetch = jest.fn(async url => {
+      if (url.includes('replacement-document')) {
+        return new Response(
+          `
+            <doc xmlns="https://hyperview.org/hyperview">
+              <navigator id="root" type="stack">
+                <nav-route id="home" href="http://myapp.com/replacement-home" />
+              </navigator>
+            </doc>
+          `,
+          { status: 200 },
+        );
+      }
+      if (url.includes('replacement-home')) {
+        return new Response(
+          `
+            <doc xmlns="https://hyperview.org/hyperview">
+              <screen>
+                <body>
+                  <view
+                    id="load-destination"
+                    action="reload"
+                    href="${destinationUrl}"
+                  />
+                </body>
+              </screen>
+            </doc>
+          `,
+          { status: 200 },
+        );
+      }
+      if (url.includes(destinationUrl)) {
+        destinationRouteUrls.push(getCurrentUrl());
+        return new Response(await destinationBody, { status: 200 });
+      }
+      return new Response('Not found', { status: 404 });
+    });
+
+    render(
+      <>
+        <NavigationContainer ref={navigationRef}>
+          <Hyperview
+            entrypointUrl="http://myapp.com/replacement-document"
+            fetch={mockFetch}
+            formatDate={formatDate}
+          />
+        </NavigationContainer>
+        <Pressable
+          onPress={() => resolveDestination(destinationXml)}
+          testID="resolve-destination"
+        />
+      </>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('load-destination')).toBeOnTheScreen();
+    });
+    fireEvent.press(screen.getByTestId('load-destination'));
+
+    await waitFor(() => {
+      expect(
+        mockFetch.mock.calls.filter(([url]) => url === destinationUrl),
+      ).toHaveLength(1);
+    });
+    expect(getCurrentUrl()).not.toBe(destinationUrl);
+
+    fireEvent.press(screen.getByTestId('resolve-destination'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('destination')).toBeOnTheScreen();
+      expect(getCurrentUrl()).toBe(destinationUrl);
+    });
+    expect(destinationRouteUrls).toEqual(['http://myapp.com/replacement-home']);
+    expect(
+      mockFetch.mock.calls.filter(([url]) => url === destinationUrl),
+    ).toHaveLength(1);
+  });
+});

--- a/src/services/navigator/helpers.test.ts
+++ b/src/services/navigator/helpers.test.ts
@@ -8,6 +8,7 @@ import {
   buildParams,
   buildRequest,
   cleanHrefFragment,
+  expandNestedNavigate,
   findPath,
   getChildElements,
   getNavAction,
@@ -16,11 +17,13 @@ import {
   getSelectedNavRouteElement,
   getUrlFromHref,
   isNavigationElement,
+  isReactNavigation7,
   isUrlFragment,
   mergeDocument,
   removeStackRoute,
   validateUrl,
 } from './helpers';
+import { CommonActions } from '@react-navigation/native';
 import { DOMParser } from '@instawork/xmldom';
 import { NAV_ACTIONS } from 'hyperview/src/types';
 import type { NavigationState } from '@react-navigation/native';
@@ -417,6 +420,19 @@ describe('findPath', () => {
     it('should not find a path to `to_be_found`', () => {
       expect(path.length).toEqual(0);
     });
+  });
+});
+
+describe('expandNestedNavigate', () => {
+  it('detects the installed React Navigation 6 dependency', () => {
+    expect(isReactNavigation7).toBe(false);
+  });
+
+  it('preserves bare nested navigation under React Navigation 6', () => {
+    const state = StateSource as NavigationState;
+    const action = CommonActions.navigate('performance_2');
+
+    expect(expandNestedNavigate(state, action)).toBe(action);
   });
 });
 

--- a/src/services/navigator/helpers.ts
+++ b/src/services/navigator/helpers.ts
@@ -1,6 +1,7 @@
 import * as Errors from './errors';
 import * as Helpers from 'hyperview/src/services/dom/helpers';
 import * as Namespaces from 'hyperview/src/services/namespaces';
+import * as ReactNavigation from '@react-navigation/native';
 import * as Types from './types';
 import * as UrlService from 'hyperview/src/services/url';
 import {
@@ -15,9 +16,19 @@ import type {
   RouteParams,
   RouteProps,
 } from 'hyperview/src/types';
+import type {
+  NavigationAction,
+  NavigationState,
+} from '@react-navigation/native';
 import { ANCHOR_ID_SEPARATOR } from './types';
-import type { NavigationState } from '@react-navigation/native';
 import { shallowCloneToRoot } from 'hyperview/src/services';
+
+const navigationWithLocale = ReactNavigation as Types.ReactNavigationWithLocale;
+
+export const isReactNavigation7 = navigationWithLocale.useLocale !== undefined;
+
+export const useCompatibleLocale =
+  navigationWithLocale.useLocale ?? (() => ({ direction: 'ltr' as const }));
 
 /**
  * Card and modal routes are not defined in the document
@@ -151,6 +162,77 @@ export const findPath = (
 };
 
 /**
+ * Find the key of the navigator that directly contains a route key
+ */
+export const findNavigatorKeyForRoute = (
+  state: NavigationState | undefined,
+  routeKey: string,
+): string | undefined => {
+  if (!state?.routes) {
+    return undefined;
+  }
+
+  if (state.routes.some(route => route.key === routeKey)) {
+    return state.key;
+  }
+
+  return state.routes.reduce<string | undefined>(
+    (navigatorKey, route) =>
+      navigatorKey ||
+      findNavigatorKeyForRoute(route.state as NavigationState, routeKey),
+    undefined,
+  );
+};
+
+/**
+ * Convert a Hyperview-style bare nested navigate into explicit RN7 nested params
+ * Uses mounted navigation state first, then an optional HXML path fallback
+ */
+export const expandNestedNavigate = <Action extends NavigationAction>(
+  state: NavigationState,
+  action: Action,
+  getFallbackPath?: (targetId: string) => string[],
+): Action => {
+  if (!isReactNavigation7 || action.type !== 'NAVIGATE') {
+    return action;
+  }
+
+  const payload = action.payload as Types.NavigateActionPayload | undefined;
+  const targetId = payload?.name;
+
+  if (!targetId || state.routeNames.includes(targetId)) {
+    return action;
+  }
+
+  const statePath = findPath(state, targetId);
+  const [parentId, ...path] = statePath.length
+    ? statePath
+    : getFallbackPath?.(targetId) || [];
+
+  if (!parentId || path.length === 0 || !state.routeNames.includes(parentId)) {
+    return action;
+  }
+
+  const params = path.reduceRight<object | undefined>(
+    (childParams, screen) => ({
+      params: childParams,
+      screen,
+    }),
+    payload.params,
+  );
+
+  return {
+    ...action,
+    payload: {
+      ...payload,
+      name: parentId,
+      params,
+      pop: payload.pop ?? true,
+    },
+  } as Action;
+};
+
+/**
  * Continue up the hierarchy until a navigation is found which contains the target
  * If the target is not found, no navigation is returned
  * If no target is provided, the current navigation is returned
@@ -266,6 +348,44 @@ export const getNavigatorById = (
     return n.getAttribute(Types.KEY_ID) === id;
   });
   return navigators[0];
+};
+
+/**
+ * Build the route id path from a navigator to a target route in the HXML
+ */
+export const findPathFromDom = (
+  doc: Document | undefined,
+  navigatorId: string,
+  targetId: string,
+): string[] => {
+  const route = doc ? getRouteById(doc, targetId) : undefined;
+  const path: string[] = [];
+  const visited = new Set<Node>();
+  let node: Node | null = route || null;
+  while (
+    node &&
+    node.nodeType === NODE_TYPE.ELEMENT_NODE &&
+    !visited.has(node)
+  ) {
+    visited.add(node);
+    const element = node as Element;
+    if (
+      element.localName === LOCAL_NAME.NAVIGATOR &&
+      element.getAttribute(Types.KEY_ID) === navigatorId
+    ) {
+      return path.reverse();
+    }
+
+    if (element.localName === LOCAL_NAME.NAV_ROUTE) {
+      const routeId = element.getAttribute(Types.KEY_ID);
+      if (routeId) {
+        path.push(routeId);
+      }
+    }
+    node = element.parentNode;
+  }
+
+  return [];
 };
 
 /**

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -3,15 +3,17 @@ export { Navigator } from './navigator';
 export { HvRouteError, HvNavigatorError, HvRenderError } from './errors';
 export {
   addStackRoute,
-  isDynamicRoute,
-  isUrlFragment,
   cleanHrefFragment,
+  expandNestedNavigate,
+  findPathFromDom,
   getChildElements,
   getNavigatorById,
   getRouteById,
   getSelectedNavRouteElement,
   getUrlFromHref,
+  isDynamicRoute,
   isReactNavigation7,
+  isUrlFragment,
   mergeDocument,
   removeStackRoute,
   setSelected,
@@ -19,3 +21,4 @@ export {
   useCompatibleLocale,
 } from './helpers';
 export { ANCHOR_ID_SEPARATOR, ID_CARD, ID_MODAL, KEY_MODAL } from './types';
+export type { Locale } from './types';

--- a/src/services/navigator/index.ts
+++ b/src/services/navigator/index.ts
@@ -11,9 +11,11 @@ export {
   getRouteById,
   getSelectedNavRouteElement,
   getUrlFromHref,
+  isReactNavigation7,
   mergeDocument,
   removeStackRoute,
   setSelected,
   updateRouteUrlFromState,
+  useCompatibleLocale,
 } from './helpers';
 export { ANCHOR_ID_SEPARATOR, ID_CARD, ID_MODAL, KEY_MODAL } from './types';

--- a/src/services/navigator/navigator.test.ts
+++ b/src/services/navigator/navigator.test.ts
@@ -1,0 +1,369 @@
+import * as Types from './types';
+import {
+  CommonActions,
+  NavigationState,
+  StackActions,
+} from '@react-navigation/native';
+import type {
+  NavigationProps,
+  RouteParams,
+  RouteProps,
+} from 'hyperview/src/types';
+import { NAV_ACTIONS } from 'hyperview/src/types';
+import { Navigator } from './navigator';
+
+const rootState = {
+  index: 0,
+  key: 'stack-root',
+  routeNames: ['tabs'],
+  routes: [
+    {
+      key: 'tabs-key',
+      name: 'tabs',
+      state: {
+        index: 0,
+        key: 'tab-root',
+        routeNames: ['tab-navigation'],
+        routes: [
+          {
+            key: 'tab-navigation-key',
+            name: 'tab-navigation',
+          },
+        ],
+        stale: false,
+        type: 'tab',
+      },
+    },
+  ],
+  stale: false,
+  type: 'stack',
+} as NavigationState;
+
+const createNavigation = (state: NavigationState): NavigationProps => ({
+  addListener: jest.fn(() => jest.fn()),
+  dispatch: jest.fn(),
+  getParent: jest.fn(),
+  getState: jest.fn(() => state),
+  goBack: jest.fn(),
+  isFocused: jest.fn(() => true),
+  navigate: jest.fn(),
+});
+
+describe('Navigator.routeBackRequest', () => {
+  it('targets the navigator containing the revealed route when setting params', () => {
+    const navigation = createNavigation({
+      index: 1,
+      key: 'stack-root',
+      routeNames: ['tabs', 'card'],
+      routes: [
+        {
+          key: 'tabs-key',
+          name: 'tabs',
+        },
+        {
+          key: 'card-key',
+          name: 'card',
+        },
+      ],
+      stale: false,
+      type: 'stack',
+    } as NavigationState);
+    const rootNavigation = ({
+      getCurrentRoute: jest.fn(() => ({
+        key: 'tab-navigation-key',
+        name: 'tab-navigation',
+      })),
+      getRootState: jest.fn(() => rootState),
+    } as unknown) as NonNullable<Types.Props['rootNavigation']>;
+    const routeParams: RouteParams = {
+      url: 'https://example.com/changed.xml',
+    };
+    const navigator = new Navigator({
+      entrypointUrl: 'https://example.com/index.xml',
+      navigation,
+      rootNavigation,
+      route: {
+        key: 'card-key',
+        name: 'card',
+      } as RouteProps,
+      setElement: jest.fn(),
+    });
+
+    navigator.routeBackRequest(
+      navigation,
+      NAV_ACTIONS.BACK,
+      'card-key',
+      routeParams,
+    );
+
+    expect(navigation.goBack).toHaveBeenCalled();
+    expect(navigation.dispatch).toHaveBeenCalledWith({
+      ...CommonActions.setParams(routeParams),
+      source: 'tab-navigation-key',
+      target: 'tab-root',
+    });
+  });
+});
+
+describe('Navigator.sendRequest', () => {
+  it('closes the current nested modal during a modal flow event', () => {
+    const parentNavigation = createNavigation({
+      index: 1,
+      key: 'stack-root',
+      routeNames: ['tabs', 'modal'],
+      routes: [
+        {
+          key: 'tabs-key',
+          name: 'tabs',
+        },
+        {
+          key: 'modal-key',
+          name: 'modal',
+        },
+      ],
+      stale: false,
+      type: 'stack',
+    } as NavigationState);
+    const navigation = createNavigation({
+      index: 1,
+      key: 'modal-stack',
+      routeNames: ['modal-screen', 'modal'],
+      routes: [
+        {
+          key: 'modal-screen-key',
+          name: 'modal-screen',
+        },
+        {
+          key: 'nested-modal-key',
+          name: 'modal',
+        },
+      ],
+      stale: false,
+      type: 'stack',
+    } as NavigationState);
+    (navigation.getParent as jest.Mock).mockReturnValue(parentNavigation);
+    const navigator = new Navigator({
+      entrypointUrl: 'https://example.com/index.xml',
+      navigation,
+      route: {
+        key: 'modal-screen-key',
+        name: 'modal-screen',
+        params: {
+          isModal: true,
+        },
+      } as RouteProps,
+      setElement: jest.fn(),
+    });
+
+    navigator.sendRequest(NAV_ACTIONS.CLOSE);
+
+    expect(navigation.goBack).toHaveBeenCalled();
+    expect(parentNavigation.goBack).not.toHaveBeenCalled();
+  });
+
+  it('closes a named modal through its modal sub-stack', () => {
+    const parentNavigation = createNavigation({
+      index: 1,
+      key: 'stack-root',
+      routeNames: ['tabs', 'welcome'],
+      routes: [
+        {
+          key: 'tabs-key',
+          name: 'tabs',
+        },
+        {
+          key: 'welcome-key',
+          name: 'welcome',
+          params: {
+            isModal: true,
+          },
+        },
+      ],
+      stale: false,
+      type: 'stack',
+    } as NavigationState);
+    const navigation = createNavigation({
+      index: 0,
+      key: 'welcome-stack',
+      routeNames: ['modal-screen-welcome'],
+      routes: [
+        {
+          key: 'modal-screen-welcome-key',
+          name: 'modal-screen-welcome',
+        },
+      ],
+      stale: false,
+      type: 'stack',
+    } as NavigationState);
+    (navigation.getParent as jest.Mock).mockReturnValue(parentNavigation);
+    const navigator = new Navigator({
+      entrypointUrl: 'https://example.com/index.xml',
+      navigation,
+      route: {
+        key: 'modal-screen-welcome-key',
+        name: 'modal-screen-welcome',
+        params: {
+          isModal: true,
+        },
+      } as RouteProps,
+      setElement: jest.fn(),
+    });
+
+    navigator.sendRequest(NAV_ACTIONS.CLOSE);
+
+    expect(navigation.goBack).toHaveBeenCalled();
+    expect(parentNavigation.goBack).not.toHaveBeenCalled();
+  });
+
+  it('continues navigation from the parent after its route is removed', () => {
+    const parentState = {
+      index: 0,
+      key: 'stack-root',
+      routeNames: ['home'],
+      routes: [
+        {
+          key: 'home-key',
+          name: 'home',
+        },
+      ],
+      stale: false,
+      type: 'stack',
+    } as NavigationState;
+    const parentNavigation = createNavigation(parentState);
+    const navigation = createNavigation({
+      index: 0,
+      key: 'modal-stack',
+      routeNames: ['modal-screen'],
+      routes: [
+        {
+          key: 'modal-screen-key',
+          name: 'modal-screen',
+        },
+      ],
+      stale: false,
+      type: 'stack',
+    } as NavigationState);
+    (navigation.getParent as jest.Mock).mockReturnValue(parentNavigation);
+    const rootNavigation = ({
+      getRootState: jest.fn(() => parentState),
+    } as unknown) as NonNullable<Types.Props['rootNavigation']>;
+    const navigator = new Navigator({
+      entrypointUrl: 'https://example.com/index.xml',
+      navigation,
+      rootNavigation,
+      route: {
+        key: 'modal-screen-key',
+        name: 'modal-screen',
+      } as RouteProps,
+      setElement: jest.fn(),
+    });
+    const routeParams = {
+      url: 'https://example.com/destination.xml',
+    };
+
+    navigator.sendRequest(NAV_ACTIONS.PUSH, routeParams);
+
+    expect(parentNavigation.dispatch).toHaveBeenCalledWith(
+      StackActions.push('card', routeParams),
+    );
+    expect(navigation.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('keeps navigation within a modal while its route is active', () => {
+    const modalState = {
+      index: 0,
+      key: 'modal-stack',
+      routeNames: ['modal-screen'],
+      routes: [
+        {
+          key: 'modal-screen-key',
+          name: 'modal-screen',
+        },
+      ],
+      stale: false,
+      type: 'stack',
+    } as NavigationState;
+    const rootNavigation = ({
+      getRootState: jest.fn(
+        () =>
+          ({
+            index: 1,
+            key: 'stack-root',
+            routeNames: ['home', 'modal'],
+            routes: [
+              {
+                key: 'home-key',
+                name: 'home',
+              },
+              {
+                key: 'modal-key',
+                name: 'modal',
+                state: modalState,
+              },
+            ],
+            stale: false,
+            type: 'stack',
+          } as NavigationState),
+      ),
+    } as unknown) as NonNullable<Types.Props['rootNavigation']>;
+    const navigation = createNavigation(modalState);
+    const parentNavigation = createNavigation(rootNavigation.getRootState());
+    (navigation.getParent as jest.Mock).mockReturnValue(parentNavigation);
+    const navigator = new Navigator({
+      entrypointUrl: 'https://example.com/index.xml',
+      navigation,
+      rootNavigation,
+      route: {
+        key: 'modal-screen-key',
+        name: 'modal-screen',
+      } as RouteProps,
+      setElement: jest.fn(),
+    });
+    const routeParams = {
+      url: 'https://example.com/destination.xml',
+    };
+
+    navigator.sendRequest(NAV_ACTIONS.PUSH, routeParams);
+
+    expect(navigation.dispatch).toHaveBeenCalledWith(
+      StackActions.push('card', routeParams),
+    );
+    expect(parentNavigation.dispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('Navigator.updateRouteUrl', () => {
+  it('updates the URL param of the current route', () => {
+    const navigation = createNavigation({
+      index: 0,
+      key: 'tab-root',
+      routeNames: ['tab-navigation'],
+      routes: [
+        {
+          key: 'tab-navigation-key',
+          name: 'tab-navigation',
+        },
+      ],
+      stale: false,
+      type: 'tab',
+    } as NavigationState);
+    const navigator = new Navigator({
+      entrypointUrl: 'https://example.com/changed.xml',
+      navigation,
+      route: {
+        key: 'tab-navigation-key',
+        name: 'tab-navigation',
+      } as RouteProps,
+      setElement: jest.fn(),
+    });
+
+    navigator.updateRouteUrl('https://example.com/index.xml');
+
+    expect(navigation.dispatch).toHaveBeenCalledWith({
+      ...CommonActions.setParams({
+        url: 'https://example.com/index.xml',
+      }),
+      source: 'tab-navigation-key',
+    });
+  });
+});

--- a/src/services/navigator/navigator.ts
+++ b/src/services/navigator/navigator.ts
@@ -107,7 +107,14 @@ export class Navigator implements NavigationProvider {
       case NAV_ACTIONS.NAVIGATE:
       case NAV_ACTIONS.NEW:
         if (routeId) {
-          navigation.dispatch(CommonActions.navigate(routeId, params));
+          navigation.dispatch({
+            ...CommonActions.navigate(routeId, params),
+            payload: {
+              name: routeId,
+              params,
+              pop: true,
+            },
+          });
         }
         break;
       case NAV_ACTIONS.PUSH:

--- a/src/services/navigator/navigator.ts
+++ b/src/services/navigator/navigator.ts
@@ -66,22 +66,47 @@ export class Navigator implements NavigationProvider {
     if (routeParams) {
       const route = this.props.rootNavigation?.getCurrentRoute();
       if (route) {
+        const target = Helpers.findNavigatorKeyForRoute(
+          this.props.rootNavigation?.getRootState(),
+          route.key,
+        );
         navigation.dispatch({
           ...CommonActions.setParams({
             ...routeParams,
           }),
           source: route.key,
+          ...(target && { target }),
         });
       }
     }
   }
 
   /**
+   * Resolve the navigator which owns the route.
+   */
+  getActiveNavigation = (): NavigationProps | undefined => {
+    const { navigation, rootNavigation, route } = this.props;
+    const rootState = rootNavigation?.getRootState();
+
+    if (
+      !navigation ||
+      !route?.key ||
+      !rootState ||
+      Helpers.findNavigatorKeyForRoute(rootState, route.key)
+    ) {
+      return navigation;
+    }
+
+    return navigation.getParent() || navigation;
+  };
+
+  /**
    * Prepare and send the request
    */
   sendRequest = (action: NavAction, routeParams?: RouteParams) => {
+    const activeNavigation = this.getActiveNavigation();
     const [navAction, navigation, routeId, params] = Helpers.buildRequest(
-      this.props.navigation,
+      activeNavigation,
       action,
       routeParams,
     );
@@ -206,5 +231,18 @@ export class Navigator implements NavigationProvider {
 
   openModalAction = (params: RouteParams) => {
     this.sendRequest(NAV_ACTIONS.NEW, params);
+  };
+
+  updateRouteUrl = (url: string) => {
+    const routeKey = this.props.route?.key;
+    if (!this.props.navigation || !routeKey) {
+      return;
+    }
+    this.props.navigation.dispatch({
+      ...CommonActions.setParams({
+        url,
+      }),
+      source: routeKey,
+    });
   };
 }

--- a/src/services/navigator/types.ts
+++ b/src/services/navigator/types.ts
@@ -1,3 +1,4 @@
+import type * as ReactNavigation from '@react-navigation/native';
 import type {
   NavigationProps,
   RouteParams,
@@ -38,4 +39,19 @@ export type NavigateParams = {
  */
 export type RouteMap = {
   [key: string]: Element;
+};
+
+export type NavigateActionPayload = {
+  merge?: boolean;
+  name?: string;
+  params?: object;
+  pop?: boolean;
+};
+
+export type Locale = {
+  direction: 'ltr' | 'rtl';
+};
+
+export type ReactNavigationWithLocale = typeof ReactNavigation & {
+  useLocale?: () => Locale;
 };

--- a/test/helpers/navigation.ts
+++ b/test/helpers/navigation.ts
@@ -1,0 +1,14 @@
+import type {
+  ParamListBase,
+  StackNavigationState,
+} from '@react-navigation/native';
+
+type StackState = Omit<StackNavigationState<ParamListBase>, 'preloadedRoutes'>;
+
+export const createStackNavigationState = (
+  state: StackState,
+): StackNavigationState<ParamListBase> =>
+  (({
+    ...state,
+    preloadedRoutes: [],
+  } as unknown) as StackNavigationState<ParamListBase>);

--- a/test/helpers/navigation.ts
+++ b/test/helpers/navigation.ts
@@ -3,12 +3,18 @@ import type {
   StackNavigationState,
 } from '@react-navigation/native';
 
-type StackState = Omit<StackNavigationState<ParamListBase>, 'preloadedRoutes'>;
+type CompatibleStackState = StackNavigationState<ParamListBase> & {
+  preloadedRoutes: StackNavigationState<ParamListBase>['routes'];
+};
+
+type StackStateWithoutPreloadedRoutes = Omit<
+  CompatibleStackState,
+  'preloadedRoutes'
+>;
 
 export const createStackNavigationState = (
-  state: StackState,
-): StackNavigationState<ParamListBase> =>
-  (({
-    ...state,
-    preloadedRoutes: [],
-  } as unknown) as StackNavigationState<ParamListBase>);
+  state: StackStateWithoutPreloadedRoutes,
+): CompatibleStackState => ({
+  ...state,
+  preloadedRoutes: [],
+});

--- a/test/integration/navigation.test.tsx
+++ b/test/integration/navigation.test.tsx
@@ -8,7 +8,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react-native';
-import Hyperview from './hyperview';
+import Hyperview from 'hyperview/src/hyperview';
 import { Pressable } from 'react-native';
 import React from 'react';
 import { fetchFactory } from 'hyperview/test/helpers/fetch';


### PR DESCRIPTION
## Summary

Support React Navigation 7 while retaining React Navigation 6 compatibility and Hyperview's existing public navigation behavior. Consumers can continue using the same HXML actions, bare route IDs, deep links, and integration APIs under either major version.

## Changes and rationale

- **Support both custom navigator contracts.** React Navigation 7 adds `describe`, locale direction, and updated state/type requirements. Hyperview detects v7-only capabilities at runtime so the same stack and tab implementations remain valid under v6.
- **Resolve bare nested route IDs explicitly.** React Navigation 7 no longer searches child navigators for `navigate('route-id')`. Hyperview resolves mounted navigation state first, then uses an HXML fallback for unloaded routes reached by deep links and external navigation refs.
- **Preserve existing navigation semantics.** Compatible `pop: true` payloads retain Hyperview's unwind behavior, while follow-up actions after `close` are redirected from stale child navigators to their active parent.
- **Preserve screen presentation and transitions.** Screens provide both v6 `animationEnabled` and v7 `animation`, explicitly distinguish card and modal presentation, and retain the existing card interpolators so RN6 transitions remain unchanged. Explicitly requested sub-stacks carry a stable route ID and flag into `HvNavigator` so nested modal routes render consistently under both versions.
- **Fix reload route-state synchronization exposed during React Navigation 7 testing.** A replacement document could render while the route params still contained the previous URL. Hyperview now updates route identity only after a successful load.

## Validation

- Manually validated Hyperview demo and MDS navigation flows on iOS and Android.