### PR TITLE
fix: finish loading cycle after failed fragment fetch

### DIFF
--- a/src/hyperview.test.tsx
+++ b/src/hyperview.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react-native';
+import { act, render, screen, waitFor } from '@testing-library/react-native';
 import Hyperview from './hyperview';
 import { NavigationContainer } from '@react-navigation/native';
 import React from 'react';
@@ -793,6 +793,119 @@ describe('Hyperview', () => {
               { timeout: 2000 },
             );
           });
+        });
+      });
+    });
+
+    describe('Fragment fetch error', () => {
+      test('restores indicators after a failed replace', async () => {
+        const mockFetch = fetchFactory([
+          [
+            'http://myapp.com/navigator',
+            `
+              <doc xmlns="https://hyperview.org/hyperview">
+                <navigator id="root" type="stack">
+                  <nav-route id="home" href="http://myapp.com/view" />
+                </navigator>
+              </doc>
+            `,
+          ],
+          [
+            'http://myapp.com/view',
+            `
+              <doc xmlns="https://hyperview.org/hyperview">
+                <screen>
+                  <body>
+                    <view id="container">
+                      <behavior
+                        action="replace"
+                        trigger="load"
+                        href="http://myapp.com/fail-fragment"
+                        target="container"
+                        show-during-load="loading-indicator"
+                        hide-during-load="status-text"
+                        once="true"
+                      />
+                      <text id="container-text">Original fragment</text>
+                    </view>
+                    <text id="status-text">Ready</text>
+                    <spinner id="loading-indicator" hide="true" />
+                  </body>
+                </screen>
+              </doc>
+            `,
+          ],
+          ['http://myapp.com/fail-fragment', 'Internal Server Error', 500],
+        ]);
+
+        behaviorRender(mockFetch);
+
+        await waitFor(() => {
+          expect(
+            screen.getByText('ServerError: ServerError (status 500)'),
+          ).toBeOnTheScreen();
+          expect(screen.getByTestId('container-text')).toBeOnTheScreen();
+          expect(screen.queryByTestId('loading-indicator')).toBeNull();
+          expect(screen.getByText('Ready')).toBeOnTheScreen();
+        });
+      });
+
+      test('stops list pull-to-refresh after a failed replace', async () => {
+        const mockFetch = fetchFactory([
+          [
+            'http://myapp.com/navigator',
+            `
+              <doc xmlns="https://hyperview.org/hyperview">
+                <navigator id="root" type="stack">
+                  <nav-route id="home" href="http://myapp.com/view" />
+                </navigator>
+              </doc>
+            `,
+          ],
+          [
+            'http://myapp.com/view',
+            `
+              <doc xmlns="https://hyperview.org/hyperview">
+                <screen>
+                  <body>
+                    <list id="tasks" trigger="refresh">
+                      <behavior
+                        trigger="refresh"
+                        href="http://myapp.com/fail-fragment"
+                        action="replace"
+                        target="tasks"
+                      />
+                      <item key="1">
+                        <text id="task-text">Example task</text>
+                      </item>
+                    </list>
+                  </body>
+                </screen>
+              </doc>
+            `,
+          ],
+          ['http://myapp.com/fail-fragment', 'Internal Server Error', 500],
+        ]);
+
+        behaviorRender(mockFetch);
+
+        await waitFor(() => {
+          expect(screen.getByTestId('tasks')).toBeOnTheScreen();
+        });
+
+        const { refreshControl } = screen.getByTestId('tasks').props;
+        await act(async () => {
+          refreshControl.props.onRefresh();
+        });
+
+        await waitFor(() => {
+          expect(
+            screen.getByText('ServerError: ServerError (status 500)'),
+          ).toBeOnTheScreen();
+          expect(screen.getByTestId('task-text')).toBeOnTheScreen();
+          expect(
+            screen.getByTestId('tasks').props.refreshControl.props.refreshing,
+          ).toBe(false);
         });
       });
     });

--- a/src/hyperview.tsx
+++ b/src/hyperview.tsx
@@ -151,7 +151,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
     networkRetryEvent: string | null | undefined,
     syncId: DOMString | null | undefined = undefined,
     syncMethod: DOMString | null | undefined = 'drop',
-  ): Promise<Element | null> => {
+  ): Promise<Element | typeof NO_OP | null> => {
     if (!href) {
       Logging.warn(new Error('No href passed to fetchElement'));
       return null;
@@ -184,7 +184,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
 
       if (result === NO_OP) {
         // Request was dropped due to sync logic, return null to indicate no-op
-        return null;
+        return NO_OP;
       }
 
       const { doc, staleHeaderType } = result;
@@ -403,7 +403,7 @@ export default class Hyperview extends PureComponent<Types.Props> {
           options.syncId,
           options.syncMethod,
         ).then(newElement => {
-          if (newElement === null) {
+          if (newElement === NO_OP) {
             // Request was dropped due to sync logic, no update needed
             return;
           }


### PR DESCRIPTION
## Summary
- Fixes [#1348](https://github.com/Instawork/hyperview/issues/1348): a failed fragment fetch left `show-during-load` indicators and pull-to-refresh stuck.
- `fetchElement()` returned `null` both when sync logic dropped a request and when the request failed. The caller treated every `null` as a drop, so it skipped `setIndicatorsAfterLoad()` and `onEnd()`.
- Dropped requests now return `NO_OP` (the parser sentinel). Failed fetches still return `null`, so the target is unchanged but the loading cycle finishes.

## Test plan
- [x] `src/hyperview.test.tsx` Fragment fetch error: indicators restore after a 500 replace
- [x] `src/hyperview.test.tsx` Fragment fetch error: list pull-to-refresh spinner stops after a 500