### PR TITLE
fix(hyper-ref): resolve current element for sequenced behaviors

### DIFF
--- a/src/components/hyper-ref/hyper-ref.tsx
+++ b/src/components/hyper-ref/hyper-ref.tsx
@@ -156,11 +156,12 @@ export default class HyperRef extends PureComponent<Props, State> {
       return false;
     });
     onEventBehaviors.forEach(behaviorElement => {
+      const currentElement = this.getCurrentElement();
       const handler = Behaviors.createActionHandler(
         behaviorElement,
         this.props.onUpdate,
       );
-      handler(element);
+      handler(currentElement);
 
       Logging.info(
         Logging.deferredToString(() => {

--- a/src/components/hyper-ref/index.test.tsx
+++ b/src/components/hyper-ref/index.test.tsx
@@ -42,6 +42,42 @@ describe('HyperRef', () => {
       return container;
     };
 
+    const createSequencedContainer = (): Element => {
+      const doc = new DOMParser().parseFromString(
+        `
+          <doc xmlns="https://hyperview.org/hyperview">
+            <screen>
+              <body>
+                <form>
+                  <view id="container">
+                    <text-field id="field" name="field" hide="true" />
+                    <behavior
+                      action="set-value"
+                      trigger="on-event"
+                      event-name="test-event"
+                      target="field"
+                      new-value="on"
+                    />
+                    <behavior
+                      action="replace"
+                      trigger="on-event"
+                      event-name="test-event"
+                      target="container"
+                      href="/submit"
+                      verb="post"
+                    />
+                  </view>
+                </form>
+              </body>
+            </screen>
+          </doc>
+        `,
+        'text/xml',
+      );
+      const [container] = Array.from(doc.getElementsByTagName('view'));
+      return container;
+    };
+
     const createHyperRef = (element: Element, onUpdate: jest.Mock) =>
       new HyperRef({ element, onUpdate, options: {}, stylesheets });
 
@@ -82,6 +118,32 @@ describe('HyperRef', () => {
       hyperRef.onEventDispatch('test-event');
 
       expect(onUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    test('resolves the current element between sequenced behaviors', () => {
+      const container = createSequencedContainer();
+      const [field] = Array.from(container.getElementsByTagName('text-field'));
+      const receivedElements: Element[] = [];
+      const onUpdate = jest.fn(
+        (
+          _href: string | null | undefined,
+          _action: string | null | undefined,
+          element: Element,
+        ) => {
+          receivedElements.push(element);
+          if (receivedElements.length === 1) {
+            shallowCloneToRoot(field);
+          }
+        },
+      );
+      const hyperRef = createHyperRef(container, onUpdate);
+
+      hyperRef.onEventDispatch('test-event');
+
+      expect(onUpdate).toHaveBeenCalledTimes(2);
+      expect(receivedElements[0].parentNode).toBeNull();
+      expect(receivedElements[1].parentNode).not.toBeNull();
+      expect(receivedElements[1]).not.toBe(receivedElements[0]);
     });
   });
 });


### PR DESCRIPTION
## Summary

React Native's Fabric/concurrent renderer can defer React commits after Hyperview synchronously clones its XML DOM. This can leave a cached element detached before the next `on-event` behavior runs.

Resolve the current attached element before each behavior handler so sequenced mutations and updates operate on the latest DOM, with regression coverage for a mutation followed by an update action.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217475640930949