### PR TITLE
fix(hyper-ref): expose disabled accessibility state for non-actionable refs

### DIFF
--- a/src/components/hyper-ref/hyper-ref.tsx
+++ b/src/components/hyper-ref/hyper-ref.tsx
@@ -297,6 +297,16 @@ export default class HyperRef extends PureComponent<Props, State> {
     const style = this.getStyle();
     const { accessibilityLabel, testID } = createTestProps(this.props.element);
     const { onLongPress, onPress, onPressIn, onPressOut } = pressHandlers;
+    const elementHasAction = !!this.props.element.getAttribute('action');
+    const elementHasHref = !!this.props.element.getAttribute('href');
+    const hasActionablePressBehavior = behaviors.some(behaviorElement => {
+      const behaviorAction = (
+        behaviorElement.getAttribute(BEHAVIOR_ATTRIBUTES.ACTION) || ''
+      ).toLowerCase();
+      return behaviorAction !== '' && behaviorAction !== 'amplitude';
+    });
+    const disabled =
+      !elementHasAction && !elementHasHref && !hasActionablePressBehavior;
 
     // If element is a <text> nested under another <text>, simply add press events
     const isNestedUnderText =
@@ -310,22 +320,25 @@ export default class HyperRef extends PureComponent<Props, State> {
       return (
         <Text
           accessibilityLabel={accessibilityLabel}
+          accessibilityState={disabled ? { disabled: true } : undefined}
           accessible={false}
-          onLongPress={onLongPress}
+          onLongPress={disabled ? undefined : onLongPress}
           // when no press handler set, we still need an empty handler for pressIn or pressOut
           // handlers to work
           onPress={
-            onPress ||
-            (onPressIn !== undefined || onPressOut !== undefined
-              ? noop
-              : undefined)
+            disabled
+              ? undefined
+              : onPress ||
+                (onPressIn !== undefined || onPressOut !== undefined
+                  ? noop
+                  : undefined)
           }
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore TS2300: no overload matches this call
-          onResponderGrant={onPressIn}
+          onResponderGrant={disabled ? undefined : onPressIn}
           // Both release and terminate responder are needed to properly pressOut
-          onResponderRelease={onPressOut}
-          onResponderTerminate={onPressOut}
+          onResponderRelease={disabled ? undefined : onPressOut}
+          onResponderTerminate={disabled ? undefined : onPressOut}
           style={style}
           suppressHighlighting
           testID={testID}
@@ -338,8 +351,10 @@ export default class HyperRef extends PureComponent<Props, State> {
     return (
       <TouchableOpacity
         accessibilityLabel={accessibilityLabel}
+        accessibilityState={disabled ? { disabled: true } : undefined}
         accessible={false}
         activeOpacity={1}
+        disabled={disabled}
         onLongPress={onLongPress}
         onPress={onPress}
         onPressIn={onPressIn}

--- a/src/components/hyper-ref/hyper-ref.tsx
+++ b/src/components/hyper-ref/hyper-ref.tsx
@@ -303,7 +303,13 @@ export default class HyperRef extends PureComponent<Props, State> {
       const behaviorAction = (
         behaviorElement.getAttribute(BEHAVIOR_ATTRIBUTES.ACTION) || ''
       ).toLowerCase();
-      return behaviorAction !== '' && behaviorAction !== 'amplitude';
+      const behaviorHref = behaviorElement.getAttribute(
+        BEHAVIOR_ATTRIBUTES.HREF,
+      );
+      return (
+        (behaviorAction !== '' && behaviorAction !== 'amplitude') ||
+        !!behaviorHref
+      );
     });
     const disabled =
       !elementHasAction && !elementHasHref && !hasActionablePressBehavior;


### PR DESCRIPTION
## Summary
- derive a `disabled` flag for refs that have no actionable target (`action`, `href`, or non-analytics behavior action)
- pass disabled semantics to native wrappers by setting `disabled` on `TouchableOpacity` and `accessibilityState.disabled` on both touchable and nested text wrappers
- avoid attaching text press/responder handlers when the ref is disabled so Appium accessibility state aligns with interaction state
- treat behavior-level `href` as actionable so href-only press behaviors are not marked disabled

## Implementation notes
- disabled state is computed from both ref attributes and press behavior attributes (`action`/`href`)
- nested text refs now skip `onPress`/`onLongPress`/responder handlers when disabled
- touchable refs expose disabled state through both `disabled` prop and `accessibilityState`

## Evidence
| Test | Platform | Recording |
| --- | --- | --- |
| Appium DOM capture: disabled ref reports `enabled=false` | iOS | <img width="1332" height="893" alt="image" src="https://github.com/user-attachments/assets/bf5fbee0-9f58-44c7-8bbb-d7627fbe0f44" /> |
| Appium DOM capture: enabled ref reports `enabled=true` | iOS | TBD defined if the PR makes sense |




