### PR TITLE
feat(hyper-ref): allow disabling touchables

### DIFF
--- a/demo/backend/behaviors/basic/triggers/disabled/_button/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/disabled/_button/index.xml.njk
@@ -1,0 +1,20 @@
+{% from 'macros/button/index.xml.njk' import button %}
+{% from 'macros/description/index.xml.njk' import description %}
+
+{{ description('Pressing the enabled button will replace its content.') }}
+{% call button('Enabled') -%}
+  <behavior
+    action="replace"
+    href="/hyperview/public/behaviors/basic/triggers/disabled/button/replace_fragment.xml"
+    trigger="press"
+  />
+{%- endcall %}
+
+{{ description('The disabled button exposes its disabled state and does not respond to presses.') }}
+{% call button('Disabled', attributes={disabled:"true", id:"disabled-button", style:"button button-disabled"}) -%}
+  <behavior
+    action="replace"
+    href="/hyperview/public/behaviors/basic/triggers/disabled/button/replace_fragment.xml"
+    trigger="press"
+  />
+{%- endcall %}

--- a/demo/backend/behaviors/basic/triggers/disabled/button/replace_fragment.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/disabled/button/replace_fragment.xml.njk
@@ -1,0 +1,7 @@
+---
+permalink: "/behaviors/basic/triggers/disabled/button/replace_fragment.xml"
+---
+
+{% from 'macros/button/index.xml.njk' import button %}
+
+{{ button('Replaced!', {"xmlns":"https://hyperview.org/hyperview"}) }}

--- a/demo/backend/behaviors/basic/triggers/disabled/index.xml.njk
+++ b/demo/backend/behaviors/basic/triggers/disabled/index.xml.njk
@@ -1,0 +1,11 @@
+---
+permalink: "/behaviors/basic/triggers/disabled/index.xml"
+tags: "Behaviors/Basic/Triggers"
+hv_title: "Disabled"
+hv_button_behavior: "back"
+---
+{% extends 'templates/scrollview.xml.njk' %}
+
+{% block content %}
+  {% include './_button/index.xml.njk' %}
+{% endblock %}

--- a/docs/reference_image.md
+++ b/docs/reference_image.md
@@ -35,6 +35,7 @@ An `<image>` element can appear anywhere within a `<screen>` element (including 
 - [`style`](#style)
 - [`id`](#id)
 - [`hide`](#hide)
+- [`disabled`](#disabled)
 
 #### Behavior attributes
 
@@ -78,3 +79,11 @@ A global attribute uniquely identifying the element in the whole document.
 | **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.
+
+#### `disabled`
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
+
+If `disabled="true"`, press behaviors on the element will not respond to user interaction. The element's native disabled state is exposed to UI automation frameworks.

--- a/docs/reference_text.md
+++ b/docs/reference_text.md
@@ -53,6 +53,7 @@ A `<view>` element can only appear anywhere within a `<screen>` element.
 - [`numberOfLines`](#numberoflines)
 - [`id`](#id)
 - [`hide`](#hide)
+- [`disabled`](#disabled)
 - [`selectable`](#selectable)
 - [`adjustsFontSizeToFit`](#adjustsFontSizeToFit)
 - [`allowFontScaling`](#allowFontScaling)
@@ -95,6 +96,14 @@ A global attribute uniquely identifying the element in the whole document.
 | **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.
+
+#### `disabled`
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
+
+If `disabled="true"`, press behaviors on the element will not respond to user interaction. The element's native disabled state is exposed to UI automation frameworks.
 
 #### `selectable`
 

--- a/docs/reference_view.md
+++ b/docs/reference_view.md
@@ -59,6 +59,7 @@ A `<view>` element can only appear anywhere within a `<screen>` element.
 - [`shows-scroll-indicator`](#shows-scroll-indicator)
 - [`id`](#id)
 - [`hide`](#hide)
+- [`disabled`](#disabled)
 - [`avoid-keyboard`](#avoid-keyboard)
 - [`sticky`](#sticky)
 - [`keyboard-dismiss-mode`](#keyboard-dismiss-mode)
@@ -143,6 +144,14 @@ A global attribute uniquely identifying the element in the whole document.
 | **false** (default), true | No       |
 
 If `hide="true"`, the element will not be rendered on screen. If the element or any of the element's children have a behavior that triggers on "load" or "visible", those behaviors will not trigger while the element is hidden.
+
+#### `disabled`
+
+| Type                      | Required |
+| ------------------------- | -------- |
+| **false** (default), true | No       |
+
+If `disabled="true"`, press behaviors on the element will not respond to user interaction. The element's native disabled state is exposed to UI automation frameworks.
 
 #### `avoid-keyboard`
 

--- a/schema/core.xsd
+++ b/schema/core.xsd
@@ -481,6 +481,7 @@
     <xs:attribute name="id" type="hv:ID" />
     <xs:attribute name="key" type="hv:KEY" />
     <xs:attribute name="hide" type="xs:boolean" />
+    <xs:attribute name="disabled" type="xs:boolean" />
     <xs:attribute name="avoid-keyboard" type="xs:boolean" />
     <xs:attribute name="safe-area" type="xs:boolean" />
     <xs:attribute name="value" type="xs:string" />
@@ -926,6 +927,7 @@
       <xs:attribute name="id" type="hv:ID" />
       <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
+      <xs:attribute name="disabled" type="xs:boolean" />
       <xs:attribute name="resizeMode" type="hv:resizeMode" />
       <xs:attribute name="value" type="xs:string" />
       <xs:attributeGroup ref="hv:behaviorAttributes" />
@@ -940,6 +942,7 @@
       <xs:attribute name="id" type="hv:ID" />
       <xs:attribute name="key" type="hv:KEY" />
       <xs:attribute name="hide" type="xs:boolean" />
+      <xs:attribute name="disabled" type="xs:boolean" />
       <xs:attribute name="selectable" type="xs:boolean" />
       <xs:attribute name="preformatted" type="xs:boolean" />
       <xs:attribute name="value" type="xs:string" />

--- a/src/components/hyper-ref/hyper-ref.tsx
+++ b/src/components/hyper-ref/hyper-ref.tsx
@@ -297,6 +297,7 @@ export default class HyperRef extends PureComponent<Props, State> {
     const style = this.getStyle();
     const { accessibilityLabel, testID } = createTestProps(this.props.element);
     const { onLongPress, onPress, onPressIn, onPressOut } = pressHandlers;
+    const disabled = this.props.element.getAttribute('disabled') === 'true';
 
     // If element is a <text> nested under another <text>, simply add press events
     const isNestedUnderText =
@@ -311,6 +312,7 @@ export default class HyperRef extends PureComponent<Props, State> {
         <Text
           accessibilityLabel={accessibilityLabel}
           accessible={false}
+          disabled={disabled}
           onLongPress={onLongPress}
           // when no press handler set, we still need an empty handler for pressIn or pressOut
           // handlers to work
@@ -340,6 +342,7 @@ export default class HyperRef extends PureComponent<Props, State> {
         accessibilityLabel={accessibilityLabel}
         accessible={false}
         activeOpacity={1}
+        disabled={disabled}
         onLongPress={onLongPress}
         onPress={onPress}
         onPressIn={onPressIn}


### PR DESCRIPTION
Support a new `disabled` attribute on elements that support behaviors. When set to `false`, carries forward as a prop on the `TouchableOpacity` instance. This allows automation frameworks (UIAutomator2, XCUITest) to read the disabled state of a button and select/assert on its value.