### PR TITLE
feat(date-field): expose displayed text for automation

### DIFF
--- a/docs/reference_datefield.md
+++ b/docs/reference_datefield.md
@@ -190,6 +190,10 @@ The duration in milliseconds that the close animation of the date selection moda
 
 A global attribute uniquely identifying the element in the whole document.
 
+When set, the text displaying the formatted value (or placeholder) is also given the
+automation identifier `<id>-text`, so UI automation can read the displayed label
+without depending on the element hierarchy.
+
 #### `hide`
 
 | Type                      | Required |

--- a/docs/reference_datefield.md
+++ b/docs/reference_datefield.md
@@ -191,7 +191,7 @@ The duration in milliseconds that the close animation of the date selection moda
 A global attribute uniquely identifying the element in the whole document.
 
 When set, the text displaying the formatted value (or placeholder) is also given the
-automation identifier `<id>-text`, so UI automation can read the displayed label
+automation identifier `<id>/field-label`, so UI automation can read the displayed label
 without depending on the element hierarchy.
 
 #### `hide`

--- a/src/elements/hv-date-field/field-label/index.tsx
+++ b/src/elements/hv-date-field/field-label/index.tsx
@@ -3,6 +3,7 @@ import type { Props } from './types';
 import React from 'react';
 import type { StyleSheet } from 'hyperview/src/types';
 import { Text } from 'react-native';
+import { createTestPropsFromId } from 'hyperview/src/services';
 
 /**
  * This text label of the field. Contains logic to decide how to format the value
@@ -22,10 +23,15 @@ export default (props: Props) => {
   const label: string | undefined = props.value
     ? props.formatter(props.value, labelFormat || undefined)
     : placeholder || '';
+  const fieldId = props.element.getAttribute('id');
+  const textProps = {
+    ...createTestPropsFromId(fieldId && `${fieldId}-text`),
+    ...FontScale.getFontScaleProps(props.element),
+  };
 
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
-    <Text style={labelStyles} {...FontScale.getFontScaleProps(props.element)}>
+    <Text style={labelStyles} {...textProps}>
       {label}
     </Text>
   );

--- a/src/elements/hv-date-field/field-label/index.tsx
+++ b/src/elements/hv-date-field/field-label/index.tsx
@@ -25,7 +25,7 @@ export default (props: Props) => {
     : placeholder || '';
   const fieldId = props.element.getAttribute('id');
   const textProps = {
-    ...createTestPropsFromId(fieldId && `${fieldId}-text`),
+    ...createTestPropsFromId(fieldId && `${fieldId}/field-label`),
     ...FontScale.getFontScaleProps(props.element),
   };
 

--- a/src/elements/hv-date-field/index.test.tsx
+++ b/src/elements/hv-date-field/index.test.tsx
@@ -77,6 +77,7 @@ describe('HvDateField', () => {
       await waitFor(() => {
         const element = screen.getByTestId('date-field');
         expect(element).toBeOnTheScreen();
+        expect(screen.getByTestId('date-field-text')).toBeOnTheScreen();
         return true;
       });
     });

--- a/src/elements/hv-date-field/index.test.tsx
+++ b/src/elements/hv-date-field/index.test.tsx
@@ -77,7 +77,7 @@ describe('HvDateField', () => {
       await waitFor(() => {
         const element = screen.getByTestId('date-field');
         expect(element).toBeOnTheScreen();
-        expect(screen.getByTestId('date-field-text')).toBeOnTheScreen();
+        expect(screen.getByTestId('date-field/field-label')).toBeOnTheScreen();
         return true;
       });
     });

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -96,10 +96,13 @@ export const createTestProps = (
 ): {
   testID?: string;
   accessibilityLabel?: string;
-} =>
-  options?.skipTestProps
-    ? {}
-    : createTestPropsFromId(element.getAttribute('id'));
+} => {
+  if (options?.skipTestProps) {
+    return {};
+  }
+
+  return createTestPropsFromId(element.getAttribute('id'));
+};
 
 export const createCollapsableProps = (
   element: Element,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -65,6 +65,26 @@ export const createStyleProp = (
 };
 
 /**
+ * Sets the given id as a test id and accessibility label
+ * (for testing automation purposes).
+ */
+export const createTestPropsFromId = (
+  id: DOMString | null | undefined,
+): {
+  testID?: string;
+  accessibilityLabel?: string;
+} => {
+  const testProps = {};
+  if (!id) {
+    return testProps;
+  }
+  if (Platform.OS === 'ios') {
+    return { testID: id };
+  }
+  return { accessibilityLabel: id };
+};
+
+/**
  * Sets the element's id attribute as a test id and accessibility label
  * (for testing automation purposes).
  * Returns no props when `skipTestProps` is set, which happens when an ancestor
@@ -76,17 +96,10 @@ export const createTestProps = (
 ): {
   testID?: string;
   accessibilityLabel?: string;
-} => {
-  const testProps = {};
-  const id: DOMString | null | undefined = element.getAttribute('id');
-  if (!id || options?.skipTestProps) {
-    return testProps;
-  }
-  if (Platform.OS === 'ios') {
-    return { testID: id };
-  }
-  return { accessibilityLabel: id };
-};
+} =>
+  options?.skipTestProps
+    ? {}
+    : createTestPropsFromId(element.getAttribute('id'));
 
 export const createCollapsableProps = (
   element: Element,


### PR DESCRIPTION
## Summary
- expose a derived `<date-field id>` text automation identifier for date labels
- preserve platform-specific automation props through a shared id helper
- document and cover the text identifier

## Screenshots

| Android Before | Android After |
|--------|--------|
| <img width="994" height="791" alt="image" src="https://github.com/user-attachments/assets/a98f6aab-0c7b-4af9-b4d4-8ca233b38fcc" /> | <img width="1075" height="954" alt="image" src="https://github.com/user-attachments/assets/7312d8a1-9b0c-4033-bd06-e6ed115f72b5" /> | 



| iOS Before | iOS After |
|--------|--------|
| <img width="1060" height="892" alt="image" src="https://github.com/user-attachments/assets/5692cb43-42e1-43ae-9f56-9ab32141f1e6" /> | <img width="1078" height="569" alt="image" src="https://github.com/user-attachments/assets/76819189-c491-43f0-8568-b1265673bb9a" /> |

Example of adding IDs from the Instawork repo to these components
<img width="500" alt="image" src="https://github.com/user-attachments/assets/44a6aab1-60db-4ab2-9c41-99c2bab5f675" />









